### PR TITLE
Ensure subscribeMany includes options parameter in profile hook

### DIFF
--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -8,7 +8,11 @@ export function useProfile(pubkey?: string) {
   useEffect(() => {
     if (!pubkey) return;
     const pool = getPool();
-    const sub = pool.subscribeMany(RELAYS, [{ kinds: [kinds.Metadata], authors: [pubkey], limit: 1 } as Filter]);
+    const sub = pool.subscribeMany(
+      RELAYS,
+      [{ kinds: [kinds.Metadata], authors: [pubkey], limit: 1 } as Filter],
+      {},
+    );
     sub.on('event', (ev) => {
       try {
         setMeta(JSON.parse(ev.content));


### PR DESCRIPTION
## Summary
- add missing options object to `subscribeMany` in `useProfile` hook
- audited repository for other `subscribeMany` calls without options

## Testing
- `pnpm --filter @paiduan/web build` *(fails: Conflicting paths from getStaticPaths)*

------
https://chatgpt.com/codex/tasks/task_e_6895b2c56c94833190687c2fc979f574