### PR TITLE
Handle root onboarding redirects and placeholder feed layout

### DIFF
--- a/apps/web/components/AuthorPanel.tsx
+++ b/apps/web/components/AuthorPanel.tsx
@@ -1,0 +1,10 @@
+export default function AuthorPanel({ pubkey, onFilter }: { pubkey?: string; onFilter: () => void }) {
+  if (!pubkey) return null;
+  return (
+    <div className="rounded-xl border border-gray-200/60 dark:border-gray-700/60 p-3 space-y-2">
+      <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">Author</div>
+      <div className="text-xs text-gray-600 dark:text-gray-400 break-all">{pubkey}</div>
+      <button onClick={onFilter} className="btn btn-outline w-full">Show only this author</button>
+    </div>
+  );
+}

--- a/apps/web/components/FabUpload.tsx
+++ b/apps/web/components/FabUpload.tsx
@@ -1,0 +1,13 @@
+import { useRouter } from 'next/router';
+
+export default function FabUpload() {
+  const router = useRouter();
+  return (
+    <button
+      className="fixed bottom-20 right-4 z-40 h-14 w-14 rounded-full bg-[var(--accent)] text-white shadow-xl lg:hidden"
+      onClick={() => router.push('/en/create')}
+    >
+      +
+    </button>
+  );
+}

--- a/apps/web/components/FeedTabs.tsx
+++ b/apps/web/components/FeedTabs.tsx
@@ -1,0 +1,7 @@
+export default function FeedTabs() {
+  return (
+    <div className="mb-4 text-gray-900 dark:text-gray-100">
+      Feed tabs
+    </div>
+  );
+}

--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function MiniProfileCard() {
+  return (
+    <div className="rounded-xl border border-gray-200/60 dark:border-gray-700/60 p-3 text-center">
+      <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">@user</div>
+      <Link href="/en/settings#profile" className="text-xs text-[var(--accent)]">
+        Manage profile
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -56,7 +56,7 @@ const SearchBar: React.FC = () => {
           title={t('toggle_theme')}
           className="hover:text-accent"
         >
-          {mode === 'dark' ? <Sun /> : <Moon />}
+          {mode === 'dark' ? <Sun className="text-gray-900 dark:text-gray-100" /> : <Moon className="text-gray-900 dark:text-gray-100" />}
         </button>
         <NotificationBell />
       </div>

--- a/apps/web/components/ThreadedComments.tsx
+++ b/apps/web/components/ThreadedComments.tsx
@@ -1,0 +1,10 @@
+export default function ThreadedComments({ noteId }: { noteId?: string }) {
+  if (!noteId) return null;
+  return (
+    <div className="rounded-xl border border-gray-200/60 dark:border-gray-700/60 p-3">
+      <h3 className="text-sm font-semibold mb-2 text-gray-900 dark:text-gray-100">Comments</h3>
+      {/* TODO: subscribe to kind 1 with e=noteId; simple list for now */}
+      <p className="text-xs text-gray-600 dark:text-gray-400">Thread will render here.</p>
+    </div>
+  );
+}

--- a/apps/web/components/VideoFeed.tsx
+++ b/apps/web/components/VideoFeed.tsx
@@ -1,0 +1,7 @@
+export default function VideoFeed({ onAuthorClick }: { onAuthorClick: (pubkey: string) => void }) {
+  return (
+    <div className="text-gray-900 dark:text-gray-100">
+      Video feed placeholder
+    </div>
+  );
+}

--- a/apps/web/hooks/useVaultGate.ts
+++ b/apps/web/hooks/useVaultGate.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+
+export function useVaultGate(nextHrefWhenHasKeys = '/en/feed') {
+  useEffect(() => {
+    try {
+      const vault = localStorage.getItem('nostrVault');
+      if (vault) window.location.replace(nextHrefWhenHasKeys);
+    } catch {}
+  }, [nextHrefWhenHasKeys]);
+}

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -6,6 +6,7 @@ import { Toaster } from 'react-hot-toast';
 import { NotificationsProvider } from '../hooks/useNotifications';
 import NotificationDrawer from '../components/NotificationDrawer';
 import NavBar from '../components/NavBar';
+import FabUpload from '../components/FabUpload';
 import { ThemeProvider } from '@/context/themeContext';
 import InstallBanner from '../components/InstallBanner';
 import useOffline from '../utils/useOffline';
@@ -21,6 +22,10 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const locale = (router.query.locale as string) || 'en';
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  useEffect(() => {
+    const accent = localStorage.getItem('accent') || 'violet';
+    document.documentElement.setAttribute('data-accent', accent);
+  }, []);
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_SENTRY_DSN && consentGiven()) {
@@ -59,8 +64,9 @@ export default function MyApp({ Component, pageProps }: AppProps) {
               >
                 <Component {...pageProps} />
               </Sentry.ErrorBoundary>
+              {!pageProps?.config?.hideFab && <FabUpload />}
               <NotificationDrawer />
-              <NavBar />
+              {router.pathname.startsWith('/en/feed') || router.pathname.startsWith('/en/create') || router.pathname.startsWith('/en/settings') ? <NavBar /> : null}
               <InstallBanner />
               <Toaster />
             </NotificationsProvider>

--- a/apps/web/pages/en/create.tsx
+++ b/apps/web/pages/en/create.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'), { ssr: false });
+
+export const config = { hideFab: true };
+
+export default function CreatePage() {
+  return <CreatorWizard />;
+}

--- a/apps/web/pages/en/feed.tsx
+++ b/apps/web/pages/en/feed.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import SearchBar from '@/components/SearchBar';
+import MiniProfileCard from '@/components/MiniProfileCard';
+import FeedTabs from '@/components/FeedTabs';
+import VideoFeed from '@/components/VideoFeed';
+import AuthorPanel from '@/components/AuthorPanel';
+import ThreadedComments from '@/components/ThreadedComments';
+
+export default function FeedPage() {
+  const [author, setAuthor] = useState<string | undefined>();
+  const [currentNoteId, setCurrentNoteId] = useState<string | undefined>();
+
+  return (
+    <main className="mx-auto max-w-[1400px] px-4">
+      <div className="grid gap-6 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[280px_minmax(0,1fr)_340px]">
+        <aside className="hidden lg:block self-start sticky top-20 space-y-4">
+          <SearchBar />
+          <MiniProfileCard />
+        </aside>
+
+        <section>
+          <FeedTabs />
+          <VideoFeed onAuthorClick={(pubkey) => setAuthor(pubkey)} />
+        </section>
+
+        <aside className="hidden xl:block self-start sticky top-20 space-y-4">
+          <AuthorPanel pubkey={author} onFilter={() => {}} />
+          <ThreadedComments noteId={currentNoteId} />
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/pages/en/get-started.tsx
+++ b/apps/web/pages/en/get-started.tsx
@@ -1,0 +1,17 @@
+import { GetServerSideProps } from 'next';
+
+function hasVault(cookies: Record<string, string>) {
+  // If you store in localStorage only, we can't read it here.
+  // Fallback client-side redirect (below). Keep SSR simple:
+  return false;
+}
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (hasVault(ctx.req.cookies)) {
+    return { redirect: { destination: '/en/feed', permanent: false } };
+  }
+  // No server-stored keys → go to Settings Keys section
+  return { redirect: { destination: '/en/settings#keys', permanent: false } };
+};
+
+export default function GetStarted() { return null; }

--- a/apps/web/pages/en/index.tsx
+++ b/apps/web/pages/en/index.tsx
@@ -1,0 +1,29 @@
+import Logo from '@/components/branding/Logo'
+import HeroArt from '@/components/branding/HeroArt'
+import Link from 'next/link'
+import { useVaultGate } from '@/hooks/useVaultGate'
+
+export default function LandingPage() {
+  useVaultGate();
+  return (
+    <section className="relative overflow-hidden">
+      <div className="absolute inset-0 -z-10">
+        <HeroArt className="w-full h-[400px] text-foreground" />
+      </div>
+
+      <div className="relative max-w-5xl mx-auto px-4 py-20 text-center">
+        <div className="flex justify-center">
+          <Logo />
+        </div>
+        <h1 className="mt-6 text-5xl font-bold">Decentralised Short Video</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Built on Nostr. Own your keys, your audience, your revenue.
+        </p>
+        <div className="mt-8 flex justify-center gap-3">
+          <Link href="/en/get-started" className="rounded-xl px-4 py-2 font-medium bg-[var(--accent)] text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40">Get Started</Link>
+          <Link href="/en/feed" className="btn btn-secondary">Explore Feed</Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,27 +1,5 @@
-import Logo from '@/components/branding/Logo'
-import HeroArt from '@/components/branding/HeroArt'
-import Link from 'next/link'
-
-export default function LandingPage() {
-  return (
-    <section className="relative overflow-hidden">
-      <div className="absolute inset-0 -z-10">
-        <HeroArt className="w-full h-[400px] text-foreground" />
-      </div>
-
-      <div className="relative max-w-5xl mx-auto px-4 py-20 text-center">
-        <div className="flex justify-center">
-          <Logo />
-        </div>
-        <h1 className="mt-6 text-5xl font-bold">Decentralised Short Video</h1>
-        <p className="mt-4 text-lg text-muted-foreground">
-          Built on Nostr. Own your keys, your audience, your revenue.
-        </p>
-        <div className="mt-8 flex justify-center gap-3">
-          <Link className="btn btn-primary" href="/auth">Get Started</Link>
-          <Link className="btn btn-secondary" href="/feed">Explore Feed</Link>
-        </div>
-      </div>
-    </section>
-  )
-}
+import { GetServerSideProps } from 'next';
+export const getServerSideProps: GetServerSideProps = async () => ({
+  redirect: { destination: '/en', permanent: false },
+});
+export default function RootRedirect() { return null; }

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -75,3 +75,8 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); }
   .border-token { border-color: rgb(var(--border)); }
 }
 
+:root { --accent: #7c3aed; }
+[data-accent="violet"] { --accent:#7c3aed; }
+[data-accent="blue"]   { --accent:#2563eb; }
+[data-accent="green"]  { --accent:#16a34a; }
+[data-accent="pink"]   { --accent:#db2777; }


### PR DESCRIPTION
## Summary
- Redirect `/` to `/en` and route hero CTA through a `get-started` check
- Auto-jump to feed when keys exist and add floating upload button
- Introduce a basic three-column feed skeleton with author panel and comments
- Support accent color via `data-accent` and hide nav on non-core pages

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689568159c988331a72c21f144997f53