### PR TITLE
fix: transpile ui package in next config

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -16,6 +16,6 @@ const withPWAConfig = withPWA({
 
 export default withPWAConfig({
   reactStrictMode: true,
-  experimental: { appDir: false },
-  typescript: { ignoreBuildErrors: true }
+  typescript: { ignoreBuildErrors: true },
+  transpilePackages: ['@paiduan/ui']
 })


### PR DESCRIPTION
## Summary
- transpile @paiduan/ui in Next.js config so shared TS components compile correctly

## Testing
- `pnpm -F @paiduan/web build` *(fails: react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_68946341061883318e1401c0399abaa3