### PR TITLE
Handle Range key prop correctly and update ffmpeg integration

### DIFF
--- a/apps/web/components/CreatorWizard.tsx
+++ b/apps/web/components/CreatorWizard.tsx
@@ -278,34 +278,42 @@ export const CreatorWizard: React.FC<CreatorWizardProps> = ({ onClose, onPublish
         max={duration}
         step={0.1}
         onChange={(values) => setRange([values[0], values[1]])}
-        renderTrack={({ props, children }) => (
-          <div
-            {...props}
-            style={{
-              height: '4px',
-              background: getTrackBackground({
-                values: range,
-                colors: ['#ccc', '#548BF4', '#ccc'],
-                min: 0,
-                max: duration,
-              }),
-              width: '100%',
-            }}
-          >
-            {children}
-          </div>
-        )}
-        renderThumb={({ props }) => (
-          <div
-            {...props}
-            style={{
-              height: '12px',
-              width: '12px',
-              backgroundColor: '#FFF',
-              border: '1px solid #999',
-            }}
-          />
-        )}
+        renderTrack={({ props, children }) => {
+          const { key, ...trackProps } = props as { key?: string } & React.HTMLAttributes<HTMLDivElement>;
+          return (
+            <div
+              key={key}
+              {...trackProps}
+              style={{
+                height: '4px',
+                background: getTrackBackground({
+                  values: range,
+                  colors: ['#ccc', '#548BF4', '#ccc'],
+                  min: 0,
+                  max: duration,
+                }),
+                width: '100%',
+              }}
+            >
+              {children}
+            </div>
+          );
+        }}
+        renderThumb={({ props }) => {
+          const { key, ...thumbProps } = props as { key?: string } & React.HTMLAttributes<HTMLDivElement>;
+          return (
+            <div
+              key={key}
+              {...thumbProps}
+              style={{
+                height: '12px',
+                width: '12px',
+                backgroundColor: '#FFF',
+                border: '1px solid #999',
+              }}
+            />
+          );
+        }}
       />
       <div className="flex space-x-2">
         <button onClick={capturePoster} className="rounded bg-blue-500 px-4 py-2 text-white">

--- a/apps/web/utils/trimVideo.ts
+++ b/apps/web/utils/trimVideo.ts
@@ -1,22 +1,38 @@
 import type { FFmpeg } from '@ffmpeg/ffmpeg';
 
 let ffmpeg: FFmpeg | null = null;
-let fetchFile: ((input: Blob | string) => Promise<Uint8Array>) | null = null;
+
+async function ensureFFmpegLoaded() {
+  if (!ffmpeg) {
+    const { FFmpeg } = await import('@ffmpeg/ffmpeg');
+    ffmpeg = new FFmpeg();
+  }
+  if (!ffmpeg.loaded) {
+    await ffmpeg.load({
+      coreURL: '/ffmpeg/ffmpeg-core.js',
+      wasmURL: '/ffmpeg/ffmpeg-core.wasm',
+      workerURL: '/ffmpeg/ffmpeg-core.worker.js',
+    });
+  }
+}
+
+async function fetchFile(input: Blob | string): Promise<Uint8Array> {
+  if (typeof input === 'string') {
+    const response = await fetch(input);
+    return new Uint8Array(await response.arrayBuffer());
+  }
+  return new Uint8Array(await input.arrayBuffer());
+}
 
 export async function trimVideo(blob: Blob, start: number, end: number): Promise<Blob> {
   if (typeof window === 'undefined') {
     throw new Error('trimVideo can only run in the browser');
   }
-  if (!ffmpeg) {
-    const ffmpegModule = await import('@ffmpeg/ffmpeg');
-    ffmpeg = ffmpegModule.createFFmpeg({ log: false, corePath: '/ffmpeg/ffmpeg-core.js' });
-    fetchFile = ffmpegModule.fetchFile;
-  }
-  if (!ffmpeg.isLoaded()) await ffmpeg.load();
-  const data = await fetchFile!(blob);
-  ffmpeg.FS('writeFile', 'input.mp4', data);
+  await ensureFFmpegLoaded();
+  const data = await fetchFile(blob);
+  await ffmpeg!.writeFile('input.mp4', data);
   const duration = end - start;
-  await ffmpeg.run(
+  await ffmpeg!.exec([
     '-ss',
     `${start}`,
     '-i',
@@ -26,7 +42,7 @@ export async function trimVideo(blob: Blob, start: number, end: number): Promise
     '-c',
     'copy',
     'out.mp4',
-  );
-  const trimmed = ffmpeg.FS('readFile', 'out.mp4');
+  ]);
+  const trimmed = await ffmpeg!.readFile('out.mp4');
   return new Blob([trimmed], { type: 'video/mp4' });
 }


### PR DESCRIPTION
## Summary
- avoid spreading React `key` into Range track/thumb elements
- switch trimVideo to new FFmpeg API

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6894a9bd25a08331bd00cde45dd38764