### PR TITLE
fix: use relayInit in NIP-46 signer

### DIFF
--- a/apps/web/lib/signers/nip46.ts
+++ b/apps/web/lib/signers/nip46.ts
@@ -1,6 +1,6 @@
 import {
   SimplePool,
-  Relay,
+  relayInit,
   generateSecretKey,
   getPublicKey,
   nip04,
@@ -72,7 +72,7 @@ export class Nip46Signer implements Signer {
   private async rpc(method: string, params: any[]): Promise<any> {
     const conns = await Promise.all(
       this.session.relays.map(async (url) => {
-        const r = new Relay(url);
+        const r = relayInit(url);
         try {
           await r.connect();
         } catch {


### PR DESCRIPTION
## Summary
- replace deprecated `Relay` usage with `relayInit` in NIP-46 signer

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web dev`

------
https://chatgpt.com/codex/tasks/task_e_6895adacfc48833193957d826f2c6f11