### PR TITLE
refactor: use ffmpegClient singleton for trimming video

### DIFF
--- a/apps/web/utils/trimVideo.ts
+++ b/apps/web/utils/trimVideo.ts
@@ -1,14 +1,16 @@
-import { loadFFmpeg, ffmpeg, fetchFile } from './ffmpeg'
+import { getFFmpeg } from '@/lib/ffmpegClient'
+import type { FFmpeg } from '@ffmpeg/ffmpeg'
 
 export async function trimVideo(blob: Blob, start: number, end: number): Promise<Blob> {
   if (typeof window === 'undefined') {
     throw new Error('trimVideo can only run in the browser');
   }
-  await loadFFmpeg();
-  const data = await fetchFile!(blob);
-  await ffmpeg!.writeFile('input.mp4', data);
-  const duration = end - start;
-  await ffmpeg!.exec([
+  const ffmpeg: FFmpeg = await getFFmpeg()
+  const { fetchFile } = await import('@ffmpeg/ffmpeg')
+
+  ffmpeg.FS('writeFile', 'input.mp4', await fetchFile(blob))
+  const duration = end - start
+  await ffmpeg.run(
     '-ss',
     `${start}`,
     '-i',
@@ -18,7 +20,7 @@ export async function trimVideo(blob: Blob, start: number, end: number): Promise
     '-c',
     'copy',
     'out.mp4',
-  ]);
-  const trimmed = await ffmpeg!.readFile('out.mp4');
-  return new Blob([trimmed], { type: 'video/mp4' });
+  )
+  const trimmed = ffmpeg.FS('readFile', 'out.mp4')
+  return new Blob([trimmed.buffer], { type: 'video/mp4' })
 }


### PR DESCRIPTION
## Summary
- use getFFmpeg singleton in trimVideo util
- use ffmpeg FS/run API instead of custom loader

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689598bd008c8331b981abc4d84b1a35