### PR TITLE
fix: prevent notification bell hydration mismatch

### DIFF
--- a/apps/web/components/NotificationBell.tsx
+++ b/apps/web/components/NotificationBell.tsx
@@ -4,14 +4,24 @@ import { useNotifications } from '../hooks/useNotifications';
 
 const NotificationBell: React.FC = () => {
   const { unreadCount, setOpen } = useNotifications();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const count = mounted ? unreadCount : 0;
+
   return (
     <button onClick={() => setOpen(true)} className="relative text-foreground hover:text-accent">
       <Bell className="h-5 w-5" />
-      {unreadCount > 0 && (
-        <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-accent text-xs text-white">
-          {unreadCount}
-        </span>
-      )}
+      <span
+        className={`absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-accent text-xs text-white  ${
+          count > 0 ? '' : 'hidden'
+        }`}
+      >
+        {count}
+      </span>
     </button>
   );
 };


### PR DESCRIPTION
## Summary
- ensure NotificationBell badge markup matches between server and client

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895847de9ec8331adaa2a668d3441b0