### PR TITLE
feat(web): add inline SVG branding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Treat SVG as text so they diff cleanly
+*.svg text eol=lf
+
+# Block common binaries from normal diffs/merges (we don’t add them in this PR)
+*.wasm -diff -merge binary
+*.webm -diff -merge binary
+*.mp4  -diff -merge binary
+*.png  -diff -merge binary
+*.jpg  -diff -merge binary
+*.jpeg -diff -merge binary
+*.gif  -diff -merge binary

--- a/apps/web/components/branding/HeroArt.tsx
+++ b/apps/web/components/branding/HeroArt.tsx
@@ -1,0 +1,22 @@
+export default function HeroArt({ className = '' }: { className?: string }) {
+  return (
+    <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 400" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Hero illustration">
+      <defs>
+        <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#6a11cb" />
+          <stop offset="100%" stopColor="#2575fc" />
+        </linearGradient>
+      </defs>
+      <rect width="1440" height="400" fill="currentColor" opacity="0.04" />
+      <g transform="skewX(-10) translate(-100,0)">
+        <rect x="100" y="50"  width="220" height="140" rx="8" fill="url(#heroGrad)" opacity="0.9"/>
+        <rect x="360" y="50"  width="220" height="140" rx="8" fill="currentColor" opacity="0.08"/>
+        <rect x="620" y="50"  width="220" height="140" rx="8" fill="currentColor" opacity="0.08"/>
+        <rect x="100" y="220" width="220" height="140" rx="8" fill="currentColor" opacity="0.08"/>
+        <rect x="360" y="220" width="220" height="140" rx="8" fill="url(#heroGrad)" opacity="0.9"/>
+        <rect x="620" y="220" width="220" height="140" rx="8" fill="currentColor" opacity="0.08"/>
+      </g>
+      <ellipse cx="720" cy="200" rx="600" ry="200" fill="url(#heroGrad)" opacity="0.15"/>
+    </svg>
+  );
+}

--- a/apps/web/components/branding/Logo.tsx
+++ b/apps/web/components/branding/Logo.tsx
@@ -1,0 +1,28 @@
+export default function Logo({ width = 280, height = 60 }: { width?: number; height?: number }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox="0 0 280 60" aria-label="PaiDuan logo" role="img">
+      <defs>
+        <linearGradient id="pd-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#6a11cb" />
+          <stop offset="100%" stopColor="#2575fc" />
+        </linearGradient>
+      </defs>
+
+      {/* Icon: relay nodes */}
+      <circle cx="30" cy="30" r="12" fill="url(#pd-grad)" />
+      <circle cx="15" cy="15" r="4" fill="#fff"/>
+      <circle cx="45" cy="15" r="4" fill="#fff"/>
+      <circle cx="15" cy="45" r="4" fill="#fff"/>
+      <circle cx="45" cy="45" r="4" fill="#fff"/>
+      <line x1="15" y1="15" x2="45" y2="15" stroke="#fff" strokeWidth="2"/>
+      <line x1="15" y1="45" x2="45" y2="45" stroke="#fff" strokeWidth="2"/>
+      <line x1="15" y1="15" x2="15" y2="45" stroke="#fff" strokeWidth="2"/>
+      <line x1="45" y1="15" x2="45" y2="45" stroke="#fff" strokeWidth="2"/>
+
+      {/* Wordmark */}
+      <text x="70" y="40" fontFamily="Inter, Segoe UI, Arial, sans-serif" fontSize="32" fontWeight={700} fill="url(#pd-grad)">
+        PaiDuan
+      </text>
+    </svg>
+  );
+}

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,9 +1,27 @@
-import Hero from '../components/landing/Hero'
+import Logo from '@/components/branding/Logo'
+import HeroArt from '@/components/branding/HeroArt'
+import Link from 'next/link'
 
-export default function Home() {
+export default function LandingPage() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-500 text-white">
-      <Hero />
-    </div>
+    <section className="relative overflow-hidden">
+      <div className="absolute inset-0 -z-10">
+        <HeroArt className="w-full h-[400px] text-foreground" />
+      </div>
+
+      <div className="relative max-w-5xl mx-auto px-4 py-20 text-center">
+        <div className="flex justify-center">
+          <Logo />
+        </div>
+        <h1 className="mt-6 text-5xl font-bold">Decentralised Short Video</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Built on Nostr. Own your keys, your audience, your revenue.
+        </p>
+        <div className="mt-8 flex justify-center gap-3">
+          <Link className="btn btn-primary" href="/auth">Get Started</Link>
+          <Link className="btn btn-secondary" href="/feed">Explore Feed</Link>
+        </div>
+      </div>
+    </section>
   )
 }

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -24,6 +24,8 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); }
 
 @layer utilities {
   .text-muted-foreground { color: hsl(var(--foreground) / 0.6); }
+  .text-foreground { color: hsl(var(--foreground)); }
+  .bg-app { background: hsl(var(--background)); }
   .break-inside-avoid { break-inside: avoid; }
 }
 


### PR DESCRIPTION
## Summary
- add inline SVG logo and hero art components
- show logo and hero on landing page with calls to action
- enforce text handling for svg files and block common binaries

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68956158129883318e28c66c9351f04e