### PR TITLE
feat: secure passphrase entry with masked prompt

### DIFF
--- a/apps/web/components/AuthLockControls.tsx
+++ b/apps/web/components/AuthLockControls.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '../context/authContext';
+import { promptPassphrase } from '../utils/promptPassphrase';
 
 export function AuthLockControls() {
   const auth = useAuth();
@@ -8,7 +9,7 @@ export function AuthLockControls() {
   if (!auth.auth || auth.auth.method === 'public') return null;
 
   async function unlock() {
-    const pass = prompt('Enter passphrase');
+    const pass = await promptPassphrase('Enter passphrase');
     if (!pass) return;
     setBusy(true);
     try {

--- a/apps/web/components/settings/ChangePassphrase.tsx
+++ b/apps/web/components/settings/ChangePassphrase.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '../../context/authContext';
 import { encryptPrivkeyHex } from '../../utils/cryptoVault';
 import { saveKey } from '../../utils/keyStorage';
+import { promptPassphrase } from '../../utils/promptPassphrase';
 
 export function ChangePassphrase() {
   const auth = useAuth();
@@ -9,7 +10,7 @@ export function ChangePassphrase() {
 
   async function run() {
     if (!auth.privkeyHex) {
-      const p = prompt('Enter current passphrase');
+      const p = await promptPassphrase('Enter current passphrase');
       if (!p) return;
       try {
         await auth.unlock(p);
@@ -19,8 +20,12 @@ export function ChangePassphrase() {
       }
     }
     if (!auth.privkeyHex) return;
-    const newPass = prompt('Enter new passphrase');
+    const newPass = await promptPassphrase('Enter new passphrase');
     if (!newPass) return;
+    if (newPass.length < 8) {
+      alert('Passphrase must be at least 8 characters');
+      return;
+    }
     const encPriv = await encryptPrivkeyHex(auth.privkeyHex, newPass);
     const updated = { ...auth.auth, encPriv } as any;
     saveKey(updated);

--- a/apps/web/components/settings/KeysCard.tsx
+++ b/apps/web/components/settings/KeysCard.tsx
@@ -3,6 +3,7 @@ import { nip19 } from 'nostr-tools';
 import { hexToBytes } from '@noble/hashes/utils';
 import { encryptPrivkeyHex } from '../../utils/cryptoVault';
 import { saveKey } from '../../utils/keyStorage';
+import { promptPassphrase } from '../../utils/promptPassphrase';
 import { Card } from '../ui/Card';
 
 export function KeysCard() {
@@ -34,7 +35,7 @@ export function KeysCard() {
   }
 
   async function unlock() {
-    const pass = prompt('Enter passphrase');
+    const pass = await promptPassphrase('Enter passphrase');
     if (!pass) return;
     try {
       await auth.unlock(pass);
@@ -46,7 +47,7 @@ export function KeysCard() {
 
   async function changePassphrase() {
     if (!auth.privkeyHex) {
-      const p = prompt('Enter current passphrase');
+      const p = await promptPassphrase('Enter current passphrase');
       if (!p) return;
       try {
         await auth.unlock(p);
@@ -56,8 +57,12 @@ export function KeysCard() {
       }
     }
     if (!auth.privkeyHex) return;
-    const newPass = prompt('Enter new passphrase');
+    const newPass = await promptPassphrase('Enter new passphrase');
     if (!newPass) return;
+    if (newPass.length < 8) {
+      alert('Passphrase must be at least 8 characters');
+      return;
+    }
     const encPriv = await encryptPrivkeyHex(auth.privkeyHex, newPass);
     const updated = { ...auth.auth, encPriv } as any;
     saveKey(updated);

--- a/apps/web/utils/promptPassphrase.ts
+++ b/apps/web/utils/promptPassphrase.ts
@@ -1,0 +1,40 @@
+export async function promptPassphrase(message: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+    overlay.innerHTML = `
+      <div class="rounded bg-background p-4 text-foreground">
+        <div class="mb-2">${message}</div>
+        <input type="password" class="mb-3 w-full rounded border p-2" />
+        <div class="flex justify-end space-x-2">
+          <button class="cancel px-3 py-1">Cancel</button>
+          <button class="ok rounded bg-accent px-3 py-1 text-white">OK</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+
+    const input = overlay.querySelector('input') as HTMLInputElement;
+    const cleanup = () => document.body.removeChild(overlay);
+
+    overlay.querySelector('.ok')?.addEventListener('click', () => {
+      const val = input.value;
+      cleanup();
+      resolve(val);
+    });
+
+    overlay.querySelector('.cancel')?.addEventListener('click', () => {
+      cleanup();
+      resolve(null);
+    });
+
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        overlay.querySelector('.ok')?.dispatchEvent(new Event('click'));
+      }
+    });
+
+    input.focus();
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable password modal to hide passphrase input
- validate passphrase length and avoid runtime errors
- use secure prompt across auth components

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689530f5638883319bcc455b0dd6bf43