### PR TITLE
fix: lazy load ffmpeg for client-side trimming

### DIFF
--- a/apps/web/utils/trimVideo.ts
+++ b/apps/web/utils/trimVideo.ts
@@ -1,15 +1,32 @@
-import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
-
-const ffmpeg = createFFmpeg({ log: true });
+let ffmpeg: any;
+let fetchFile: any;
 
 export async function trimVideo(blob: Blob, start: number, end: number): Promise<Blob> {
+  if (typeof window === 'undefined') {
+    throw new Error('trimVideo can only run in the browser');
+  }
+  if (!ffmpeg) {
+    const ffmpegModule = await import('@ffmpeg/ffmpeg');
+    ffmpeg = ffmpegModule.createFFmpeg({ log: true });
+    fetchFile = ffmpegModule.fetchFile;
+  }
   if (!ffmpeg.isLoaded()) {
     await ffmpeg.load();
   }
   const data = await fetchFile(blob);
   ffmpeg.FS('writeFile', 'input.mp4', data);
   const duration = end - start;
-  await ffmpeg.run('-ss', `${start}`, '-i', 'input.mp4', '-t', `${duration}`, '-c', 'copy', 'out.mp4');
+  await ffmpeg.run(
+    '-ss',
+    `${start}`,
+    '-i',
+    'input.mp4',
+    '-t',
+    `${duration}`,
+    '-c',
+    'copy',
+    'out.mp4',
+  );
   const trimmed = ffmpeg.FS('readFile', 'out.mp4');
   return new Blob([trimmed], { type: 'video/mp4' });
 }


### PR DESCRIPTION
## Summary
- lazy load `@ffmpeg/ffmpeg` so util only runs in browser

## Testing
- `pnpm --filter @paiduan/web exec eslint utils/trimVideo.ts && echo 'Lint OK'`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68947eefd24083318d7c0667b1f52a68