### PR TITLE
fix: redirect onboarding locale path

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,7 +1,7 @@
-import withPWA from 'next-pwa'
-import runtimeCaching from 'next-pwa/cache.js'
+import withPWA from 'next-pwa';
+import runtimeCaching from 'next-pwa/cache.js';
 
-const isProd = process.env.NODE_ENV === 'production'
+const isProd = process.env.NODE_ENV === 'production';
 
 const withPWAConfig = withPWA({
   dest: 'public',
@@ -10,13 +10,22 @@ const withPWAConfig = withPWA({
   buildExcludes: [/middleware-manifest\.json$/],
   fallbacks: {
     image: '/offline.jpg',
-    document: '/offline.html'
-  }
-})
+    document: '/offline.html',
+  },
+});
 
 export default withPWAConfig({
   experimental: { esmExternals: 'loose' },
   reactStrictMode: true,
   typescript: { ignoreBuildErrors: true },
-  transpilePackages: ['@paiduan/ui']
-})
+  transpilePackages: ['@paiduan/ui'],
+  async redirects() {
+    return [
+      {
+        source: '/en/onboarding/:path*',
+        destination: '/onboarding/:path*',
+        permanent: false,
+      },
+    ];
+  },
+});


### PR DESCRIPTION
## Summary
- redirect /en/onboarding/* to /onboarding/* to avoid 404s

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6895ab0047788331a4c89dee4e8fdd1c