### PR TITLE
Pre-generate localized pages for /en, /zh, /ar

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-const locales = ['en', 'zh', 'ar'];
+import { locales } from './utils/locales';
 const PUBLIC_FILE = /\.(.*)$/;
 
 function getLocale(req: NextRequest): string {

--- a/apps/web/pages/[locale]/feed.tsx
+++ b/apps/web/pages/[locale]/feed.tsx
@@ -1,2 +1,14 @@
+import { locales } from '../../utils/locales';
 export { default } from '../feed';
+
+export function getStaticPaths() {
+  return {
+    paths: locales.map((locale) => ({ params: { locale } })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps() {
+  return { props: {} };
+}
 

--- a/apps/web/pages/[locale]/index.tsx
+++ b/apps/web/pages/[locale]/index.tsx
@@ -1,2 +1,14 @@
+import { locales } from '../../utils/locales';
 export { default } from '../index';
+
+export function getStaticPaths() {
+  return {
+    paths: locales.map((locale) => ({ params: { locale } })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps() {
+  return { props: {} };
+}
 

--- a/apps/web/pages/[locale]/offline.tsx
+++ b/apps/web/pages/[locale]/offline.tsx
@@ -1,2 +1,14 @@
+import { locales } from '../../utils/locales';
 export { default } from '../offline';
+
+export function getStaticPaths() {
+  return {
+    paths: locales.map((locale) => ({ params: { locale } })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps() {
+  return { props: {} };
+}
 

--- a/apps/web/pages/[locale]/settings.tsx
+++ b/apps/web/pages/[locale]/settings.tsx
@@ -1,2 +1,14 @@
+import { locales } from '../../utils/locales';
 export { default } from '../settings';
+
+export function getStaticPaths() {
+  return {
+    paths: locales.map((locale) => ({ params: { locale } })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps() {
+  return { props: {} };
+}
 

--- a/apps/web/utils/locales.ts
+++ b/apps/web/utils/locales.ts
@@ -1,0 +1,2 @@
+export const locales = ['en', 'zh', 'ar'] as const;
+export type Locale = typeof locales[number];


### PR DESCRIPTION
## Summary
- add locale constants for reuse
- export `getStaticPaths`/`getStaticProps` from locale pages so `/en`, `/zh`, and `/ar` are built
- pull middleware locale list from shared util

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web build` *(fails: Attempted import error: 'NextIntlProvider' is not exported from 'next-intl'; 'createFFmpeg' is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68946dfb885c833186882c69346aad1c