### PR TITLE
feat: add video feed with gesture controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ pnpm dev
 ```
 
 The development server starts the Next.js web app at <http://localhost:3000>.
+
+Visit <http://localhost:3000/feed> for the swipeable video feed demo.

--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { useSpring, animated, useGesture } from '@paiduan/ui';
+import { VideoCard, VideoCardProps } from './VideoCard';
+
+interface FeedProps {
+  items: VideoCardProps[];
+}
+
+export const Feed: React.FC<FeedProps> = ({ items }) => {
+  const [index, setIndex] = useState(0);
+  const [{ y }, api] = useSpring(() => ({ y: 0 }));
+
+  const bind = useGesture(
+    {
+      onDrag: ({ down, movement: [, my], direction: [, dy], cancel }) => {
+        if (!down) return;
+        if (my < -50 && index < items.length - 1) {
+          setIndex((i) => i + 1);
+          cancel();
+        }
+        if (my > 50 && index > 0) {
+          setIndex((i) => i - 1);
+          cancel();
+        }
+      },
+    },
+    { drag: { axis: 'y' } },
+  );
+
+  useEffect(() => {
+    api.start({ y: -index * 100 });
+  }, [index]);
+
+  return (
+    <div {...bind()} className="relative h-screen w-screen overflow-hidden">
+      <animated.div
+        style={{ transform: y.to((py) => `translateY(${py}%)`) }}
+        className="h-full w-full"
+      >
+        {items.map((item, i) => (
+          <div key={i} className="h-screen w-screen">
+            <VideoCard {...item} />
+          </div>
+        ))}
+      </animated.div>
+    </div>
+  );
+};
+
+export default Feed;

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,6 +1,11 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
+import { GestureProvider } from '@paiduan/ui';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <GestureProvider>
+      <Component {...pageProps} />
+    </GestureProvider>
+  );
 }

--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Feed from '../components/Feed';
+import { VideoCardProps } from '../components/VideoCard';
+
+const items: VideoCardProps[] = [
+  {
+    videoUrl: 'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+    author: 'bunny',
+    caption: 'Big Buck Bunny',
+    eventId: '1',
+    onLike: () => console.log('like 1'),
+    onZap: () => console.log('zap 1'),
+  },
+  {
+    videoUrl: 'https://storage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+    author: 'elephant',
+    caption: 'Elephant Dream',
+    eventId: '2',
+    onLike: () => console.log('like 2'),
+    onZap: () => console.log('zap 2'),
+  },
+  {
+    videoUrl: 'https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4',
+    author: 'joyride',
+    caption: 'Joyrides',
+    eventId: '3',
+    onLike: () => console.log('like 3'),
+    onZap: () => console.log('zap 3'),
+  },
+];
+
+export default function FeedPage() {
+  return <Feed items={items} />;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,8 @@
   "types": "src/index.ts",
   "private": true,
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "@react-spring/web": "^9.7.2",
+    "react-use-gesture": "^9.1.3"
   }
 }

--- a/packages/ui/src/GestureProvider.tsx
+++ b/packages/ui/src/GestureProvider.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+import { useGesture as useGestureImpl } from 'react-use-gesture';
+import { useSpring as useSpringImpl, animated } from '@react-spring/web';
+
+export const GestureProvider = ({ children }: { children: ReactNode }) => {
+  return <>{children}</>;
+};
+
+export const useGesture = useGestureImpl;
+export const useSpring = useSpringImpl;
+export { animated };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,2 @@
 export * from './Button';
+export * from './GestureProvider';


### PR DESCRIPTION
## Summary
- add shared gesture hooks and provider
- implement VideoCard with playback gestures
- add swipeable Feed component and demo page

## Testing
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_6893c36421888331ae60bd55142cb1c4