### PR TITLE
fix: set locale timezone for use-intl

### DIFF
--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -18,6 +18,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   useOffline();
   const router = useRouter();
   const locale = (router.query.locale as string) || 'en';
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_SENTRY_DSN && consentGiven()) {
@@ -33,7 +34,16 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   }, [router]);
 
   return (
-    <NextIntlClientProvider locale={locale} messages={pageProps.messages}>
+    <NextIntlClientProvider
+      locale={locale}
+      messages={pageProps.messages}
+      timeZone={timeZone}
+      onError={(err) => {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(err);
+        }
+      }}
+    >
       <>
         <ThemeProvider>
           <GestureProvider>

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["NODE_ENV"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- explicitly set `timeZone` for NextIntl provider and log errors in dev
- declare NODE_ENV for lint to avoid undeclared env var errors

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689478996be083319b18b021b82a84b5