### PR TITLE
chore: assign unique port for mod dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ pnpm dev
 ```
 
 The development server starts the Next.js web app at <http://localhost:3000>.
+The moderation dashboard runs on <http://localhost:3001>.
 Visit <http://localhost:3000/feed> for the swipeable video feed demo.
 
 Client-side video trimming relies on [`@ffmpeg/ffmpeg`](https://github.com/ffmpegwasm/ffmpeg.wasm) and toast notifications are provided by [`react-hot-toast`](https://react-hot-toast.com/).

--- a/packages/mod-dashboard/package.json
+++ b/packages/mod-dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "node dev.js",
+    "dev": "node dev.js -p 3001",
     "build": "next build",
     "start": "next start"
   },


### PR DESCRIPTION
## Summary
- run mod dashboard dev server on port 3001 to avoid conflicts
- document mod dashboard port in README

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895625d9bcc83319cae3045cb6557b3