### PR TITLE
Specify ffmpeg core paths

### DIFF
--- a/apps/web/lib/ffmpegClient.ts
+++ b/apps/web/lib/ffmpegClient.ts
@@ -2,6 +2,9 @@
 
 import type { FFmpeg } from '@ffmpeg/ffmpeg';
 
+const base =
+  'https://unpkg.com/@ffmpeg/core@0.12.6/dist/ffmpeg-core';
+
 let ffmpeg: FFmpeg | null = null;
 let loading: Promise<void> | null = null;
 
@@ -9,8 +12,9 @@ export async function getFFmpeg(): Promise<FFmpeg> {
   if (!ffmpeg) {
     const { createFFmpeg } = await import('@ffmpeg/ffmpeg');
     ffmpeg = createFFmpeg({
-      corePath:
-        'https://unpkg.com/@ffmpeg/core@0.12.6/dist/ffmpeg-core.js',
+      corePath: `${base}.js`,
+      wasmPath: `${base}.wasm`,
+      workerPath: `${base}.worker.js`,
     });
     loading = ffmpeg.load();
   }


### PR DESCRIPTION
## Summary
- set base URL for FFmpeg core assets
- explicitly load ffmpeg core, wasm, and worker from unified source

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b13b8f988331a6cf78d74c6d333a