### PR TITLE
test: ensure placeholder renders on empty VideoFeed

### DIFF
--- a/apps/web/components/VideoFeed.test.tsx
+++ b/apps/web/components/VideoFeed.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import VideoFeed from './VideoFeed';
+
+// Ensure React is available globally for components compiled with the classic JSX runtime
+(globalThis as any).React = React;
+
+describe('VideoFeed', () => {
+  it('renders placeholder when no videos', () => {
+    const html = renderToStaticMarkup(<VideoFeed onAuthorClick={() => {}} />);
+    expect(html).toContain('<svg');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test to ensure `VideoFeed` renders placeholder when no videos are available

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68959eb4c6188331a2695cc17bea1cc1