### PR TITLE
chore: rename install translation key

### DIFF
--- a/apps/web/components/InstallBanner.tsx
+++ b/apps/web/components/InstallBanner.tsx
@@ -31,7 +31,7 @@ export default function InstallBanner() {
 
   return (
     <div className="fixed bottom-0 inset-x-0 z-50 bg-background/90 p-4 flex items-center justify-between">
-      <span>{t('install_zapstr')}</span>
+      <span>{t('install_paiduan')}</span>
       <div className="space-x-2">
         <button onClick={handleInstall} className="rounded bg-accent px-3 py-1 text-white">
           {t('install')}

--- a/apps/web/locales/ar/common.json
+++ b/apps/web/locales/ar/common.json
@@ -7,7 +7,7 @@
   "following": "يتابع",
   "tags": "الوسوم",
   "back": "رجوع",
-  "install_zapstr": "تثبيت Zapstr",
+  "install_paiduan": "تثبيت PaiDuan",
   "install": "تثبيت",
   "dismiss": "تجاهل",
   "appearance": "المظهر",

--- a/apps/web/locales/en/common.json
+++ b/apps/web/locales/en/common.json
@@ -7,7 +7,7 @@
   "following": "Following",
   "tags": "Tags",
   "back": "Back",
-  "install_zapstr": "Install Zapstr",
+  "install_paiduan": "Install PaiDuan",
   "install": "Install",
   "dismiss": "Dismiss",
   "appearance": "Appearance",

--- a/apps/web/locales/zh/common.json
+++ b/apps/web/locales/zh/common.json
@@ -7,7 +7,7 @@
   "following": "关注",
   "tags": "标签",
   "back": "返回",
-  "install_zapstr": "安装 Zapstr",
+  "install_paiduan": "安装 PaiDuan",
   "install": "安装",
   "dismiss": "忽略",
   "appearance": "外观",


### PR DESCRIPTION
## Summary
- replace `install_zapstr` with `install_paiduan` in locale files
- update `InstallBanner` to use new translation key

## Testing
- `pnpm test`
- `pnpm lint --filter @paiduan/web` *(fails: ADMIN_PUBKEYS is not listed as a dependency in turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947eafb3108331b93400ba4eb4d37a