### PR TITLE
feat: client routing for landing hero

### DIFF
--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -1,7 +1,14 @@
-import { useRouter } from 'next/router'
+"use client"
+
+import { useRouter } from 'next/navigation'
 
 export default function Hero() {
   const router = useRouter()
+
+  const handleClick = () => {
+    const privKey = localStorage.privkey
+    router.push(privKey ? '/feed' : '/onboarding/key')
+  }
 
   return (
     <section className="py-16 px-4 grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
@@ -14,10 +21,7 @@ export default function Hero() {
           Lightning-fast short video, powered by Nostr and Lightning.
         </p>
         <div className="mt-8 flex justify-center md:justify-start">
-          <button
-            className="btn-primary"
-            onClick={() => router.push('/onboarding')}
-          >
+          <button className="btn-primary" onClick={handleClick}>
             Get Started
           </button>
         </div>


### PR DESCRIPTION
## Summary
- make Hero.tsx a client component
- route to /feed or /onboarding/key based on localStorage privkey

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a2849c9483319847d45423fbd1c5