### PR TITLE
feat: add encrypted nostr key management

### DIFF
--- a/apps/web/components/AuthLockControls.tsx
+++ b/apps/web/components/AuthLockControls.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { useAuth } from '../context/authContext';
+
+export function AuthLockControls() {
+  const auth = useAuth();
+  const [busy, setBusy] = useState(false);
+
+  if (!auth.auth || auth.auth.method === 'public') return null;
+
+  async function unlock() {
+    const pass = prompt('Enter passphrase');
+    if (!pass) return;
+    setBusy(true);
+    try {
+      await auth.unlock(pass);
+      alert('Unlocked');
+    } catch {
+      alert('Incorrect passphrase');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {auth.isUnlocked ? (
+        <button onClick={auth.lock} disabled={busy} className="btn-outline">
+          Lock
+        </button>
+      ) : (
+        <button onClick={unlock} disabled={busy} className="btn-outline">
+          Unlock
+        </button>
+      )}
+    </div>
+  );
+}
+

--- a/apps/web/components/settings/ChangePassphrase.tsx
+++ b/apps/web/components/settings/ChangePassphrase.tsx
@@ -1,0 +1,37 @@
+import { useAuth } from '../../context/authContext';
+import { encryptPrivkeyHex } from '../../utils/cryptoVault';
+import { saveKey } from '../../utils/keyStorage';
+
+export function ChangePassphrase() {
+  const auth = useAuth();
+  if (!auth.auth || auth.auth.method === 'nip07' || auth.auth.method === 'public')
+    return null;
+
+  async function run() {
+    if (!auth.privkeyHex) {
+      const p = prompt('Enter current passphrase');
+      if (!p) return;
+      try {
+        await auth.unlock(p);
+      } catch {
+        alert('Incorrect passphrase');
+        return;
+      }
+    }
+    if (!auth.privkeyHex) return;
+    const newPass = prompt('Enter new passphrase');
+    if (!newPass) return;
+    const encPriv = await encryptPrivkeyHex(auth.privkeyHex, newPass);
+    const updated = { ...auth.auth, encPriv } as any;
+    saveKey(updated);
+    alert('Passphrase updated');
+    auth.lock();
+  }
+
+  return (
+    <button onClick={run} className="px-3 py-2 rounded border">
+      Change passphrase
+    </button>
+  );
+}
+

--- a/apps/web/components/settings/KeysCard.tsx
+++ b/apps/web/components/settings/KeysCard.tsx
@@ -1,0 +1,85 @@
+import { useAuth } from '../../context/authContext';
+import { nip19 } from 'nostr-tools';
+import { hexToBytes } from '@noble/hashes/utils';
+
+export function KeysCard() {
+  const auth = useAuth();
+  if (!auth.auth) return null;
+
+  const pubhex = auth.pubkey ?? '';
+  const npub = pubhex ? nip19.npubEncode(pubhex) : '';
+
+  async function copy(text: string, label: string) {
+    await navigator.clipboard.writeText(text);
+    alert(`${label} copied`);
+  }
+
+  function exportVault() {
+    if (auth.auth.method === 'nip07' || auth.auth.method === 'public') {
+      alert('No private key stored');
+      return;
+    }
+    const blob = new Blob([JSON.stringify(auth.auth.encPriv, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'paiduan-nostr-vault.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function copyNsec() {
+    if (!auth.privkeyHex) {
+      const pass = prompt('Enter passphrase');
+      if (!pass) return;
+      try {
+        await auth.unlock(pass);
+      } catch {
+        alert('Incorrect passphrase');
+        return;
+      }
+    }
+    if (!auth.privkeyHex) return;
+    const nsec = nip19.nsecEncode(hexToBytes(auth.privkeyHex));
+    await copy(nsec, 'nsec');
+  }
+
+  return (
+    <div className="rounded-2xl border p-4 space-y-3">
+      <h3 className="text-lg font-semibold">Keys</h3>
+      <div>
+        <div className="text-sm text-gray-500">Public key (hex)</div>
+        <div className="break-all text-sm">{pubhex}</div>
+        <button
+          className="underline text-sm"
+          onClick={() => copy(pubhex, 'Public key (hex)')}
+        >
+          Copy hex
+        </button>
+      </div>
+      <div>
+        <div className="text-sm text-gray-500">Public key (npub)</div>
+        <div className="break-all text-sm">{npub}</div>
+        <button
+          className="underline text-sm"
+          onClick={() => copy(npub, 'npub')}
+        >
+          Copy npub
+        </button>
+      </div>
+      <div className="flex gap-3 pt-2">
+        <button className="px-3 py-2 rounded border" onClick={exportVault}>
+          Export encrypted vault
+        </button>
+        {auth.auth.method !== 'nip07' && auth.auth.method !== 'public' && (
+          <button className="px-3 py-2 rounded border" onClick={copyNsec}>
+            {auth.isUnlocked ? 'Copy nsec' : 'Unlock & copy nsec'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/context/authContext.tsx
+++ b/apps/web/context/authContext.tsx
@@ -1,25 +1,80 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { getStoredKey } from '../utils/keyStorage';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  ReactNode,
+} from 'react';
+import { getStoredKey, type AuthState } from '../utils/keyStorage';
+import { decryptPrivkeyHex } from '../utils/cryptoVault';
 
-interface AuthContextValue {
-  pubkey: string;
-  privkey?: string;
-  method: string;
-}
+type UnlockCtx = {
+  auth: AuthState | null;
+  isUnlocked: boolean;
+  pubkey: string | null;
+  privkeyHex?: string | null;
+  unlock: (pass: string) => Promise<void>;
+  lock: () => void;
+  setAuth: (a: AuthState | null) => void;
+};
 
-const AuthContext = createContext<AuthContextValue | null>(null);
+const AuthContext = createContext<UnlockCtx>({} as any);
+
+const AUTO_LOCK_MS = 10 * 60 * 1000;
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [auth, setAuth] = useState<AuthContextValue | null>(null);
+  const [auth, setAuth] = useState<AuthState | null>(null);
+  const [privkeyHex, setPrivkeyHex] = useState<string | null>(null);
+  const timer = useRef<number | null>(null);
 
   useEffect(() => {
-    const key = getStoredKey();
-    if (key) setAuth(key);
+    const a = getStoredKey();
+    setAuth(a);
   }, []);
 
-  return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>;
+  function startAutoLock() {
+    if (timer.current) window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(() => setPrivkeyHex(null), AUTO_LOCK_MS);
+  }
+
+  async function unlock(pass: string) {
+    if (!auth) throw new Error('No account');
+    if (auth.method === 'nip07' || auth.method === 'public') {
+      setPrivkeyHex(null);
+      return;
+    }
+    const hex = await decryptPrivkeyHex(auth.encPriv, pass);
+    setPrivkeyHex(hex);
+    startAutoLock();
+  }
+
+  function lock() {
+    setPrivkeyHex(null);
+    if (timer.current) window.clearTimeout(timer.current);
+  }
+
+  const value = useMemo(
+    () => ({
+      auth,
+      isUnlocked: !!privkeyHex || auth?.method === 'nip07',
+      pubkey: auth?.pubkey ?? null,
+      privkeyHex,
+      unlock,
+      lock,
+      setAuth: (a: AuthState | null) => {
+        setPrivkeyHex(null);
+        setAuth(a);
+      },
+    }),
+    [auth, privkeyHex]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {
   return useContext(AuthContext);
 }
+

--- a/apps/web/hooks/useLightning.ts
+++ b/apps/web/hooks/useLightning.ts
@@ -103,8 +103,8 @@ export default function useLightning() {
         };
         const signed = await signWithAuth(event, auth);
         pool.publish(relayList(), signed);
-      } catch (err) {
-        console.error(err);
+      } catch (err: any) {
+        alert(err.message || 'Sign-in required');
       }
     }
 

--- a/apps/web/hooks/useNostrAuth.ts
+++ b/apps/web/hooks/useNostrAuth.ts
@@ -1,33 +1,72 @@
-import { generatePrivateKey, getPublicKey } from 'nostr-tools';
+import { getPublicKey, generateSecretKey, nip19 } from 'nostr-tools';
+import { bytesToHex } from '@noble/hashes/utils';
 import { saveKey } from '../utils/keyStorage';
+import { encryptPrivkeyHex } from '../utils/cryptoVault';
+
+function privHexFrom(input: string): string {
+  const s = input.trim();
+  if (/^nsec1/i.test(s)) {
+    const { type, data } = nip19.decode(s);
+    if (type !== 'nsec') throw new Error('Invalid nsec');
+    return typeof data === 'string' ? data.toLowerCase() : bytesToHex(data);
+  }
+  if (/^[0-9a-f]{64}$/i.test(s)) return s.toLowerCase();
+  throw new Error('Unsupported private key format');
+}
+
+function pubHexFrom(input: string): string {
+  const s = input.trim();
+  if (/^npub1/i.test(s)) {
+    const { type, data } = nip19.decode(s);
+    if (type !== 'npub') throw new Error('Invalid npub');
+    return typeof data === 'string' ? data.toLowerCase() : bytesToHex(data);
+  }
+  if (/^[0-9a-f]{64}$/i.test(s)) return s.toLowerCase();
+  throw new Error('Unsupported public key format');
+}
 
 export function useNostrAuth() {
-  function signInWithExtension() {
-    if (window.nostr?.getPublicKey) {
-      window.nostr.getPublicKey().then((pubkey: string) => {
-        saveKey({ pubkey, method: 'nip07' });
-        window.location.href = '/feed';
-      });
+  async function signInWithExtension() {
+    if ((window as any).nostr?.getPublicKey) {
+      const pubkey = await (window as any).nostr.getPublicKey();
+      saveKey({ method: 'nip07', pubkey });
+      window.location.href = '/feed';
     } else {
       alert('No Nostr extension found.');
     }
   }
 
-  function importKey() {
-    const nsec = prompt('Paste your Nostr private key (nsec...)');
-    if (!nsec) return;
-    const privkey = nsec; // decoding omitted for simplicity
-    const pubkey = getPublicKey(privkey);
-    saveKey({ privkey, pubkey, method: 'manual' });
+  async function importKey() {
+    const input = prompt('Paste nsec (preferred), npub (read only), or 64-hex');
+    if (!input) return;
+    if (/^npub1/i.test(input)) {
+      const pubkey = pubHexFrom(input);
+      saveKey({ method: 'public', pubkey });
+      alert(
+        'Imported public key only. To post, unlock with an nsec or connect a NIP-07 signer.'
+      );
+      window.location.href = '/feed';
+      return;
+    }
+    const privHex = privHexFrom(input);
+    const pubkey = getPublicKey(privHex);
+    const pass = prompt('Set a passphrase to encrypt your key');
+    if (!pass) return;
+    const encPriv = await encryptPrivkeyHex(privHex, pass);
+    saveKey({ method: 'manual', pubkey, encPriv });
     window.location.href = '/feed';
   }
 
-  function generateKey() {
-    const privkey = generatePrivateKey();
-    const pubkey = getPublicKey(privkey);
-    saveKey({ privkey, pubkey, method: 'generated' });
+  async function generateKey() {
+    const pass = prompt('Set a passphrase to encrypt your new key');
+    if (!pass) return;
+    const privHex = bytesToHex(generateSecretKey());
+    const pubkey = getPublicKey(privHex);
+    const encPriv = await encryptPrivkeyHex(privHex, pass);
+    saveKey({ method: 'generated', pubkey, encPriv });
     window.location.href = '/feed';
   }
 
   return { signInWithExtension, importKey, generateKey };
 }
+

--- a/apps/web/hooks/usePublisher.ts
+++ b/apps/web/hooks/usePublisher.ts
@@ -13,8 +13,12 @@ export function usePublisher() {
       created_at: Math.floor(Date.now() / 1000),
     };
 
-    const signed = await signWithAuth(event, auth);
-    // publish signed event
+    try {
+      const signed = await signWithAuth(event, auth);
+      // publish signed event
+    } catch (e: any) {
+      alert(e.message || 'Sign-in required');
+    }
   }
 
   return { publishNote };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "next-intl": "^4.3.4",
     "next-pwa": "^5.6.0",
     "nostr-tools": "^2.6.0",
+    "@noble/hashes": "^1.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -5,6 +5,9 @@ import { useRouter } from 'next/router';
 import useAlwaysSD from '../hooks/useAlwaysSD';
 import SettingsLayout from '../components/SettingsLayout';
 import { clearKey } from '../utils/keyStorage';
+import { KeysCard } from '../components/settings/KeysCard';
+import { ChangePassphrase } from '../components/settings/ChangePassphrase';
+import { AuthLockControls } from '../components/AuthLockControls';
 
 const swatches = ['#3b82f6', '#f43f5e', '#10b981', '#f59e0b', '#6366f1', '#ec4899'];
 
@@ -43,6 +46,11 @@ export default function SettingsPage() {
   return (
     <SettingsLayout>
       <div className="space-y-6">
+        <KeysCard />
+        <div className="flex gap-3">
+          <AuthLockControls />
+          <ChangePassphrase />
+        </div>
         <div className="rounded bg-brand-panel p-4">
           <h2 className="mb-2 text-lg font-semibold">{t('appearance')}</h2>
           <button onClick={toggleMode} className="btn-outline">

--- a/apps/web/utils/cryptoVault.ts
+++ b/apps/web/utils/cryptoVault.ts
@@ -1,0 +1,64 @@
+const te = new TextEncoder();
+const td = new TextDecoder();
+const b64 = (b: ArrayBuffer) => btoa(String.fromCharCode(...new Uint8Array(b)));
+const ub64 = (s: string) =>
+  Uint8Array.from(atob(s), (c) => c.charCodeAt(0)).buffer;
+
+async function deriveKey(pass: string, salt: ArrayBuffer, iter = 250_000) {
+  const base = await crypto.subtle.importKey(
+    'raw',
+    te.encode(pass),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', hash: 'SHA-256', salt, iterations: iter },
+    base,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function encryptPrivkeyHex(privHex: string, pass: string) {
+  if (!/^[0-9a-f]{64}$/i.test(privHex))
+    throw new Error('privkey must be 64-hex');
+  const salt = crypto.getRandomValues(new Uint8Array(16)).buffer;
+  const iv = crypto.getRandomValues(new Uint8Array(12)).buffer;
+  const k = await deriveKey(pass, salt);
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    k,
+    te.encode(privHex.toLowerCase())
+  );
+  return {
+    v: 1,
+    kdf: 'pbkdf2' as const,
+    iter: 250_000,
+    salt: b64(salt),
+    iv: b64(iv),
+    ct: b64(ct),
+  };
+}
+
+export async function decryptPrivkeyHex(
+  vault: {
+    v: number;
+    kdf: 'pbkdf2';
+    iter: number;
+    salt: string;
+    iv: string;
+    ct: string;
+  },
+  pass: string
+) {
+  const k = await deriveKey(pass, ub64(vault.salt), vault.iter);
+  const pt = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: ub64(vault.iv) },
+    k,
+    ub64(vault.ct)
+  );
+  return td.decode(pt);
+}
+

--- a/apps/web/utils/keyStorage.ts
+++ b/apps/web/utils/keyStorage.ts
@@ -1,12 +1,32 @@
-export function saveKey({ pubkey, privkey, method }: { pubkey: string; privkey?: string; method: string }) {
-  localStorage.setItem('nostr-auth', JSON.stringify({ pubkey, privkey, method }));
+export type AuthState =
+  | { method: 'nip07'; pubkey: string }
+  | { method: 'public'; pubkey: string }
+  | {
+      method: 'manual' | 'generated';
+      pubkey: string;
+      encPriv: {
+        v: number;
+        kdf: 'pbkdf2';
+        iter: number;
+        salt: string;
+        iv: string;
+        ct: string;
+      };
+    };
+
+const KEY = 'nostr-auth';
+
+export function saveKey(data: AuthState) {
+  if ((data as any).privkey) throw new Error('Refusing to store plaintext privkey');
+  localStorage.setItem(KEY, JSON.stringify(data));
 }
 
-export function getStoredKey(): { pubkey: string; privkey?: string; method: string } | null {
-  const data = localStorage.getItem('nostr-auth');
-  return data ? JSON.parse(data) : null;
+export function getStoredKey(): AuthState | null {
+  const raw = localStorage.getItem(KEY);
+  return raw ? JSON.parse(raw) : null;
 }
 
 export function clearKey() {
-  localStorage.removeItem('nostr-auth');
+  localStorage.removeItem(KEY);
 }
+

--- a/apps/web/utils/signWithAuth.ts
+++ b/apps/web/utils/signWithAuth.ts
@@ -1,17 +1,17 @@
-import { signEvent as localSign, Event as NostrEvent } from 'nostr-tools';
+import { signEvent as localSign } from 'nostr-tools';
 
-interface AuthInfo {
-  pubkey: string;
-  privkey?: string;
-  method: string;
-}
-
-export async function signWithAuth(event: NostrEvent, auth: AuthInfo | null) {
-  if (auth?.method === 'nip07' && (window as any)?.nostr?.signEvent) {
+export async function signWithAuth(
+  event: any,
+  authCtx: { auth: any; privkeyHex?: string | null }
+) {
+  if (authCtx?.auth?.method === 'nip07' && (window as any)?.nostr?.signEvent) {
     return await (window as any).nostr.signEvent(event);
-  } else if (auth?.privkey) {
-    return localSign(event, auth.privkey);
-  } else {
-    throw new Error('No signing method available.');
   }
+  if (authCtx?.privkeyHex) {
+    return localSign(event, authCtx.privkeyHex);
+  }
+  throw new Error(
+    'Locked or public-only. Unlock with your passphrase or connect a NIP-07 signer.'
+  );
 }
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@ffmpeg/ffmpeg':
         specifier: ^0.12.5
         version: 0.12.15
+      '@noble/hashes':
+        specifier: ^1.3.1
+        version: 1.3.2
       '@paiduan/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -5840,12 +5843,12 @@ snapshots:
   '@scure/bip32@1.3.1':
     dependencies:
       '@noble/curves': 1.1.0
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
 
   '@scure/bip39@1.2.1':
     dependencies:
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
 
   '@sentry-internal/browser-utils@10.2.0':


### PR DESCRIPTION
## Summary
- add encrypted local storage for nostr keys with PBKDF2/AES-GCM vault
- support extension, manual, or generated login flows and unified event signing
- expose key export and passphrase controls in settings

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6895197506448331884ff1407b9486c9