### PR TITLE
Fix feed viewport scrolling and ffmpeg trimming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 dist
 .env
 .DS_Store
+apps/web/public/ffmpeg/

--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import Feed from '../components/Feed';
 import UploadButton from '../components/UploadButton';
 import CreatorWizard from '../components/CreatorWizard';
 import useFeed, { FeedMode } from '../hooks/useFeed';
 import useFollowing from '../hooks/useFollowing';
-import { VideoCardProps } from '../components/VideoCard';
+import { VideoCard, VideoCardProps } from '../components/VideoCard';
 import SearchBar from '../components/SearchBar';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -96,7 +95,13 @@ export default function FeedPage() {
       {tab === 'tags' && !selectedTag ? (
         renderTagList()
       ) : (
-        <Feed items={items} />
+        <div className="h-[calc(100vh-104px)] overflow-y-auto snap-y snap-mandatory">
+          {items.map((v) => (
+            <div key={v.eventId} className="snap-center flex justify-center">
+              <VideoCard {...v} />
+            </div>
+          ))}
+        </div>
       )}
       {tab === 'tags' && selectedTag && (
         <button

--- a/apps/web/utils/trimVideo.ts
+++ b/apps/web/utils/trimVideo.ts
@@ -1,14 +1,17 @@
-let ffmpeg: any;
-let fetchFile: any;
+import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
 
-export async function trimVideo(blob: Blob, start: number, end: number): Promise<Blob> {
+const ffmpeg = createFFmpeg({
+  log: false,
+  corePath: '/ffmpeg/ffmpeg-core.js',
+});
+
+export async function trimVideo(
+  blob: Blob,
+  start: number,
+  end: number,
+): Promise<Blob> {
   if (typeof window === 'undefined') {
     throw new Error('trimVideo can only run in the browser');
-  }
-  if (!ffmpeg) {
-    const ffmpegModule = await import('@ffmpeg/ffmpeg');
-    ffmpeg = ffmpegModule.createFFmpeg({ log: true });
-    fetchFile = ffmpegModule.fetchFile;
   }
   if (!ffmpeg.isLoaded()) {
     await ffmpeg.load();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "format": "prettier --write .",
     "test": "vitest run",
     "test:analytics": "vitest run scripts/aggregate-creator-stats.test.ts apps/web/pages/api/creator-stats.test.ts",
-    "cron:summary": "node scripts/cron-summary.js"
+    "cron:summary": "node scripts/cron-summary.js",
+    "postinstall": "node scripts/copy-ffmpeg-core.js"
   },
   "packageManager": "pnpm@10.5.2",
   "devDependencies": {

--- a/scripts/copy-ffmpeg-core.js
+++ b/scripts/copy-ffmpeg-core.js
@@ -1,0 +1,10 @@
+const { copyFileSync, mkdirSync } = require('fs');
+const { dirname, join } = require('path');
+
+const coreDir = dirname(require.resolve('@ffmpeg/core/dist/ffmpeg-core.js'));
+const destDir = join(__dirname, '..', 'apps', 'web', 'public', 'ffmpeg');
+
+mkdirSync(destDir, { recursive: true });
+['ffmpeg-core.js', 'ffmpeg-core.wasm', 'ffmpeg-core.worker.js'].forEach((file) => {
+  copyFileSync(join(coreDir, file), join(destDir, file));
+});


### PR DESCRIPTION
## Summary
- ensure feed page scrolls with snap-style videos
- load ffmpeg.wasm from local public assets without committing binaries

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68948fc540a48331a18dc403bc2b33ca