### PR TITLE
Add settings and theming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ videos in real time. A bell icon in the app bar shows the count of unseen
 alerts and opens a slide‑down drawer listing the newest notifications. Unread
 items persist in `localStorage` so the badge survives a reload.
 
+## Settings & theming
+
+The `/settings` page provides controls for the app's appearance. Switch between
+light and dark themes, pick an accent colour, or clear cached videos,
+notifications and follow data. Preferences are saved in `localStorage` and
+applied across all pages. A sun/moon icon in the toolbar also toggles light and
+dark modes without leaving the feed.
+
 ## Feed modes
 
 The feed supports three modes:

--- a/apps/web/components/CommentDrawer.tsx
+++ b/apps/web/components/CommentDrawer.tsx
@@ -122,12 +122,12 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
   return (
     <animated.div
       style={{ transform: y.to((py) => `translateY(${py}%)`) }}
-      className="fixed inset-x-0 bottom-0 z-50 h-1/2 bg-black text-white"
+      className="fixed inset-x-0 bottom-0 z-50 h-1/2 bg-background text-foreground"
       {...bind()}
     >
-      <div className="flex items-center justify-between border-b border-white/10 p-2">
+      <div className="flex items-center justify-between border-b border-foreground/10 p-2">
         <span className="font-semibold">Comments</span>
-        <button onClick={onClose} className="p-1">
+        <button onClick={onClose} className="p-1 hover:text-accent">
           <X />
         </button>
       </div>
@@ -135,15 +135,15 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
         {topLevel.map((c) => (
           <div key={c.id}>
             <div className="flex items-start space-x-2">
-              <div className="h-8 w-8 rounded-full bg-gray-500" />
+              <div className="h-8 w-8 rounded-full bg-foreground/20" />
               <div>
                 <div className="text-sm font-semibold">@{c.pubkey.slice(0, 8)}</div>
                 <div className="text-sm">{c.content}</div>
-                <div className="text-xs text-gray-400">
+                <div className="text-xs text-foreground/50">
                   {new Date(c.created_at * 1000).toLocaleString()}
                 </div>
                 <button
-                  className="text-xs text-blue-400"
+                  className="text-xs text-accent"
                   onClick={() => setReplyTo(c)}
                 >
                   Reply
@@ -152,15 +152,15 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
             </div>
             {repliesMap[c.id]?.map((r) => (
               <div key={r.id} className="mt-2 ml-8 flex items-start space-x-2">
-                <div className="h-6 w-6 rounded-full bg-gray-500" />
+                <div className="h-6 w-6 rounded-full bg-foreground/20" />
                 <div>
                   <div className="text-sm font-semibold">@{r.pubkey.slice(0, 8)}</div>
                   <div className="text-sm">{r.content}</div>
-                  <div className="text-xs text-gray-400">
+                  <div className="text-xs text-foreground/50">
                     {new Date(r.created_at * 1000).toLocaleString()}
                   </div>
                   <button
-                    className="text-xs text-blue-400"
+                    className="text-xs text-accent"
                     onClick={() => setReplyTo(r)}
                   >
                     Reply
@@ -171,11 +171,11 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
           </div>
         ))}
       </div>
-      <div className="absolute bottom-0 left-0 right-0 border-t border-white/10 p-2">
+      <div className="absolute bottom-0 left-0 right-0 border-t border-foreground/10 p-2">
         {replyTo && (
-          <div className="mb-1 text-xs text-gray-400">
+          <div className="mb-1 text-xs text-foreground/50">
             Replying to @{replyTo.pubkey.slice(0, 8)}{' '}
-            <button onClick={() => setReplyTo(null)} className="underline">
+            <button onClick={() => setReplyTo(null)} className="underline hover:text-accent">
               cancel
             </button>
           </div>
@@ -185,7 +185,7 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Add a comment"
-          className="w-full rounded bg-gray-800 p-2 text-sm outline-none"
+          className="w-full rounded bg-foreground/10 p-2 text-sm outline-none"
           disabled={!open}
         />
       </div>

--- a/apps/web/components/NotificationBell.tsx
+++ b/apps/web/components/NotificationBell.tsx
@@ -5,10 +5,10 @@ import { useNotifications } from '../hooks/useNotifications';
 const NotificationBell: React.FC = () => {
   const { unreadCount, setOpen } = useNotifications();
   return (
-    <button onClick={() => setOpen(true)} className="relative text-white">
+    <button onClick={() => setOpen(true)} className="relative text-foreground hover:text-accent">
       <Bell className="h-5 w-5" />
       {unreadCount > 0 && (
-        <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-600 text-xs">
+        <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-accent text-xs text-white">
           {unreadCount}
         </span>
       )}

--- a/apps/web/components/NotificationDrawer.tsx
+++ b/apps/web/components/NotificationDrawer.tsx
@@ -15,16 +15,16 @@ const NotificationDrawer: React.FC = () => {
   return (
     <div
       className={
-        `fixed top-12 left-0 right-0 z-30 max-h-1/2 transform overflow-y-auto bg-black text-white transition-transform duration-300 ${
+        `fixed top-12 left-0 right-0 z-30 max-h-1/2 transform overflow-y-auto bg-background text-foreground transition-transform duration-300 ${
           open ? 'translate-y-0' : '-translate-y-full'
         }`
       }
     >
-      <div className="flex items-center justify-between border-b border-white/20 p-2">
+      <div className="flex items-center justify-between border-b border-foreground/20 p-2">
         <span className="font-semibold">Notifications</span>
         {notifications.length > 0 && (
           <button
-            className="text-sm text-blue-400"
+            className="text-sm text-accent"
             onClick={() => {
               markAllAsRead();
               setOpen(false);
@@ -40,18 +40,18 @@ const NotificationDrawer: React.FC = () => {
       {notifications.map((n) => (
         <div
           key={n.id}
-          className="cursor-pointer border-b border-white/20 p-3"
+          className="cursor-pointer border-b border-foreground/20 p-3"
           onClick={() => handleClick(n.id, n.noteId)}
         >
           <div className="flex items-start space-x-3">
-            <div className="h-8 w-8 rounded-full bg-gray-500" />
+            <div className="h-8 w-8 rounded-full bg-foreground/20" />
             <div>
               <div className="text-sm">
                 {n.type === 'zap'
                   ? `${n.from.slice(0, 8)} zapped you ${n.amount ?? 0} sats`
                   : `${n.from.slice(0, 8)} replied: ${n.text}`}
               </div>
-              <div className="text-xs text-gray-400">
+              <div className="text-xs text-foreground/50">
                 {new Date(n.created_at * 1000).toLocaleString()}
               </div>
             </div>

--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { X } from 'lucide-react';
+import { X, Sun, Moon } from 'lucide-react';
 import useSearch from '../hooks/useSearch';
 import NotificationBell from './NotificationBell';
+import { useTheme } from '../hooks/useTheme';
 
 const SearchBar: React.FC = () => {
   const [value, setValue] = useState('');
   const [query, setQuery] = useState('');
   const router = useRouter();
   const { videos, creators } = useSearch(query);
+  const { mode, toggleMode } = useTheme();
 
   useEffect(() => {
     const handler = setTimeout(() => setQuery(value.trim()), 300);
@@ -34,27 +36,34 @@ const SearchBar: React.FC = () => {
 
   return (
     <>
-      <div className="fixed top-0 left-0 right-0 z-20 flex h-12 items-center space-x-2 bg-black/80 p-2">
+      <div className="fixed top-0 left-0 right-0 z-20 flex h-12 items-center space-x-2 bg-background/80 p-2 text-foreground">
         <input
           value={value}
           onChange={(e) => setValue(e.target.value)}
           placeholder="Search"
-          className="flex-1 rounded px-2 py-1 text-black"
+          className="flex-1 rounded bg-background px-2 py-1 text-foreground"
         />
         {value && (
-          <button onClick={clear} className="text-white">
+          <button onClick={clear} className="hover:text-accent">
             <X />
           </button>
         )}
+        <button
+          onClick={toggleMode}
+          title="Toggle light/dark"
+          className="hover:text-accent"
+        >
+          {mode === 'dark' ? <Sun /> : <Moon />}
+        </button>
         <NotificationBell />
       </div>
       <div
-        className={`fixed inset-x-0 bottom-0 z-20 max-h-1/2 overflow-y-auto bg-black text-white transition-transform duration-300 ${
+        className={`fixed inset-x-0 bottom-0 z-20 max-h-1/2 overflow-y-auto bg-background text-foreground transition-transform duration-300 ${
           showDrawer ? 'translate-y-0' : 'translate-y-full'
         }`}
       >
         {creators.length > 0 && (
-          <div className="p-4 border-b border-white/20">
+          <div className="p-4 border-b border-foreground/20">
             <div className="mb-2 text-sm">Creators</div>
             {creators.map((c) => (
               <div
@@ -69,7 +78,7 @@ const SearchBar: React.FC = () => {
                     className="h-8 w-8 rounded-full object-cover"
                   />
                 ) : (
-                  <div className="h-8 w-8 rounded-full bg-gray-500" />
+                  <div className="h-8 w-8 rounded-full bg-foreground/20" />
                 )}
                 <div>{c.name}</div>
               </div>
@@ -92,7 +101,7 @@ const SearchBar: React.FC = () => {
                     className="h-12 w-16 object-cover"
                   />
                 ) : (
-                  <div className="h-12 w-16 bg-gray-500" />
+                  <div className="h-12 w-16 bg-foreground/20" />
                 )}
                 <div className="text-sm">{v.caption}</div>
               </div>

--- a/apps/web/components/UploadButton.tsx
+++ b/apps/web/components/UploadButton.tsx
@@ -7,7 +7,7 @@ interface UploadButtonProps {
 export const UploadButton: React.FC<UploadButtonProps> = ({ onClick }) => (
   <button
     onClick={onClick}
-    className="fixed bottom-8 right-8 z-50 rounded-full bg-pink-500 p-4 text-white shadow-lg"
+    className="fixed bottom-8 right-8 z-50 rounded-full bg-accent p-4 text-white shadow-lg"
   >
     +
   </button>

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -124,7 +124,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   return (
     <div
       ref={containerRef}
-      className="relative h-screen w-screen overflow-hidden bg-black text-white"
+      className="relative h-screen w-screen overflow-hidden bg-background text-foreground"
       onDoubleClick={onLike}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
@@ -145,13 +145,13 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       />
 
       <div className="absolute right-4 bottom-24 flex flex-col items-center space-y-4">
-        <button onClick={onLike} className="text-white">
+        <button onClick={onLike} className="hover:text-accent">
           <Heart />
         </button>
-        <button className="relative text-white" onClick={() => setCommentsOpen(true)}>
+        <button className="relative hover:text-accent" onClick={() => setCommentsOpen(true)}>
           <MessageCircle />
           {commentCount > 0 && (
-            <span className="absolute -right-2 -top-2 text-xs">{commentCount}</span>
+            <span className="absolute -right-2 -top-2 text-xs text-foreground">{commentCount}</span>
           )}
         </button>
         <ZapButton
@@ -160,7 +160,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           pubkey={pubkey}
           total={zapTotal}
         />
-        <button onClick={handleShare} className="text-white">
+        <button onClick={handleShare} className="hover:text-accent">
           <Share2 />
         </button>
       </div>
@@ -170,12 +170,15 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           {avatar ? (
             <img src={avatar} alt={displayName} className="h-10 w-10 rounded-full object-cover" />
           ) : (
-            <div className="h-10 w-10 rounded-full bg-gray-500" />
+            <div className="h-10 w-10 rounded-full bg-foreground/20" />
           )}
           <div className="font-semibold">@{displayName}</div>
         </Link>
         {!isFollowing && (
-          <button onClick={() => follow(pubkey)} className="mt-2 text-sm text-white">
+          <button
+            onClick={() => follow(pubkey)}
+            className="mt-2 rounded bg-accent px-2 py-1 text-sm text-white"
+          >
             Follow
           </button>
         )}
@@ -184,10 +187,10 @@ export const VideoCard: React.FC<VideoCardProps> = ({
 
       <animated.div
         style={{ opacity }}
-        className="absolute bottom-1/4 left-0 right-0 h-1 bg-white/50"
+        className="absolute bottom-1/4 left-0 right-0 h-1 bg-foreground/50"
       >
-        <div className="absolute left-1/2 top-0 h-1 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white" />
-        <div className="absolute -top-5 left-1/2 -translate-x-1/2 rounded bg-black/50 px-1 text-xs">
+        <div className="absolute left-1/2 top-0 h-1 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground" />
+        <div className="absolute -top-5 left-1/2 -translate-x-1/2 rounded bg-background/50 px-1 text-xs">
           {seekPreview.toFixed(1)}s
         </div>
       </animated.div>

--- a/apps/web/components/ZapButton.tsx
+++ b/apps/web/components/ZapButton.tsx
@@ -15,7 +15,7 @@ export const ZapButton: React.FC<ZapButtonProps> = ({ lightningAddress, eventId,
 
   return (
     <>
-      <button onClick={() => setOpen(true)} className="flex flex-col items-center text-white">
+      <button onClick={() => setOpen(true)} className="flex flex-col items-center text-foreground hover:text-accent">
         <Zap />
         <span className="text-xs">{count}</span>
       </button>

--- a/apps/web/components/ZapModal.tsx
+++ b/apps/web/components/ZapModal.tsx
@@ -27,14 +27,14 @@ export const ZapModal: React.FC<ZapModalProps> = ({ lightningAddress, eventId, p
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/70">
-      <div className="rounded bg-white p-4 text-black w-64">
+      <div className="w-64 rounded bg-background p-4 text-foreground">
         <h2 className="mb-2 text-lg font-semibold">Send sats</h2>
         <div className="mb-2 flex space-x-2">
           {preset.map((p) => (
             <button
               key={p}
               onClick={() => send(p)}
-              className="flex-1 rounded border px-2 py-1"
+              className="flex-1 rounded border px-2 py-1 hover:bg-accent hover:text-white"
             >
               {p}
             </button>
@@ -45,17 +45,17 @@ export const ZapModal: React.FC<ZapModalProps> = ({ lightningAddress, eventId, p
             type="number"
             value={custom}
             onChange={(e) => setCustom(e.target.value)}
-            className="flex-1 rounded border px-2 py-1"
+            className="flex-1 rounded border px-2 py-1 bg-background"
             placeholder="Custom"
           />
           <button
             onClick={() => custom && send(Number(custom))}
-            className="rounded border px-2 py-1"
+            className="rounded border px-2 py-1 hover:bg-accent hover:text-white"
           >
             Zap
           </button>
         </div>
-        <button onClick={onClose} className="mt-3 text-sm underline">
+        <button onClick={onClose} className="mt-3 text-sm underline hover:text-accent">
           Cancel
         </button>
       </div>

--- a/apps/web/hooks/useTheme.tsx
+++ b/apps/web/hooks/useTheme.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Mode = 'light' | 'dark';
+
+interface ThemeContextValue {
+  mode: Mode;
+  accent: string;
+  toggleMode: () => void;
+  setAccent: (color: string) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [mode, setMode] = useState<Mode>('light');
+  const [accent, setAccentState] = useState<string>('#3b82f6');
+
+  // initial load
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const savedMode = localStorage.getItem('theme-mode') as Mode | null;
+    const savedAccent = localStorage.getItem('theme-accent');
+    if (savedMode) {
+      setMode(savedMode);
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setMode('dark');
+    }
+    if (savedAccent) setAccentState(savedAccent);
+  }, []);
+
+  // apply mode
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.classList.toggle('dark', mode === 'dark');
+    }
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme-mode', mode);
+    }
+  }, [mode]);
+
+  // apply accent
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.style.setProperty('--accent', accent);
+    }
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme-accent', accent);
+    }
+  }, [accent]);
+
+  const toggleMode = () => setMode((m) => (m === 'light' ? 'dark' : 'light'));
+  const setAccent = (c: string) => setAccentState(c);
+
+  return (
+    <ThemeContext.Provider value={{ mode, accent, toggleMode, setAccent }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}
+
+export default useTheme;

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -4,15 +4,18 @@ import { GestureProvider } from '@paiduan/ui';
 import { Toaster } from 'react-hot-toast';
 import { NotificationsProvider } from '../hooks/useNotifications';
 import NotificationDrawer from '../components/NotificationDrawer';
+import { ThemeProvider } from '../hooks/useTheme';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <GestureProvider>
-      <NotificationsProvider>
-        <Component {...pageProps} />
-        <NotificationDrawer />
-        <Toaster />
-      </NotificationsProvider>
-    </GestureProvider>
+    <ThemeProvider>
+      <GestureProvider>
+        <NotificationsProvider>
+          <Component {...pageProps} />
+          <NotificationDrawer />
+          <Toaster />
+        </NotificationsProvider>
+      </GestureProvider>
+    </ThemeProvider>
   );
 }

--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -58,7 +58,7 @@ export default function FeedPage() {
   };
 
   const renderTabs = () => (
-    <div className="fixed top-12 left-0 right-0 z-10 flex justify-around bg-black/80 text-white">
+    <div className="fixed top-12 left-0 right-0 z-10 flex justify-around bg-background/80 text-foreground">
       {(['all', 'following', 'tags'] as Tab[]).map((t) => (
         <button
           key={t}
@@ -66,7 +66,7 @@ export default function FeedPage() {
             setTab(t);
             if (t !== 'tags') setSelectedTag(undefined);
           }}
-          className={`flex-1 py-2 ${tab === t ? 'border-b-2 border-white' : ''}`}
+          className={`flex-1 py-2 ${tab === t ? 'border-b-2 border-foreground' : ''}`}
         >
           {t === 'all' ? 'For You' : t === 'following' ? 'Following' : 'Tags'}
         </button>
@@ -75,10 +75,10 @@ export default function FeedPage() {
   );
 
   const renderTagList = () => (
-    <div className="pt-20 h-screen overflow-y-auto bg-black text-white">
+    <div className="pt-20 h-screen overflow-y-auto bg-background text-foreground">
       {tags.map((t) => (
-        <div key={t} className="p-4 border-b border-white/20">
-          <Link href={`/feed?tag=${t}`} className="block w-full text-left">
+        <div key={t} className="p-4 border-b border-foreground/20">
+          <Link href={`/feed?tag=${t}`} className="block w-full text-left hover:text-accent">
             #{t}
           </Link>
         </div>
@@ -97,7 +97,7 @@ export default function FeedPage() {
       )}
       {tab === 'tags' && selectedTag && (
         <button
-          className="fixed left-4 top-14 z-20 text-white"
+          className="fixed left-4 top-14 z-20 text-foreground hover:text-accent"
           onClick={() => {
             setSelectedTag(undefined);
             router.push('/feed');

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@paiduan/ui';
 
 export default function Home() {
   return (
-    <div className="bg-red-500 min-h-screen flex items-center justify-center">
+    <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
       <Button label="Click me" />
     </div>
   );

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useTheme } from '../hooks/useTheme';
+
+const swatches = ['#3b82f6', '#f43f5e', '#10b981', '#f59e0b', '#6366f1', '#ec4899'];
+
+export default function SettingsPage() {
+  const { mode, toggleMode, accent, setAccent } = useTheme();
+
+  const clearStorage = () => {
+    if (typeof window === 'undefined') return;
+    const keys = ['feed-tab', 'feed-tag', 'unseen-notifications', 'following'];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (k && k.startsWith('followers-')) keys.push(k);
+    }
+    keys.forEach((k) => window.localStorage.removeItem(k));
+  };
+
+  return (
+    <div className="min-h-screen bg-background p-4 text-foreground space-y-6">
+      <div className="rounded border border-foreground/20 p-4">
+        <h2 className="mb-2 text-lg font-semibold">Appearance</h2>
+        <button
+          onClick={toggleMode}
+          className="rounded border border-foreground/20 px-3 py-1 hover:bg-accent hover:text-white"
+        >
+          {mode === 'dark' ? 'Switch to light' : 'Switch to dark'}
+        </button>
+      </div>
+      <div className="rounded border border-foreground/20 p-4">
+        <h2 className="mb-2 text-lg font-semibold">Accent Colour</h2>
+        <div className="flex space-x-2">
+          {swatches.map((c) => (
+            <button
+              key={c}
+              onClick={() => setAccent(c)}
+              style={{ backgroundColor: c }}
+              className="h-8 w-8 rounded-full border border-foreground/20"
+            />
+          ))}
+          <input
+            type="color"
+            value={accent}
+            onChange={(e) => setAccent(e.target.value)}
+            className="h-8 w-8 rounded-full border border-foreground/20 p-0"
+          />
+        </div>
+      </div>
+      <div className="rounded border border-foreground/20 p-4">
+        <h2 className="mb-2 text-lg font-semibold">Storage</h2>
+        <button
+          onClick={clearStorage}
+          className="rounded border border-foreground/20 px-3 py-1 hover:bg-accent hover:text-white"
+        >
+          Clear cached data
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -1,3 +1,20 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --accent: #3b82f6;
+  --background: #ffffff;
+  --foreground: #000000;
+}
+
+.dark {
+  --background: #000000;
+  --foreground: #ffffff;
+}
+
+@layer base {
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -5,8 +5,15 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
     '../../packages/ui/src/**/*.{js,ts,jsx,tsx}'
   ],
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        accent: 'var(--accent)',
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add theme context and persistent accent variables
- implement settings page with appearance and storage controls
- wire up light/dark toggle and accent styling across UI

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689408e2f854833193e263324698b26e