### PR TITLE
fix: add locale onboarding profile route

### DIFF
--- a/apps/web/pages/[locale]/onboarding/profile.tsx
+++ b/apps/web/pages/[locale]/onboarding/profile.tsx
@@ -1,0 +1,13 @@
+import { locales } from '../../../utils/locales';
+export { default } from '../../onboarding/profile';
+
+export function getStaticPaths() {
+  return {
+    paths: locales.map((locale) => ({ params: { locale } })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps() {
+  return { props: {} };
+}


### PR DESCRIPTION
## Summary
- add locale-aware onboarding profile page to resolve 404 at /en/onboarding/profile

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895484426f8833193acae1f9159f37c