### PR TITLE
Use client-only FFmpeg loader

### DIFF
--- a/apps/web/pages/create.tsx
+++ b/apps/web/pages/create.tsx
@@ -1,16 +1,13 @@
 import dynamic from 'next/dynamic'
 import { useEffect } from 'react'
-import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg'
-
-const ffmpeg = createFFmpeg({ log: true })
+import { loadFFmpeg } from '@/utils/ffmpeg'
 const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'), { ssr: false })
 
 export default function CreatePage() {
   useEffect(() => {
-    ffmpeg.load()
+    loadFFmpeg()
   }, [])
 
   return <CreatorWizard />
 }
 
-export { ffmpeg, fetchFile }

--- a/apps/web/utils/ffmpeg.ts
+++ b/apps/web/utils/ffmpeg.ts
@@ -1,0 +1,22 @@
+import type { FFmpeg } from '@ffmpeg/ffmpeg'
+
+let ffmpeg: FFmpeg | null = null
+let fetchFile: typeof import('@ffmpeg/ffmpeg').fetchFile | null = null
+
+export async function loadFFmpeg() {
+  if (!ffmpeg || !fetchFile) {
+    const { FFmpeg, fetchFile: ff } = await import('@ffmpeg/ffmpeg')
+    ffmpeg = new FFmpeg()
+    fetchFile = ff
+  }
+  if (!ffmpeg.loaded) {
+    await ffmpeg.load({
+      coreURL: '/ffmpeg/ffmpeg-core.js',
+      wasmURL: '/ffmpeg/ffmpeg-core.wasm',
+      workerURL: '/ffmpeg/ffmpeg-core.worker.js',
+    })
+  }
+  return ffmpeg
+}
+
+export { ffmpeg, fetchFile }

--- a/apps/web/utils/trimVideo.ts
+++ b/apps/web/utils/trimVideo.ts
@@ -1,35 +1,11 @@
-import type { FFmpeg } from '@ffmpeg/ffmpeg';
-
-let ffmpeg: FFmpeg | null = null;
-
-async function ensureFFmpegLoaded() {
-  if (!ffmpeg) {
-    const { FFmpeg } = await import('@ffmpeg/ffmpeg');
-    ffmpeg = new FFmpeg();
-  }
-  if (!ffmpeg.loaded) {
-    await ffmpeg.load({
-      coreURL: '/ffmpeg/ffmpeg-core.js',
-      wasmURL: '/ffmpeg/ffmpeg-core.wasm',
-      workerURL: '/ffmpeg/ffmpeg-core.worker.js',
-    });
-  }
-}
-
-async function fetchFile(input: Blob | string): Promise<Uint8Array> {
-  if (typeof input === 'string') {
-    const response = await fetch(input);
-    return new Uint8Array(await response.arrayBuffer());
-  }
-  return new Uint8Array(await input.arrayBuffer());
-}
+import { loadFFmpeg, ffmpeg, fetchFile } from './ffmpeg'
 
 export async function trimVideo(blob: Blob, start: number, end: number): Promise<Blob> {
   if (typeof window === 'undefined') {
     throw new Error('trimVideo can only run in the browser');
   }
-  await ensureFFmpegLoaded();
-  const data = await fetchFile(blob);
+  await loadFFmpeg();
+  const data = await fetchFile!(blob);
   await ffmpeg!.writeFile('input.mp4', data);
   const duration = end - start;
   await ffmpeg!.exec([


### PR DESCRIPTION
## Summary
- replace direct FFmpeg import in `create.tsx` with client-only loader
- add `utils/ffmpeg` helper exporting ffmpeg instance and fetchFile
- update `trimVideo` to rely on new loader

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895914e65e48331bc65ebeac903b641