### PR TITLE
fix: wrap intl messages under common namespace

### DIFF
--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -62,5 +62,11 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   const appProps = await App.getInitialProps(appContext);
   const locale = (appContext.router?.query?.locale as string) || 'en';
   const messages = (await import(`../locales/${locale}/common.json`)).default;
-  return { ...appProps, pageProps: { ...appProps.pageProps, messages } };
+  return {
+    ...appProps,
+    pageProps: {
+      ...appProps.pageProps,
+      messages: { common: messages },
+    },
+  };
 };


### PR DESCRIPTION
## Summary
- wrap locale messages under `common` namespace

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6894776fad00833192d36bb0d1897b36