### PR TITLE
feat: show placeholder when feed is empty

### DIFF
--- a/apps/web/components/PlaceholderVideo.tsx
+++ b/apps/web/components/PlaceholderVideo.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function PlaceholderVideo({ className }: { className?: string }) {
+  return (
+    <div className={className}>
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-full w-full"
+      >
+        <rect x="3" y="3" width="18" height="14" rx="2" ry="2" />
+        <line x1="8" y1="21" x2="16" y2="21" />
+        <line x1="12" y1="17" x2="12" y2="21" />
+      </svg>
+    </div>
+  );
+}

--- a/apps/web/components/VideoFeed.tsx
+++ b/apps/web/components/VideoFeed.tsx
@@ -1,4 +1,12 @@
+import PlaceholderVideo from './PlaceholderVideo';
+
 export default function VideoFeed({ onAuthorClick }: { onAuthorClick: (pubkey: string) => void }) {
+  const videos: unknown[] = [];
+
+  if (videos.length === 0) {
+    return <PlaceholderVideo className="aspect-[9/16] w-full max-w-[420px] mx-auto text-foreground" />;
+  }
+
   return (
     <div className="text-gray-900 dark:text-gray-100">
       Video feed placeholder


### PR DESCRIPTION
## Summary
- add placeholder clip for empty feeds
- render placeholder video when no clips available

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689599d396348331a6a8c4c6289d2eb1