### PR TITLE
feat(web): enable loose esm externals

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -15,6 +15,7 @@ const withPWAConfig = withPWA({
 })
 
 export default withPWAConfig({
+  experimental: { esmExternals: 'loose' },
   reactStrictMode: true,
   typescript: { ignoreBuildErrors: true },
   transpilePackages: ['@paiduan/ui']


### PR DESCRIPTION
## Summary
- allow loose ESM externals in web app config

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689597308ba883318423be583445f90c