### PR TITLE
chore: update analytics domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ the full URL (e.g. `<origin>/v/<id>`) to the clipboard. Tags can be shared via
 
 Zapstr can report anonymous usage metrics and runtime errors.
 
-- Analytics are powered by a self-hosted [Plausible](https://plausible.io) instance at `stats.zapstr.app`.
+- Analytics are powered by a self-hosted [Plausible](https://plausible.io) instance at `stats.paiduan.app`.
   The script is only loaded when `NEXT_PUBLIC_ANALYTICS=enabled` and users have opted in.
   Events are proxied through `/api/event` to avoid third-party cookies. Custom events include `zap_click`,
   `comment_send`, `install_prompt_shown` and `install_prompt_accepted`, along with page views for feed,

--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -32,8 +32,8 @@ export default function Document({ dir }: Props) {
 if (localStorage.getItem('analytics-consent') === '1') {
   window.plausible = window.plausible || function(){(window.plausible.q = window.plausible.q || []).push(arguments)};
   var s=document.createElement('script');
-  s.src='https://stats.zapstr.app/js/script.js';
-  s.setAttribute('data-domain','zapstr.app');
+  s.src='https://stats.paiduan.app/js/script.js';
+  s.setAttribute('data-domain','paiduan.app');
   s.setAttribute('data-api','/api/event');
   s.defer=true;
   document.head.appendChild(s);

--- a/apps/web/pages/api/event.ts
+++ b/apps/web/pages/api/event.ts
@@ -6,7 +6,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
   try {
-    await fetch('https://stats.zapstr.app/api/event', {
+    await fetch('https://stats.paiduan.app/api/event', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- point analytics script at stats.paiduan.app and data-domain paiduan.app
- proxy analytics events to stats.paiduan.app/api/event
- update documentation to reference new analytics host

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689480b74e308331b42576c6c19e0635