### PR TITLE
feat(web): implement three-column feed layout and theme tokens

### DIFF
--- a/apps/web/components/comments/Thread.tsx
+++ b/apps/web/components/comments/Thread.tsx
@@ -1,0 +1,10 @@
+'use client';
+export default function Thread() {
+  return (
+    <div className="p-4">
+      <h3 className="font-semibold mb-3">Comments</h3>
+      {/* TODO: replace with real threaded comments bound to the selected note */}
+      <p className="text-sm text-muted-foreground">Threaded comments will appear here.</p>
+    </div>
+  );
+}

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -1,0 +1,38 @@
+'use client';
+import React from 'react';
+import Link from 'next/link';
+
+export default function RightPanel({
+  author,
+  onFilterByAuthor,
+  thread,
+}: {
+  author?: { avatar: string; name: string; username: string; pubkey: string; followers: number };
+  onFilterByAuthor: (pubkey: string) => void;
+  thread: React.ReactNode; // threaded comments component
+}) {
+  return (
+    <div className="space-y-6">
+      {author && (
+        <div className="bg-card border border-token rounded-2xl p-4">
+          <div className="flex gap-3">
+            <img src={author.avatar} className="w-12 h-12 rounded-full object-cover" alt="" />
+            <div>
+              <div className="font-semibold">{author.name}</div>
+              <div className="text-sm text-muted-foreground">@{author.username}</div>
+              <div className="text-xs text-muted-foreground mt-1">{author.followers.toLocaleString()} followers</div>
+              <div className="mt-3 flex gap-2">
+                <Link href={`/p/${author.pubkey}`} className="btn btn-secondary">View profile</Link>
+                <button className="btn btn-primary" onClick={() => onFilterByAuthor(author.pubkey)}>Filter by author</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="bg-card border border-token rounded-2xl p-0">
+        {thread}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -1,0 +1,29 @@
+'use client';
+import React from 'react';
+
+export default function AppShell({
+  left,
+  center,
+  right,
+}: { left: React.ReactNode; center: React.ReactNode; right: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-app text-foreground">
+      <div className="mx-auto w-full max-w-[1400px] grid grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)_360px] gap-0">
+        {/* Left column (sticky on desktop) */}
+        <aside className="hidden lg:block border-r border-token sticky top-0 h-screen overflow-y-auto">
+          <div className="p-4">{left}</div>
+        </aside>
+
+        {/* Center feed */}
+        <main className="min-h-screen">
+          <div className="max-w-2xl mx-auto px-4 py-6">{center}</div>
+        </main>
+
+        {/* Right column (sticky on desktop) */}
+        <aside className="hidden lg:block border-l border-token sticky top-0 h-screen overflow-y-auto">
+          <div className="p-4">{right}</div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/layout/LeftNav.tsx
+++ b/apps/web/components/layout/LeftNav.tsx
@@ -1,0 +1,49 @@
+'use client';
+import Link from 'next/link';
+
+export default function LeftNav({ me }: { me: { avatar: string; name: string; username: string; stats: { followers: number; following: number } } }) {
+  return (
+    <div className="space-y-6">
+      {/* Profile mini card */}
+      <div className="bg-card border border-token rounded-2xl p-4 flex items-center gap-3">
+        <img src={me.avatar} alt="" className="w-12 h-12 rounded-full object-cover" />
+        <div>
+          <div className="font-semibold">{me.name}</div>
+          <div className="text-sm text-muted-foreground">@{me.username}</div>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="bg-card border border-token rounded-2xl p-3">
+        <input
+          type="search"
+          placeholder="Search creators, tags…"
+          className="w-full bg-transparent outline-none text-sm"
+        />
+      </div>
+
+      {/* Nav */}
+      <nav className="bg-card border border-token rounded-2xl p-2">
+        <ul className="flex flex-col">
+          <li><Link className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block" href="/feed">Home</Link></li>
+          <li><Link className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block" href="/following">Following</Link></li>
+          <li><Link className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block" href="/create">Create</Link></li>
+          <li><Link className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block" href="/settings">Settings</Link></li>
+        </ul>
+      </nav>
+
+      {/* Stats */}
+      <div className="bg-card border border-token rounded-2xl p-4 text-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">Followers</span>
+          <span className="font-medium">{me.stats.followers.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center justify-between mt-1">
+          <span className="text-muted-foreground">Following</span>
+          <span className="font-medium">{me.stats.following.toLocaleString()}</span>
+        </div>
+        <Link href="/settings" className="mt-3 inline-block text-sm underline">Profile settings</Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/store/feedSelection.ts
+++ b/apps/web/store/feedSelection.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+type S = {
+  selectedVideoId?: string;
+  setSelectedVideoId: (id?: string) => void;
+  filterAuthor?: string;
+  setFilterAuthor: (pubkey?: string) => void;
+};
+export const useFeedSelection = create<S>((set) => ({
+  selectedVideoId: undefined,
+  setSelectedVideoId: (id) => set({ selectedVideoId: id }),
+  filterAuthor: undefined,
+  setFilterAuthor: (pubkey) => set({ filterAuthor: pubkey }),
+}));

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -48,3 +48,30 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); }
   }
 }
 
+@layer base {
+  :root {
+    --bg: 255 255 255;
+    --foreground: 17 24 39;         /* slate-900-ish */
+    --muted-foreground: 107 114 128; /* slate-500 */
+    --card: 255 255 255;
+    --border: 229 231 235;           /* gray-200 */
+  }
+  .dark {
+    --bg: 17 17 17;
+    --foreground: 243 244 246;       /* gray-100 */
+    --muted-foreground: 156 163 175; /* gray-400 */
+    --card: 24 24 27;                /* zinc-900 */
+    --border: 39 39 42;              /* zinc-800 */
+  }
+
+  html, body { background-color: rgb(var(--bg)); color: rgb(var(--foreground)); }
+}
+
+@layer utilities {
+  .text-foreground { color: rgb(var(--foreground)); }
+  .text-muted-foreground { color: rgb(var(--muted-foreground)); }
+  .bg-app { background-color: rgb(var(--bg)); }
+  .bg-card { background-color: rgb(var(--card)); }
+  .border-token { border-color: rgb(var(--border)); }
+}
+


### PR DESCRIPTION
## Summary
- add base and utility tokens for foreground/background/card colors
- introduce AppShell with sticky left/right panels and supportive components
- replace feed page with new 3-column layout and zustand feed selection store

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689565f71f5c8331a7caec5fab024ca7