### PR TITLE
feat: add real-time notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ pubkey. The web client opens a drawer from the bottom half of the screen where
 users can read the thread, post comments or replies, and see updates in real
 time.
 
+## Notifications
+
+The web client listens for zap receipts (kind 9735) and new comments on your
+videos in real time. A bell icon in the app bar shows the count of unseen
+alerts and opens a slide‑down drawer listing the newest notifications. Unread
+items persist in `localStorage` so the badge survives a reload.
+
 ## Feed modes
 
 The feed supports three modes:

--- a/apps/web/components/NotificationBell.tsx
+++ b/apps/web/components/NotificationBell.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Bell } from 'lucide-react';
+import { useNotifications } from '../hooks/useNotifications';
+
+const NotificationBell: React.FC = () => {
+  const { unreadCount, setOpen } = useNotifications();
+  return (
+    <button onClick={() => setOpen(true)} className="relative text-white">
+      <Bell className="h-5 w-5" />
+      {unreadCount > 0 && (
+        <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-600 text-xs">
+          {unreadCount}
+        </span>
+      )}
+    </button>
+  );
+};
+
+export default NotificationBell;

--- a/apps/web/components/NotificationDrawer.tsx
+++ b/apps/web/components/NotificationDrawer.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useNotifications } from '../hooks/useNotifications';
+import { useRouter } from 'next/router';
+
+const NotificationDrawer: React.FC = () => {
+  const { notifications, open, setOpen, markAsRead, markAllAsRead } = useNotifications();
+  const router = useRouter();
+
+  const handleClick = (id: string, noteId: string) => {
+    markAsRead(id);
+    setOpen(false);
+    if (noteId) router.push(`/v/${noteId}`);
+  };
+
+  return (
+    <div
+      className={
+        `fixed top-12 left-0 right-0 z-30 max-h-1/2 transform overflow-y-auto bg-black text-white transition-transform duration-300 ${
+          open ? 'translate-y-0' : '-translate-y-full'
+        }`
+      }
+    >
+      <div className="flex items-center justify-between border-b border-white/20 p-2">
+        <span className="font-semibold">Notifications</span>
+        {notifications.length > 0 && (
+          <button
+            className="text-sm text-blue-400"
+            onClick={() => {
+              markAllAsRead();
+              setOpen(false);
+            }}
+          >
+            Mark all read
+          </button>
+        )}
+      </div>
+      {notifications.length === 0 && (
+        <div className="p-4 text-center text-sm">No new notifications</div>
+      )}
+      {notifications.map((n) => (
+        <div
+          key={n.id}
+          className="cursor-pointer border-b border-white/20 p-3"
+          onClick={() => handleClick(n.id, n.noteId)}
+        >
+          <div className="flex items-start space-x-3">
+            <div className="h-8 w-8 rounded-full bg-gray-500" />
+            <div>
+              <div className="text-sm">
+                {n.type === 'zap'
+                  ? `${n.from.slice(0, 8)} zapped you ${n.amount ?? 0} sats`
+                  : `${n.from.slice(0, 8)} replied: ${n.text}`}
+              </div>
+              <div className="text-xs text-gray-400">
+                {new Date(n.created_at * 1000).toLocaleString()}
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default NotificationDrawer;

--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { X } from 'lucide-react';
 import useSearch from '../hooks/useSearch';
+import NotificationBell from './NotificationBell';
 
 const SearchBar: React.FC = () => {
   const [value, setValue] = useState('');
@@ -45,6 +46,7 @@ const SearchBar: React.FC = () => {
             <X />
           </button>
         )}
+        <NotificationBell />
       </div>
       <div
         className={`fixed inset-x-0 bottom-0 z-20 max-h-1/2 overflow-y-auto bg-black text-white transition-transform duration-300 ${

--- a/apps/web/hooks/pool.ts
+++ b/apps/web/hooks/pool.ts
@@ -1,0 +1,6 @@
+import { SimplePool } from 'nostr-tools';
+
+// Shared SimplePool instance for the web app
+const pool = new SimplePool();
+
+export default pool;

--- a/apps/web/hooks/useNotifications.tsx
+++ b/apps/web/hooks/useNotifications.tsx
@@ -1,0 +1,184 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { Event as NostrEvent } from 'nostr-tools';
+import pool from './pool';
+import { toast } from 'react-hot-toast';
+
+const relays = ['wss://relay.damus.io', 'wss://nos.lol'];
+
+export interface Notification {
+  id: string;
+  type: 'zap' | 'comment';
+  from: string;
+  noteId: string;
+  amount?: number;
+  text?: string;
+  created_at: number;
+}
+
+interface NotificationContextValue {
+  notifications: Notification[]; // unseen notifications
+  unreadCount: number;
+  markAllAsRead: () => void;
+  markAsRead: (id: string) => void;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const NotificationsContext = createContext<NotificationContextValue | null>(null);
+
+function readStorage(): Notification[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem('unseen-notifications');
+    return raw ? (JSON.parse(raw) as Notification[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(list: Notification[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem('unseen-notifications', JSON.stringify(list));
+  } catch {
+    /* ignore */
+  }
+}
+
+export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [notifications, setNotifications] = useState<Notification[]>(readStorage);
+  const [open, setOpen] = useState(false);
+
+  // keep refs to avoid stale closures
+  const openRef = useRef(open);
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+
+  const pushNotification = (n: Notification) => {
+    setNotifications((prev) => {
+      if (prev.find((p) => p.id === n.id)) return prev; // avoid duplicates
+      const next = [n, ...prev].sort((a, b) => b.created_at - a.created_at);
+      writeStorage(next);
+      if (!openRef.current) {
+        const summary =
+          n.type === 'zap'
+            ? `⚡ ${n.from.slice(0, 8)} zapped you ${n.amount ?? 0} sats`
+            : `💬 ${n.from.slice(0, 8)} replied: ${n.text ?? ''}`;
+        toast.custom((t) => (
+          <div
+            onClick={() => {
+              setOpen(true);
+              toast.dismiss(t.id);
+            }}
+            className="cursor-pointer px-2"
+          >
+            {summary}
+          </div>
+        ));
+      }
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    writeStorage(notifications);
+  }, [notifications]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const nostr = (window as any).nostr;
+    if (!nostr) return;
+    let zapSub: { unsub: () => void } | null = null;
+    let commentSub: { unsub: () => void } | null = null;
+
+    (async () => {
+      try {
+        const pubkey = await nostr.getPublicKey();
+
+        // fetch my video ids (kind 30023)
+        let myVideos: NostrEvent[] = [];
+        try {
+          myVideos = await pool.list(relays, [{ kinds: [30023], authors: [pubkey] }]);
+        } catch {
+          /* ignore */
+        }
+        const myVideoIds = myVideos.map((v) => v.id);
+
+        // subscribe to zap receipts
+        zapSub = pool.sub(relays, [{ kinds: [9735], '#p': [pubkey] }]);
+        zapSub.on('event', (ev: NostrEvent) => {
+          const eTag = ev.tags.find((t) => t[0] === 'e');
+          const amt = ev.tags.find((t) => t[0] === 'amount');
+          pushNotification({
+            id: ev.id,
+            type: 'zap',
+            from: ev.pubkey,
+            amount: amt ? Math.round(parseInt(amt[1] || '0', 10) / 1000) : undefined,
+            noteId: eTag ? eTag[1] : '',
+            created_at: ev.created_at,
+          });
+        });
+
+        // subscribe to comments on my videos
+        if (myVideoIds.length > 0) {
+          commentSub = pool.sub(relays, [{ kinds: [1], '#e': myVideoIds }]);
+          commentSub.on('event', (ev: NostrEvent) => {
+            const eTag = ev.tags.find((t) => t[0] === 'e');
+            pushNotification({
+              id: ev.id,
+              type: 'comment',
+              from: ev.pubkey,
+              text: ev.content.slice(0, 100),
+              noteId: eTag ? eTag[1] : '',
+              created_at: ev.created_at,
+            });
+          });
+        }
+      } catch {
+        /* ignore */
+      }
+    })();
+
+    return () => {
+      zapSub?.unsub();
+      commentSub?.unsub();
+    };
+  }, []);
+
+  const markAllAsRead = () => {
+    setNotifications([]);
+    writeStorage([]);
+  };
+
+  const markAsRead = (id: string) => {
+    setNotifications((prev) => {
+      const next = prev.filter((n) => n.id !== id);
+      writeStorage(next);
+      return next;
+    });
+  };
+
+  const value: NotificationContextValue = {
+    notifications,
+    unreadCount: notifications.length,
+    markAllAsRead,
+    markAsRead,
+    open,
+    setOpen,
+  };
+
+  return (
+    <NotificationsContext.Provider value={value}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+};
+
+export function useNotifications() {
+  const ctx = useContext(NotificationsContext);
+  if (!ctx) throw new Error('useNotifications must be used within NotificationsProvider');
+  return ctx;
+}
+
+export default useNotifications;

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -2,12 +2,17 @@ import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 import { GestureProvider } from '@paiduan/ui';
 import { Toaster } from 'react-hot-toast';
+import { NotificationsProvider } from '../hooks/useNotifications';
+import NotificationDrawer from '../components/NotificationDrawer';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <GestureProvider>
-      <Component {...pageProps} />
-      <Toaster />
+      <NotificationsProvider>
+        <Component {...pageProps} />
+        <NotificationDrawer />
+        <Toaster />
+      </NotificationsProvider>
     </GestureProvider>
   );
 }


### PR DESCRIPTION
## Summary
- implement global SimplePool-backed notification store for zap receipts and comment mentions
- add bell icon, drawer UI and toast alerts
- document notification behavior in README

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6893ffdeca3483319a4bef52418ee6b3