### PR TITLE
feat: add remote signer and auth polish

### DIFF
--- a/apps/web/components/NostrLogin.tsx
+++ b/apps/web/components/NostrLogin.tsx
@@ -1,4 +1,5 @@
 import { useNostrAuth } from '../hooks/useNostrAuth'
+import { saveKey } from '../utils/keyStorage'
 
 export function NostrLogin() {
   const { signInWithExtension, importKey, generateKey } = useNostrAuth()
@@ -17,6 +18,19 @@ export function NostrLogin() {
         onClick={importKey}
       >
         📥 Import Nostr Key
+      </button>
+
+      <button
+        className="px-4 py-2 rounded-xl border bg-white/80 text-gray-900 dark:bg-neutral-900/80 dark:text-gray-100"
+        onClick={async () => {
+          const relay = prompt('Enter remote signer relay URL')
+          const pubkey = prompt('Enter your public key')
+          if (!relay || !pubkey) return
+          saveKey({ method: 'remote', pubkey, relay })
+          window.location.href = '/feed'
+        }}
+      >
+        🔗 Remote Sign-In (NIP-46)
       </button>
 
       <button

--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -1,0 +1,22 @@
+import { NostrLogin } from '../NostrLogin'
+
+export default function Hero() {
+  return (
+    <section className="py-16 px-4 grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
+      {/* left: text and login */}
+      <div className="text-center md:text-left">
+        <h1 className="mb-4 text-5xl font-semibold tracking-tight">
+          PaiDuan<span className="text-yellow-300">.</span>
+        </h1>
+        <p className="mb-8 text-lg opacity-80 max-w-md md:max-w-none">
+          Lightning-fast short video, powered by Nostr and Lightning.
+        </p>
+        <div className="mt-8 flex justify-center md:justify-start">
+          <NostrLogin />
+        </div>
+      </div>
+      {/* right: preview grid */}
+      <div></div>
+    </section>
+  )
+}

--- a/apps/web/context/authContext.tsx
+++ b/apps/web/context/authContext.tsx
@@ -18,6 +18,7 @@ type UnlockCtx = {
   unlock: (pass: string) => Promise<void>;
   lock: () => void;
   setAuth: (a: AuthState | null) => void;
+  bump: () => void;
 };
 
 const AuthContext = createContext<UnlockCtx>({} as any);
@@ -55,6 +56,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (timer.current) window.clearTimeout(timer.current);
   }
 
+  function bump() {
+    if (privkeyHex) startAutoLock()
+  }
+
   const value = useMemo(
     () => ({
       auth,
@@ -67,6 +72,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setPrivkeyHex(null);
         setAuth(a);
       },
+      bump,
     }),
     [auth, privkeyHex]
   );

--- a/apps/web/hooks/useNostrAuth.ts
+++ b/apps/web/hooks/useNostrAuth.ts
@@ -52,6 +52,8 @@ export function useNostrAuth() {
     const pubkey = getPublicKey(privHex);
     const pass = prompt('Set a passphrase to encrypt your key');
     if (!pass) return;
+    if (pass.length < 8) throw new Error('Passphrase must be at least 8 characters');
+    if (pass.length < 12) alert('Warning: short passphrases are easier to guess');
     const encPriv = await encryptPrivkeyHex(privHex, pass);
     saveKey({ method: 'manual', pubkey, encPriv });
     window.location.href = '/feed';
@@ -60,6 +62,8 @@ export function useNostrAuth() {
   async function generateKey() {
     const pass = prompt('Set a passphrase to encrypt your new key');
     if (!pass) return;
+    if (pass.length < 8) throw new Error('Passphrase must be at least 8 characters');
+    if (pass.length < 12) alert('Warning: short passphrases are easier to guess');
     const privHex = bytesToHex(generateSecretKey());
     const pubkey = getPublicKey(privHex);
     const encPriv = await encryptPrivkeyHex(privHex, pass);

--- a/apps/web/hooks/useRemoteSigner.ts
+++ b/apps/web/hooks/useRemoteSigner.ts
@@ -1,0 +1,32 @@
+import { relayInit } from 'nostr-tools'
+
+export async function useRemoteSigner(relayURL: string, pubkey: string) {
+  const relay = relayInit(relayURL)
+  await relay.connect()
+
+  return {
+    sign: async (event: any) => {
+      return new Promise((resolve, reject) => {
+        const id = crypto.randomUUID()
+        relay.subscribe([{ kinds: [24133], authors: [pubkey] }])
+
+        relay.publish({
+          kind: 24133,
+          pubkey,
+          tags: [['client', 'PaiDuan']],
+          content: JSON.stringify({ id, event }),
+          created_at: Math.floor(Date.now() / 1000),
+        })
+
+        const timeout = setTimeout(() => reject('Timeout'), 5000)
+        relay.on('event', (e) => {
+          const data = JSON.parse(e.content)
+          if (data.id === id) {
+            clearTimeout(timeout)
+            resolve(data.signedEvent)
+          }
+        })
+      })
+    }
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:lan": "next dev --hostname 0.0.0.0 --port 3000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,17 +1,9 @@
-import { NostrLogin } from '../components/NostrLogin'
+import Hero from '../components/landing/Hero'
 
 export default function Home() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-brand to-purple-500 text-white">
-      <h1 className="mb-4 text-5xl font-semibold tracking-tight">
-        PaiDuan<span className="text-yellow-300">.</span>
-      </h1>
-      <p className="mb-8 text-lg opacity-80 max-w-md text-center">
-        Lightning-fast short video, powered by Nostr and Lightning.
-      </p>
-      <div className="mt-8 flex justify-center">
-        <NostrLogin />
-      </div>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-500 text-white">
+      <Hero />
     </div>
-  );
+  )
 }

--- a/apps/web/utils/keyStorage.ts
+++ b/apps/web/utils/keyStorage.ts
@@ -1,6 +1,7 @@
 export type AuthState =
   | { method: 'nip07'; pubkey: string }
   | { method: 'public'; pubkey: string }
+  | { method: 'remote'; pubkey: string; relay: string }
   | {
       method: 'manual' | 'generated';
       pubkey: string;

--- a/apps/web/utils/signWithAuth.ts
+++ b/apps/web/utils/signWithAuth.ts
@@ -1,17 +1,28 @@
-import { signEvent as localSign } from 'nostr-tools';
+import { signEvent as localSign } from 'nostr-tools'
+import { useRemoteSigner } from '../hooks/useRemoteSigner'
 
 export async function signWithAuth(
   event: any,
-  authCtx: { auth: any; privkeyHex?: string | null }
+  authCtx: { auth: any; privkeyHex?: string | null; bump?: () => void }
 ) {
   if (authCtx?.auth?.method === 'nip07' && (window as any)?.nostr?.signEvent) {
-    return await (window as any).nostr.signEvent(event);
+    const signed = await (window as any).nostr.signEvent(event)
+    authCtx.bump?.()
+    return signed
+  }
+  if (authCtx?.auth?.method === 'remote') {
+    const { sign } = await useRemoteSigner(authCtx.auth.relay, authCtx.auth.pubkey)
+    const signed = await sign(event)
+    authCtx.bump?.()
+    return signed
   }
   if (authCtx?.privkeyHex) {
-    return localSign(event, authCtx.privkeyHex);
+    const signed = localSign(event, authCtx.privkeyHex)
+    authCtx.bump?.()
+    return signed
   }
   throw new Error(
-    'Locked or public-only. Unlock with your passphrase or connect a NIP-07 signer.'
-  );
+    'Can’t sign yet. Unlock with your passphrase or connect a NIP-07 signer.'
+  )
 }
 


### PR DESCRIPTION
## Summary
- add LAN dev server script
- polish landing hero and gradient
- support remote signer login and friendlier signing errors
- enforce passphrase strength and auto-lock bump

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68951d7721f883319f551d2d36600c0a