### PR TITLE
Expose localStorage auth flags

### DIFF
--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -12,25 +12,40 @@ const LS_KEY = 'pd.auth.v1';
 
 export function useAuth() {
   const [state, setState] = useState<AuthState>({ status: 'signedOut' });
+  const [hasKeys, setHasKeys] = useState(false);
+  const [hasProfile, setHasProfile] = useState(false);
 
   useEffect(() => {
+    function refreshFlags() {
+      if (typeof localStorage === 'undefined') return;
+      setHasKeys(!!localStorage.getItem(LS_KEY) || !!localStorage.getItem('nostr-auth'));
+      setHasProfile(localStorage.getItem('pd.onboarded') === '1');
+    }
+
+    refreshFlags();
     const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LS_KEY) : null;
-    if (!raw) return;
-    (async () => {
-      try {
-        const saved = JSON.parse(raw);
-        let signer: Signer | undefined;
-        if (saved.method === 'local') signer = new LocalSigner(saved.data.privkeyHex);
-        if (saved.method === 'nip07') signer = new Nip07Signer();
-        if (saved.method === 'nip46') signer = new Nip46Signer(saved.data.session);
-        if (!signer) return;
-        const pubkey = await signer.getPublicKey();
-        setState({ status: 'ready', signer, pubkey, method: saved.method });
-      } catch (e) {
-        console.error(e);
-        localStorage.removeItem(LS_KEY);
-      }
-    })();
+    if (raw) {
+      (async () => {
+        try {
+          const saved = JSON.parse(raw);
+          let signer: Signer | undefined;
+          if (saved.method === 'local') signer = new LocalSigner(saved.data.privkeyHex);
+          if (saved.method === 'nip07') signer = new Nip07Signer();
+          if (saved.method === 'nip46') signer = new Nip46Signer(saved.data.session);
+          if (!signer) return;
+          const pubkey = await signer.getPublicKey();
+          setState({ status: 'ready', signer, pubkey, method: saved.method });
+        } catch (e) {
+          console.error(e);
+          localStorage.removeItem(LS_KEY);
+        }
+      })();
+    }
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', refreshFlags);
+      return () => window.removeEventListener('storage', refreshFlags);
+    }
   }, []);
 
   function signInWithLocal(privkeyHex: string) {
@@ -38,6 +53,7 @@ export function useAuth() {
     signer.getPublicKey().then((pubkey) => {
       localStorage.setItem(LS_KEY, JSON.stringify({ method: 'local', data: { privkeyHex } }));
       setState({ status: 'ready', signer, pubkey, method: 'local' });
+      setHasKeys(true);
     });
   }
 
@@ -46,6 +62,7 @@ export function useAuth() {
     signer.getPublicKey().then((pubkey) => {
       localStorage.setItem(LS_KEY, JSON.stringify({ method: 'nip07', data: {} }));
       setState({ status: 'ready', signer, pubkey, method: 'nip07' });
+      setHasKeys(true);
     });
   }
 
@@ -55,12 +72,22 @@ export function useAuth() {
     // @ts-ignore
     localStorage.setItem(LS_KEY, JSON.stringify({ method: 'nip46', data: { session: signer['session'] } }));
     setState({ status: 'ready', signer, pubkey, method: 'nip46' });
+    setHasKeys(true);
   }
 
   function signOut() {
     localStorage.removeItem(LS_KEY);
     setState({ status: 'signedOut' });
+    setHasKeys(false);
   }
 
-  return { state, signInWithLocal, signInWithNip07, signInWithNip46, signOut };
+  return {
+    state,
+    signInWithLocal,
+    signInWithNip07,
+    signInWithNip46,
+    signOut,
+    hasKeys,
+    hasProfile
+  };
 }


### PR DESCRIPTION
## Summary
- expose `hasKeys` and `hasProfile` from `useAuth`
- track localStorage for auth and onboarding flags

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68957d7fc4b08331bb9fc93c16577254