### PR TITLE
feat: add hashtag and following feed tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ additional `e` tag for the parent event id and a `p` tag for the parent
 pubkey. The web client opens a drawer from the bottom half of the screen where
 users can read the thread, post comments or replies, and see updates in real
 time.
+
+## Feed modes
+
+The feed supports three modes:
+
+* **For You** – shows all recent videos.
+* **Following** – filters to events authored by pubkeys in the local following list.
+* **Tags** – displays popular `t` tags from recent videos and lets you explore by hashtag.
+
+The following list is populated from the browser's `localStorage`. A helper
+`follow(pubkey)` is available in `useFollowing` to add new authors.

--- a/apps/web/hooks/useFeed.ts
+++ b/apps/web/hooks/useFeed.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react';
+import { SimplePool, Event as NostrEvent, Filter } from 'nostr-tools';
+import { VideoCardProps } from '../components/VideoCard';
+
+export type FeedMode = { type: 'all' } | { type: 'following'; authors: string[] } | { type: 'tag'; tag: string };
+
+interface FeedResult {
+  items: VideoCardProps[];
+  tags: string[];
+  prepend: (item: VideoCardProps) => void;
+}
+
+function relayList(): string[] {
+  if (typeof window === 'undefined') return ['wss://relay.damus.io', 'wss://nos.lol'];
+  const nostr = (window as any).nostr;
+  if (nostr?.getRelays) {
+    try {
+      const relays = nostr.getRelays();
+      if (Array.isArray(relays)) return relays;
+      if (relays && typeof relays === 'object') return Object.keys(relays);
+    } catch {
+      /* ignore */
+    }
+  }
+  return ['wss://relay.damus.io', 'wss://nos.lol'];
+}
+
+export function useFeed(mode: FeedMode): FeedResult {
+  const [items, setItems] = useState<VideoCardProps[]>([]);
+  const [tags, setTags] = useState<string[]>([]);
+  const poolRef = useRef<SimplePool>();
+  const subRef = useRef<{ unsub: () => void } | null>(null);
+
+  useEffect(() => {
+    const pool = (poolRef.current ||= new SimplePool());
+    // clean previous subscription
+    subRef.current?.unsub();
+
+    const filter: Filter = { kinds: [30023], limit: 1000 };
+    if (mode.type === 'following') {
+      if (mode.authors.length === 0) {
+        setItems([]);
+        return;
+      }
+      filter.authors = mode.authors;
+    }
+    if (mode.type === 'tag') {
+      filter['#t'] = [mode.tag];
+    }
+
+    const relays = relayList();
+    const sub = pool.sub(relays, [filter]);
+    const nextItems: VideoCardProps[] = [];
+    const tagCounts: Record<string, number> = {};
+
+    sub.on('event', (event: NostrEvent) => {
+      const videoTag = event.tags.find((t) => t[0] === 'v');
+      if (!videoTag) return;
+      const posterTag = event.tags.find((t) => t[0] === 'image');
+      const zapTag = event.tags.find((t) => t[0] === 'zap');
+      const tTags = event.tags.filter((t) => t[0] === 't').map((t) => t[1]);
+      tTags.forEach((t) => {
+        tagCounts[t] = (tagCounts[t] || 0) + 1;
+      });
+      nextItems.push({
+        videoUrl: videoTag[1],
+        posterUrl: posterTag ? posterTag[1] : undefined,
+        author: event.pubkey.slice(0, 8),
+        caption: tTags.join(' '),
+        eventId: event.id,
+        lightningAddress: zapTag ? zapTag[1] : '',
+        pubkey: event.pubkey,
+        zapTotal: 0,
+        onLike: () => {},
+      });
+      setItems([...nextItems]);
+      if (mode.type === 'all') {
+        const sorted = Object.entries(tagCounts)
+          .sort((a, b) => b[1] - a[1])
+          .map(([t]) => t);
+        setTags(sorted);
+      }
+    });
+    sub.on('eose', () => {});
+
+    subRef.current = sub;
+    return () => sub.unsub();
+  }, [JSON.stringify(mode)]);
+
+  const prepend = (item: VideoCardProps) => setItems((prev) => [item, ...prev]);
+
+  return { items, tags, prepend };
+}
+
+export default useFeed;

--- a/apps/web/hooks/useFollowing.ts
+++ b/apps/web/hooks/useFollowing.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'following';
+
+function readLocal(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeLocal(list: string[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function follow(pubkey: string) {
+  const current = readLocal();
+  if (!current.includes(pubkey)) {
+    current.push(pubkey);
+    writeLocal(current);
+  }
+}
+
+export function useFollowing() {
+  const [following, setFollowing] = useState<string[]>([]);
+
+  useEffect(() => {
+    setFollowing(readLocal());
+  }, []);
+
+  const add = (pubkey: string) => {
+    follow(pubkey);
+    setFollowing(readLocal());
+  };
+
+  return { following, follow: add };
+}
+
+export default useFollowing;

--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -1,53 +1,101 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Feed from '../components/Feed';
-import { VideoCardProps } from '../components/VideoCard';
 import UploadButton from '../components/UploadButton';
 import CreatorWizard from '../components/CreatorWizard';
+import useFeed, { FeedMode } from '../hooks/useFeed';
+import useFollowing from '../hooks/useFollowing';
+import { VideoCardProps } from '../components/VideoCard';
 
-const initialItems: VideoCardProps[] = [
-  {
-    videoUrl: 'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
-    author: 'bunny',
-    caption: 'Big Buck Bunny',
-    eventId: '1',
-    lightningAddress: 'hello@getalby.com',
-    pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    zapTotal: 0,
-    onLike: () => console.log('like 1'),
-  },
-  {
-    videoUrl: 'https://storage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
-    author: 'elephant',
-    caption: 'Elephant Dream',
-    eventId: '2',
-    lightningAddress: 'hello@getalby.com',
-    pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    zapTotal: 0,
-    onLike: () => console.log('like 2'),
-  },
-  {
-    videoUrl: 'https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4',
-    author: 'joyride',
-    caption: 'Joyrides',
-    eventId: '3',
-    lightningAddress: 'hello@getalby.com',
-    pubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    zapTotal: 0,
-    onLike: () => console.log('like 3'),
-  },
-];
+const TAB_KEY = 'feed-tab';
+const TAG_KEY = 'feed-tag';
+
+type Tab = 'all' | 'following' | 'tags';
 
 export default function FeedPage() {
-  const [items, setItems] = useState<VideoCardProps[]>(initialItems);
+  const { following } = useFollowing();
+  const [tab, setTab] = useState<Tab>('all');
+  const [selectedTag, setSelectedTag] = useState<string | undefined>();
   const [showWizard, setShowWizard] = useState(false);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const savedTab = window.localStorage.getItem(TAB_KEY) as Tab | null;
+    const savedTag = window.localStorage.getItem(TAG_KEY) || undefined;
+    if (savedTab) setTab(savedTab);
+    if (savedTag) setSelectedTag(savedTag);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(TAB_KEY, tab);
+    if (selectedTag) window.localStorage.setItem(TAG_KEY, selectedTag);
+    else window.localStorage.removeItem(TAG_KEY);
+  }, [tab, selectedTag]);
+
+  const mode: FeedMode =
+    tab === 'following'
+      ? { type: 'following', authors: following }
+      : tab === 'tags' && selectedTag
+      ? { type: 'tag', tag: selectedTag }
+      : { type: 'all' };
+
+  const effectiveMode = tab === 'tags' && !selectedTag ? { type: 'all' } : mode;
+  const { items, tags, prepend } = useFeed(effectiveMode);
+
   const handlePublished = (item: VideoCardProps) => {
-    setItems((prev) => [item, ...prev]);
+    prepend(item);
   };
+
+  const renderTabs = () => (
+    <div className="fixed top-0 left-0 right-0 z-10 flex justify-around bg-black/80 text-white">
+      {(['all', 'following', 'tags'] as Tab[]).map((t) => (
+        <button
+          key={t}
+          onClick={() => {
+            setTab(t);
+            if (t !== 'tags') setSelectedTag(undefined);
+          }}
+          className={`flex-1 py-2 ${tab === t ? 'border-b-2 border-white' : ''}`}
+        >
+          {t === 'all' ? 'For You' : t === 'following' ? 'Following' : 'Tags'}
+        </button>
+      ))}
+    </div>
+  );
+
+  const renderTagList = () => (
+    <div className="pt-10 h-screen overflow-y-auto bg-black text-white">
+      {tags.map((t) => (
+        <div key={t} className="p-4 border-b border-white/20">
+          <button
+            onClick={() => {
+              setSelectedTag(t);
+            }}
+            className="w-full text-left"
+          >
+            #{t}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
 
   return (
     <>
-      <Feed items={items} />
+      {renderTabs()}
+      {tab === 'tags' && !selectedTag ? (
+        renderTagList()
+      ) : (
+        <Feed items={items} />
+      )}
+      {tab === 'tags' && selectedTag && (
+        <button
+          className="fixed left-4 top-2 z-20 text-white"
+          onClick={() => setSelectedTag(undefined)}
+        >
+          Back
+        </button>
+      )}
       <UploadButton onClick={() => setShowWizard(true)} />
       {showWizard && (
         <CreatorWizard


### PR DESCRIPTION
## Summary
- refactor feed into useFeed hook with tag and following filters
- add persistent For You, Following and Tags tabs
- document feed modes and following list helper

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6893deb445bc8331906d36854391ef8a