### PR TITLE
feat(web): add ffmpeg client helper

### DIFF
--- a/apps/web/lib/ffmpegClient.ts
+++ b/apps/web/lib/ffmpegClient.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import type { FFmpeg } from '@ffmpeg/ffmpeg';
+
+let ffmpeg: FFmpeg | null = null;
+let loading: Promise<void> | null = null;
+
+export async function getFFmpeg(): Promise<FFmpeg> {
+  if (!ffmpeg) {
+    const { createFFmpeg } = await import('@ffmpeg/ffmpeg');
+    ffmpeg = createFFmpeg({
+      corePath:
+        'https://unpkg.com/@ffmpeg/core@0.12.6/dist/ffmpeg-core.js',
+    });
+    loading = ffmpeg.load();
+  }
+  if (loading) await loading;
+  return ffmpeg!;
+}
+
+export async function writeInputFile(
+  instance: FFmpeg,
+  file: File,
+  name: string,
+): Promise<void> {
+  const { fetchFile } = await import('@ffmpeg/ffmpeg');
+  instance.FS('writeFile', name, await fetchFile(file));
+}
+


### PR DESCRIPTION
## Summary
- add client-side ffmpeg loader with pinned core path
- expose writeInputFile helper for ffmpeg FS

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689594e7de7483319147390b272b4815