### PR TITLE
Handle missing mediaDevices in RecordStep

### DIFF
--- a/apps/web/components/create/RecordStep.tsx
+++ b/apps/web/components/create/RecordStep.tsx
@@ -12,12 +12,19 @@ export function RecordStep({ onBack }: { onBack: () => void }) {
 
   useEffect(() => {
     ;(async () => {
-      const s = await navigator.mediaDevices.getUserMedia({
-        video: { aspectRatio: 9 / 16 },
-        audio: true,
-      })
-      setStream(s)
-      if (videoRef.current) videoRef.current.srcObject = s
+      try {
+        // Guard against unsupported environments (SSR or old browsers)
+        if (!navigator?.mediaDevices?.getUserMedia) return
+
+        const s = await navigator.mediaDevices.getUserMedia({
+          video: { aspectRatio: 9 / 16 },
+          audio: true,
+        })
+        setStream(s)
+        if (videoRef.current) videoRef.current.srcObject = s
+      } catch (err) {
+        console.error('Failed to access media devices', err)
+      }
     })()
     return () => {
       stream?.getTracks().forEach((t) => t.stop())


### PR DESCRIPTION
## Summary
- Guard RecordStep against missing `navigator.mediaDevices.getUserMedia`
- Log errors instead of throwing when media access fails

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68959b0b435083318160c3961aad0db6