### PR TITLE
fix: improve muted foreground utility

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -23,7 +23,6 @@
 body { background: hsl(var(--background)); color: hsl(var(--foreground)); }
 
 @layer utilities {
-  .text-muted-foreground { color: hsl(var(--foreground) / 0.6); }
   .text-foreground { color: hsl(var(--foreground)); }
   .bg-app { background: hsl(var(--background)); }
   .break-inside-avoid { break-inside: avoid; }
@@ -69,7 +68,7 @@ body { background: hsl(var(--background)); color: hsl(var(--foreground)); }
 
 @layer utilities {
   .text-foreground { color: rgb(var(--foreground)); }
-  .text-muted-foreground { color: rgb(var(--muted-foreground)); }
+  .text-muted-foreground { @apply text-foreground opacity-60; }
   .bg-app { background-color: rgb(var(--bg)); }
   .bg-card { background-color: rgb(var(--card)); }
   .border-token { border-color: rgb(var(--border)); }


### PR DESCRIPTION
## Summary
- replace previous color utility with Tailwind composition for muted foreground text

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895755f6c9c8331a15c99fbf046c78e