### PR TITLE
refactor: inline svg icons to remove binaries

### DIFF
--- a/apps/web/components/icons.tsx
+++ b/apps/web/components/icons.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+export const FileTextIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <line x1="9" y1="9" x2="15" y2="9" />
+    <line x1="9" y1="13" x2="15" y2="13" />
+    <line x1="9" y1="17" x2="13" y2="17" />
+  </svg>
+);
+
+export const GlobeIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <line x1="2" y1="12" x2="22" y2="12" />
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+  </svg>
+);
+
+export const NextIcon = () => (
+  <svg viewBox="0 0 120 24" fill="currentColor">
+    <text x="0" y="18" fontSize="18" fontFamily="Arial, sans-serif">Next.js</text>
+  </svg>
+);
+
+export const TurborepoDarkIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 6v6l4 2" stroke="#fff" strokeWidth="2" fill="none" />
+  </svg>
+);
+
+export const TurborepoLightIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 6v6l4 2" />
+  </svg>
+);
+
+export const VercelIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor">
+    <polygon points="12,3 22,21 2,21" />
+  </svg>
+);
+
+export const WindowIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <line x1="3" y1="9" x2="21" y2="9" />
+  </svg>
+);
+


### PR DESCRIPTION
## Summary
- add inline SVG icon components replacing standalone files

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6893baca42c483318d0970ef7c4c3f0e