### PR TITLE
Initialize FFmpeg on create page

### DIFF
--- a/apps/web/pages/create.tsx
+++ b/apps/web/pages/create.tsx
@@ -1,7 +1,16 @@
 import dynamic from 'next/dynamic'
+import { useEffect } from 'react'
+import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg'
 
+const ffmpeg = createFFmpeg({ log: true })
 const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'), { ssr: false })
 
 export default function CreatePage() {
+  useEffect(() => {
+    ffmpeg.load()
+  }, [])
+
   return <CreatorWizard />
 }
+
+export { ffmpeg, fetchFile }


### PR DESCRIPTION
## Summary
- import and initialize `@ffmpeg/ffmpeg` on the create page
- load FFmpeg with logging before rendering CreatorWizard

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689587eb082c83318881f15c8b4dc786