### PR TITLE
feat: auto select dev port

### DIFF
--- a/apps/web/dev.js
+++ b/apps/web/dev.js
@@ -1,5 +1,6 @@
 const { spawn } = require('child_process');
 const os = require('os');
+const net = require('net');
 
 function getLocalIp() {
   const nets = os.networkInterfaces();
@@ -13,20 +14,60 @@ function getLocalIp() {
   return 'localhost';
 }
 
-const port = process.env.PORT || 3000;
-const ip = getLocalIp();
-
-const dev = spawn('next', ['dev', '--hostname', '0.0.0.0', '--port', port], {
-  stdio: ['inherit', 'pipe', 'inherit'],
-  shell: true,
-});
-
-dev.stdout.on('data', (data) => {
-  const text = data.toString();
-  process.stdout.write(text);
-  if (text.includes('started server')) {
-    console.log(`\n  ➜  Network: http://${ip}:${port}\n`);
+function parsePortArg() {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--port' || arg === '-p') {
+      return parseInt(args[i + 1], 10);
+    }
+    if (arg.startsWith('--port=')) {
+      return parseInt(arg.split('=')[1], 10);
+    }
+    if (arg.startsWith('-p')) {
+      return parseInt(arg.slice(2), 10);
+    }
   }
-});
+  return undefined;
+}
 
-dev.on('close', (code) => process.exit(code));
+function getAvailablePort(start) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', (err) => {
+      if (err.code === 'EADDRINUSE') {
+        resolve(getAvailablePort(start + 1));
+      } else {
+        reject(err);
+      }
+    });
+    server.listen(start, () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function start() {
+  const desiredPort = parsePortArg() || parseInt(process.env.PORT, 10) || 3000;
+  const port = await getAvailablePort(desiredPort);
+  const ip = getLocalIp();
+
+  const dev = spawn('next', ['dev', '--hostname', '0.0.0.0', '--port', port], {
+    stdio: ['inherit', 'pipe', 'inherit'],
+    shell: true,
+  });
+
+  dev.stdout.on('data', (data) => {
+    const text = data.toString();
+    process.stdout.write(text);
+    if (text.includes('started server')) {
+      console.log(`\n  ➜  Network: http://${ip}:${port}\n`);
+    }
+  });
+
+  dev.on('close', (code) => process.exit(code));
+}
+
+start();

--- a/packages/mod-dashboard/dev.js
+++ b/packages/mod-dashboard/dev.js
@@ -1,5 +1,6 @@
 const { spawn } = require('child_process');
 const os = require('os');
+const net = require('net');
 
 function getLocalIp() {
   const nets = os.networkInterfaces();
@@ -13,20 +14,60 @@ function getLocalIp() {
   return 'localhost';
 }
 
-const port = process.env.PORT || 3000;
-const ip = getLocalIp();
-
-const dev = spawn('next', ['dev', '--hostname', '0.0.0.0', '--port', port], {
-  stdio: ['inherit', 'pipe', 'inherit'],
-  shell: true,
-});
-
-dev.stdout.on('data', (data) => {
-  const text = data.toString();
-  process.stdout.write(text);
-  if (text.includes('started server')) {
-    console.log(`\n  ➜  Network: http://${ip}:${port}\n`);
+function parsePortArg() {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--port' || arg === '-p') {
+      return parseInt(args[i + 1], 10);
+    }
+    if (arg.startsWith('--port=')) {
+      return parseInt(arg.split('=')[1], 10);
+    }
+    if (arg.startsWith('-p')) {
+      return parseInt(arg.slice(2), 10);
+    }
   }
-});
+  return undefined;
+}
 
-dev.on('close', (code) => process.exit(code));
+function getAvailablePort(start) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', (err) => {
+      if (err.code === 'EADDRINUSE') {
+        resolve(getAvailablePort(start + 1));
+      } else {
+        reject(err);
+      }
+    });
+    server.listen(start, () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function start() {
+  const desiredPort = parsePortArg() || parseInt(process.env.PORT, 10) || 3000;
+  const port = await getAvailablePort(desiredPort);
+  const ip = getLocalIp();
+
+  const dev = spawn('next', ['dev', '--hostname', '0.0.0.0', '--port', port], {
+    stdio: ['inherit', 'pipe', 'inherit'],
+    shell: true,
+  });
+
+  dev.stdout.on('data', (data) => {
+    const text = data.toString();
+    process.stdout.write(text);
+    if (text.includes('started server')) {
+      console.log(`\n  ➜  Network: http://${ip}:${port}\n`);
+    }
+  });
+
+  dev.on('close', (code) => process.exit(code));
+}
+
+start();


### PR DESCRIPTION
## Summary
- allow web and mod-dashboard dev scripts to accept --port/PORT
- automatically choose next available port when default is taken

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68955e5a07d4833196c2048c8c7055e7