### PR TITLE
feat: add profile page with key export

### DIFF
--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -10,7 +10,7 @@ export default function NavBar() {
     { href: `/${locale}/feed`, icon: <Home />, label: 'Home' },
     { href: `/${locale}/feed?tab=following`, icon: <Users />, label: 'Following' },
     { href: `/${locale}/create`, icon: <Plus />, label: 'Create' },
-    { href: `/${locale}/settings`, icon: <User />, label: 'Profile' },
+    { href: `/${locale}/profile`, icon: <User />, label: 'Profile' },
   ];
   return (
     <nav className="fixed bottom-0 inset-x-0 lg:hidden z-30 flex justify-around bg-brand-surface/95 backdrop-blur shadow-card">

--- a/apps/web/pages/[locale]/profile.tsx
+++ b/apps/web/pages/[locale]/profile.tsx
@@ -1,0 +1,14 @@
+import { locales } from '../../utils/locales';
+export { default } from '../profile';
+
+export function getStaticPaths() {
+  return {
+    paths: locales.map((locale) => ({ params: { locale } })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps() {
+  return { props: {} };
+}
+

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -78,7 +78,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
               </Sentry.ErrorBoundary>
               {!pageProps?.config?.hideFab && <FabUpload />}
               <NotificationDrawer />
-              {router.pathname.startsWith('/en/feed') || router.pathname.startsWith('/en/create') || router.pathname.startsWith('/en/settings') ? <NavBar /> : null}
+              {router.pathname.startsWith('/en/feed') || router.pathname.startsWith('/en/create') || router.pathname.startsWith('/en/profile') || router.pathname.startsWith('/en/settings') ? <NavBar /> : null}
               <InstallBanner />
               <Toaster />
             </NotificationsProvider>

--- a/apps/web/pages/profile.tsx
+++ b/apps/web/pages/profile.tsx
@@ -1,0 +1,64 @@
+import { useRouter } from 'next/router';
+import { useAuth } from '@/hooks/useAuth';
+import { useProfile } from '@/hooks/useProfile';
+import SideNav from '../components/SideNav';
+import { Card } from '../components/ui/Card';
+import { nip19 } from 'nostr-tools';
+import { hexToBytes } from '@noble/hashes/utils';
+
+export default function Profile() {
+  const { state } = useAuth();
+  const router = useRouter();
+  const meta = useProfile(state.status === 'ready' ? state.pubkey : undefined);
+
+  const exportKey = async () => {
+    if (state.status !== 'ready' || state.method !== 'local') return;
+    const priv = (state.signer as any).privkeyHex;
+    if (!priv) return;
+    const nsec = nip19.nsecEncode(hexToBytes(priv));
+    await navigator.clipboard.writeText(nsec);
+    alert('nsec copied to clipboard');
+  };
+
+  if (state.status !== 'ready') {
+    return (
+      <>
+        <SideNav />
+        <main className="max-w-3xl mx-auto px-4 py-10 space-y-6 lg:ml-48">
+          <Card title="Profile" desc="Sign in to view your profile.">
+            <div>Not signed in.</div>
+          </Card>
+        </main>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SideNav />
+      <main className="max-w-3xl mx-auto px-4 py-10 space-y-6 lg:ml-48">
+        <Card title="Profile" desc="Your public profile information.">
+          <div className="flex items-center gap-4">
+            <img
+              src={meta?.picture || '/avatar.svg'}
+              alt="avatar"
+              className="h-24 w-24 rounded-full object-cover"
+            />
+            <div className="text-lg font-semibold">{meta?.name || 'Anonymous'}</div>
+          </div>
+          <div className="flex flex-wrap gap-3 pt-2">
+            <button className="btn-secondary" onClick={() => router.push('/onboarding/profile')}>
+              Edit
+            </button>
+            {state.method === 'local' && (
+              <button className="btn-secondary" onClick={exportKey}>
+                Export key
+              </button>
+            )}
+          </div>
+        </Card>
+      </main>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a profile page showing the user's name and avatar
- allow editing profile details and exporting the nsec key
- point mobile nav link to `/profile` and show navbar on the new route

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a532e41c8331bb4e78e667154fbb