### PR TITLE
Improve FFmpeg load error handling

### DIFF
--- a/apps/web/components/create/UploadStep.tsx
+++ b/apps/web/components/create/UploadStep.tsx
@@ -27,8 +27,10 @@ export function UploadStep({ onBack }: { onBack: () => void }) {
       ffRef.current = ff
       setReady(true)
     } catch (e) {
-      console.error(e)
-      Sentry.captureException(e)
+      console.error('Failed to initialize FFmpeg', e)
+      Sentry.captureException(e, {
+        tags: { component: 'UploadStep', action: 'loadFFmpeg' },
+      })
       if (signal?.cancelled) return
       const message = e instanceof Error ? e.message : String(e)
       setErr(`Failed to load video tools: ${message}`)
@@ -159,7 +161,7 @@ export function UploadStep({ onBack }: { onBack: () => void }) {
       {err && (
         <div className="space-y-2">
           <p className="text-sm text-red-500">{err}</p>
-          <button className="btn btn-secondary" onClick={loadFFmpeg}>
+          <button className="btn btn-secondary" onClick={() => loadFFmpeg()}>
             Retry
           </button>
         </div>


### PR DESCRIPTION
## Summary
- log FFmpeg initialization errors to Sentry with component-specific tags and show the error message in the UI
- ensure retry button properly reloads FFmpeg client

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b4bc20588331806260d8cc6d13ce