### PR TITLE
fix: route get started through onboarding

### DIFF
--- a/apps/web/pages/en/get-started.tsx
+++ b/apps/web/pages/en/get-started.tsx
@@ -10,8 +10,8 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   if (hasVault(ctx.req.cookies)) {
     return { redirect: { destination: '/en/feed', permanent: false } };
   }
-  // No server-stored keys → go to Settings Keys section
-  return { redirect: { destination: '/en/settings#keys', permanent: false } };
+  // No server-stored keys → start onboarding
+  return { redirect: { destination: '/onboarding/key', permanent: false } };
 };
 
 export default function GetStarted() { return null; }

--- a/apps/web/pages/en/index.tsx
+++ b/apps/web/pages/en/index.tsx
@@ -18,8 +18,15 @@ export default function LandingPage() {
           Built on Nostr. Own your keys, your audience, your revenue.
         </p>
         <div className="mt-8 flex justify-center gap-3">
-          <Link href="/en/get-started" className="rounded-xl px-4 py-2 font-medium bg-[var(--accent)] text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40">Get Started</Link>
-          <Link href="/en/feed" className="btn btn-secondary">Explore Feed</Link>
+          <Link
+            href="/onboarding/key"
+            className="rounded-xl px-4 py-2 font-medium bg-[var(--accent)] text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
+          >
+            Get Started
+          </Link>
+          <Link href="/en/feed" className="btn btn-secondary">
+            Explore Feed
+          </Link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- point Get Started link at onboarding
- redirect legacy /en/get-started path to onboarding

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a9d248948331a5390a84d36a515f