### PR TITLE
chore: update web manifest name

### DIFF
--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Zapstr",
-  "short_name": "Zapstr",
+  "name": "PaiDuan",
+  "short_name": "PaiDuan",
   "start_url": "/feed",
   "display": "standalone",
   "theme_color": "#101010",


### PR DESCRIPTION
## Summary
- rename web manifest name and short_name to PaiDuan

## Testing
- `npx hint apps/web/public/manifest.json`
- `pnpm --filter=@paiduan/web lint` *(fails: ADMIN_PUBKEYS is not listed as a dependency in turbo.json)*
- `pnpm test`
- `pnpm --filter=@paiduan/web build` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947d084d0c83319ab412c1ac0c9f7e