### PR TITLE
feat(web): add onboarding flow

### DIFF
--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { nip19, generateSecretKey } from 'nostr-tools';
+import { bytesToHex } from '@noble/hashes/utils';
+import { useAuth } from '@/hooks/useAuth';
+
+function privHexFrom(input: string): string {
+  const s = input.trim();
+  if (/^nsec1/i.test(s)) {
+    const { type, data } = nip19.decode(s);
+    if (type !== 'nsec') throw new Error('Invalid nsec');
+    return typeof data === 'string' ? data.toLowerCase() : bytesToHex(data);
+  }
+  if (/^[0-9a-f]{64}$/i.test(s)) return s.toLowerCase();
+  throw new Error('Unsupported private key format');
+}
+
+export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
+  const { signInWithLocal, signInWithNip07, signInWithNip46 } = useAuth();
+  const [uri, setUri] = useState('');
+
+  const importKey = () => {
+    const input = prompt('Paste nsec or hex private key');
+    if (!input) return;
+    try {
+      const priv = privHexFrom(input);
+      signInWithLocal(priv);
+      onComplete();
+    } catch (e: any) {
+      alert(e.message || 'Invalid key');
+    }
+  };
+
+  const generateKey = () => {
+    const priv = bytesToHex(generateSecretKey());
+    signInWithLocal(priv);
+    onComplete();
+  };
+
+  const connectRemote = async () => {
+    try {
+      await signInWithNip46(uri);
+      onComplete();
+    } catch (e: any) {
+      alert(e.message || 'Failed to connect');
+    }
+  };
+
+  const connectExtension = () => {
+    try {
+      signInWithNip07();
+      onComplete();
+    } catch (e: any) {
+      alert(e.message || 'No NIP-07 extension found');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 w-full max-w-xs">
+      <button
+        className="btn-primary w-full"
+        onClick={connectExtension}
+        disabled={!(globalThis as any).nostr}
+      >
+        Continue with Nostr Extension
+      </button>
+
+      <div className="space-y-2 rounded-xl border p-4">
+        <label className="text-sm font-medium">Remote signer (NIP‑46)</label>
+        <input
+          value={uri}
+          onChange={(e) => setUri(e.target.value)}
+          placeholder="nostrconnect:..."
+          className="input w-full"
+        />
+        <button className="btn-secondary w-full" onClick={connectRemote}>
+          Connect remote signer
+        </button>
+      </div>
+
+      <button className="btn-secondary w-full" onClick={importKey}>
+        Import nsec / hex
+      </button>
+      <button className="btn-secondary w-full" onClick={generateKey}>
+        Generate new key
+      </button>
+    </div>
+  );
+}
+
+export default KeySetupStep;

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react';
+import { SimplePool, EventTemplate } from 'nostr-tools';
+import { useAuth } from '@/hooks/useAuth';
+
+export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
+  const { state } = useAuth();
+  const [name, setName] = useState('');
+  const [about, setAbout] = useState('');
+  const [picture, setPicture] = useState('');
+  const [loading, setLoading] = useState(false);
+  const poolRef = useRef<SimplePool>();
+
+  useEffect(() => {
+    if (state.status !== 'ready') return;
+    const pool = (poolRef.current ||= new SimplePool());
+    const relays = ['wss://relay.damus.io', 'wss://nos.lol'];
+    const sub = pool.subscribeMany(relays, [{ kinds: [0], authors: [state.pubkey], limit: 1 }], {
+      onevent(ev) {
+        try {
+          const c = JSON.parse(ev.content);
+          setName(c.name || '');
+          setAbout(c.about || '');
+          setPicture(c.picture || '');
+        } catch {}
+      }
+    });
+    return () => sub.close();
+  }, [state]);
+
+  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setPicture(reader.result as string);
+    reader.readAsDataURL(file);
+  }
+
+  async function saveProfile() {
+    if (state.status !== 'ready') return;
+    const content = JSON.stringify({ name, about, picture });
+    const tmpl: EventTemplate = {
+      kind: 0,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+      content
+    };
+    let signed;
+    try {
+      signed = await state.signer.signEvent({ ...tmpl });
+    } catch (e: any) {
+      alert(e.message || 'No signer available');
+      return;
+    }
+    const pool = (poolRef.current ||= new SimplePool());
+    setLoading(true);
+    await pool.publish(['wss://relay.damus.io', 'wss://nos.lol'], signed as any);
+    setLoading(false);
+    onComplete();
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <h1 className="text-2xl mb-4">Set up your profile</h1>
+      <div className="w-full max-w-md space-y-3">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+          className="w-full rounded border p-2 text-black"
+        />
+        <textarea
+          value={about}
+          onChange={(e) => setAbout(e.target.value)}
+          placeholder="Bio"
+          className="w-full rounded border p-2 text-black"
+        />
+        <input type="file" accept="image/*" onChange={handleFile} />
+        {picture && (
+          <img src={picture} alt="avatar" className="h-24 w-24 rounded-full object-cover" />
+        )}
+        <button
+          onClick={saveProfile}
+          disabled={loading}
+          className="px-4 py-2 rounded-xl border bg-yellow-100/70 hover:bg-yellow-100 text-gray-900 disabled:opacity-50"
+        >
+          {loading ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ProfileSetupStep;

--- a/apps/web/pages/onboarding/index.tsx
+++ b/apps/web/pages/onboarding/index.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import KeySetupStep from '@/components/onboarding/KeySetupStep';
+import ProfileSetupStep from '@/components/onboarding/ProfileSetupStep';
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [step, setStep] = useState<'key' | 'profile'>('key');
+
+  const handleProfileComplete = () => {
+    localStorage.setItem('pd.onboarded', '1');
+    router.replace('/feed');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      {step === 'key' ? (
+        <KeySetupStep onComplete={() => setStep('profile')} />
+      ) : (
+        <ProfileSetupStep onComplete={handleProfileComplete} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/pages/onboarding/profile.tsx
+++ b/apps/web/pages/onboarding/profile.tsx
@@ -1,91 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
-import { SimplePool, EventTemplate } from 'nostr-tools'
+import ProfileSetupStep from '@/components/onboarding/ProfileSetupStep';
 
 export default function ProfileOnboarding() {
-  const { state } = useAuth()
-  const [name, setName] = useState('')
-  const [about, setAbout] = useState('')
-  const [picture, setPicture] = useState('')
-  const [loading, setLoading] = useState(false)
-  const poolRef = useRef<SimplePool>()
-
-  useEffect(() => {
-    if (state.status !== 'ready') return
-    const pool = (poolRef.current ||= new SimplePool())
-    const relays = ['wss://relay.damus.io', 'wss://nos.lol']
-    const sub = pool.subscribeMany(relays, [{ kinds: [0], authors: [state.pubkey], limit: 1 }], {
-      onevent(ev) {
-        try {
-          const c = JSON.parse(ev.content)
-          setName(c.name || '')
-          setAbout(c.about || '')
-          setPicture(c.picture || '')
-        } catch {}
-      }
-    })
-    return () => sub.close()
-  }, [state])
-
-  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]
-    if (!file) return
-    const reader = new FileReader()
-    reader.onload = () => setPicture(reader.result as string)
-    reader.readAsDataURL(file)
-  }
-
-  async function saveProfile() {
-    if (state.status !== 'ready') return
-    const content = JSON.stringify({ name, about, picture })
-    const tmpl: EventTemplate = {
-      kind: 0,
-      created_at: Math.floor(Date.now() / 1000),
-      tags: [],
-      content
-    }
-    let signed
-    try {
-      signed = await state.signer.signEvent({ ...tmpl })
-    } catch (e: any) {
-      alert(e.message || 'No signer available')
-      return
-    }
-    const pool = (poolRef.current ||= new SimplePool())
-    setLoading(true)
-    await pool.publish(['wss://relay.damus.io', 'wss://nos.lol'], signed as any)
-    setLoading(false)
-    window.location.href = `/feed`
-  }
-
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4">
-      <h1 className="text-2xl mb-4">Set up your profile</h1>
-      <div className="w-full max-w-md space-y-3">
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Name"
-          className="w-full rounded border p-2 text-black"
-        />
-        <textarea
-          value={about}
-          onChange={(e) => setAbout(e.target.value)}
-          placeholder="Bio"
-          className="w-full rounded border p-2 text-black"
-        />
-        <input type="file" accept="image/*" onChange={handleFile} />
-        {picture && (
-          <img src={picture} alt="avatar" className="h-24 w-24 rounded-full object-cover" />
-        )}
-        <button
-          onClick={saveProfile}
-          disabled={loading}
-          className="px-4 py-2 rounded-xl border bg-yellow-100/70 hover:bg-yellow-100 text-gray-900 disabled:opacity-50"
-        >
-          {loading ? 'Saving…' : 'Save'}
-        </button>
-      </div>
-    </div>
-  )
+    <ProfileSetupStep
+      onComplete={() => {
+        localStorage.setItem('pd.onboarded', '1');
+        window.location.href = '/feed';
+      }}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- add KeySetupStep and ProfileSetupStep components
- orchestrate onboarding steps and redirect to feed

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6895786d9b40833191ad84bee712ebdd