### PR TITLE
Prompt unlock when saving profile

### DIFF
--- a/apps/web/context/authContext.tsx
+++ b/apps/web/context/authContext.tsx
@@ -15,7 +15,7 @@ type UnlockCtx = {
   isUnlocked: boolean;
   pubkey: string | null;
   privkeyHex?: string | null;
-  unlock: (pass: string) => Promise<void>;
+  unlock: (pass: string) => Promise<string | null>;
   lock: () => void;
   setAuth: (a: AuthState | null) => void;
   bump: () => void;
@@ -44,11 +44,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (!auth) throw new Error('No account');
     if (auth.method === 'nip07' || auth.method === 'public') {
       setPrivkeyHex(null);
-      return;
+      return null;
     }
     const hex = await decryptPrivkeyHex(auth.encPriv, pass);
     setPrivkeyHex(hex);
     startAutoLock();
+    return hex;
   }
 
   function lock() {


### PR DESCRIPTION
## Summary
- Prompt for passphrase and unlock key when saving onboarding profile
- Expose decrypted key from `unlock` to callers

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689549d15fdc83319bc85a50fc01e530