### PR TITLE
Use three-column grid layout for AppShell

### DIFF
--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -8,18 +8,18 @@ export default function AppShell({
 }: { left: React.ReactNode; center: React.ReactNode; right: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-app text-foreground">
-      <div className="mx-auto w-full max-w-[1400px] grid grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)_360px] gap-0">
-        {/* Left column (sticky on desktop) */}
+      <div className="mx-auto w-full max-w-[1400px] grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
+        {/* Left column: menu/search/profile summary (sticky on desktop) */}
         <aside className="hidden lg:block border-r border-token sticky top-0 h-screen overflow-y-auto">
           <div className="p-4">{left}</div>
         </aside>
 
-        {/* Center feed */}
+        {/* Middle column: main feed */}
         <main className="min-h-screen">
           <div className="max-w-2xl mx-auto px-4 py-6">{center}</div>
         </main>
 
-        {/* Right column (sticky on desktop) */}
+        {/* Right column: author info & comments (sticky on desktop) */}
         <aside className="hidden lg:block border-l border-token sticky top-0 h-screen overflow-y-auto">
           <div className="p-4">{right}</div>
         </aside>


### PR DESCRIPTION
## Summary
- use desktop grid template `grid-cols-[300px_1fr_400px]`
- clarify column purposes for menu/search/profile, main feed, and author info & comments

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68959d967e408331b0c3785cc314459a