### PR TITLE
fix: update nostr signing to use finalizeEvent

### DIFF
--- a/apps/web/pages/onboarding/profile.tsx
+++ b/apps/web/pages/onboarding/profile.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useAuth } from '../../context/authContext'
 import { promptPassphrase } from '../../utils/promptPassphrase'
-import { SimplePool, EventTemplate, getEventHash, signEvent } from 'nostr-tools'
+import { SimplePool, EventTemplate, finalizeEvent } from 'nostr-tools'
+import { hexToBytes } from '@noble/hashes/utils'
 
 export default function ProfileOnboarding() {
   const { pubkey, auth, privkeyHex, unlock } = useAuth()
@@ -69,10 +70,7 @@ export default function ProfileOnboarding() {
         alert('Key is locked')
         return
       }
-      const ev: any = { ...tmpl, pubkey }
-      ev.id = getEventHash(ev)
-      ev.sig = signEvent(ev, key)
-      signed = ev
+      signed = finalizeEvent({ ...tmpl, pubkey }, hexToBytes(key))
     }
     const pool = (poolRef.current ||= new SimplePool())
     setLoading(true)

--- a/apps/web/utils/signWithAuth.ts
+++ b/apps/web/utils/signWithAuth.ts
@@ -1,4 +1,5 @@
-import { signEvent as localSign } from 'nostr-tools'
+import { finalizeEvent } from 'nostr-tools'
+import { hexToBytes } from '@noble/hashes/utils'
 import { useRemoteSigner } from '../hooks/useRemoteSigner'
 
 export async function signWithAuth(
@@ -17,7 +18,7 @@ export async function signWithAuth(
     return signed
   }
   if (authCtx?.privkeyHex) {
-    const signed = localSign(event, authCtx.privkeyHex)
+    const signed = finalizeEvent(event, hexToBytes(authCtx.privkeyHex))
     authCtx.bump?.()
     return signed
   }


### PR DESCRIPTION
## Summary
- replace deprecated `signEvent` with `finalizeEvent` and hex key conversion
- ensure local signing path returns fully signed events

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895560bcfb883319e45e030e4d3932f