### PR TITLE
refactor: use nostr-tools subpath modules

### DIFF
--- a/apps/web/components/CommentBox.tsx
+++ b/apps/web/components/CommentBox.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { SimplePool, Event } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Event } from 'nostr-tools/pure';
 import { useAuth } from '@/hooks/useAuth';
 
 const relays = ['wss://relay.damus.io', 'wss://nos.lol'];

--- a/apps/web/components/CommentDrawer.tsx
+++ b/apps/web/components/CommentDrawer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { SimplePool, Event as NostrEvent } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
 import { useGesture, useSpring, animated } from '@paiduan/ui';
 import { X, MoreVertical } from 'lucide-react';
 import { toast } from 'react-hot-toast';

--- a/apps/web/components/CreatorWizard.tsx
+++ b/apps/web/components/CreatorWizard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import Image from 'next/image';
 import { Range, getTrackBackground } from 'react-range';
-import { SimplePool } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
 import { VideoCardProps } from './VideoCard';
 import { trimVideo } from '../utils/trimVideo';
 import { toast } from 'react-hot-toast';

--- a/apps/web/components/NostrLogin.tsx
+++ b/apps/web/components/NostrLogin.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { nip19, generateSecretKey } from 'nostr-tools';
+import * as nip19 from 'nostr-tools/nip19';
+import { generateSecretKey } from 'nostr-tools/pure';
 import { bytesToHex } from '@noble/hashes/utils';
 import { useAuth } from '@/hooks/useAuth';
 

--- a/apps/web/components/ReportModal.tsx
+++ b/apps/web/components/ReportModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { SimplePool } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
 import toast from 'react-hot-toast';
 import { useAuth } from '@/hooks/useAuth';
 

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -8,7 +8,7 @@ import CommentDrawer from './CommentDrawer';
 import ReportModal from './ReportModal';
 import Link from 'next/link';
 import Image from 'next/image';
-import { SimplePool } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
 import useFollowing from '../hooks/useFollowing';
 import toast from 'react-hot-toast';
 import useOffline from '../utils/useOffline';

--- a/apps/web/components/VideoInfoPane.tsx
+++ b/apps/web/components/VideoInfoPane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { SimplePool, Event } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Event } from 'nostr-tools/pure';
 import { useCurrentVideo } from '../hooks/useCurrentVideo';
 import { useFollowing } from '../hooks/useFollowing';
 import ZapButton from './ZapButton';

--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { nip19, generateSecretKey, getPublicKey } from 'nostr-tools';
+import * as nip19 from 'nostr-tools/nip19';
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { bytesToHex } from '@noble/hashes/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { encryptPrivkeyHex } from '@/utils/cryptoVault';

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import Cropper from 'react-easy-crop';
 import type { Area } from 'react-easy-crop';
-import { EventTemplate } from 'nostr-tools';
+import type { EventTemplate } from 'nostr-tools/pure';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { getPool, RELAYS } from '@/lib/nostr';

--- a/apps/web/components/settings/KeysCard.tsx
+++ b/apps/web/components/settings/KeysCard.tsx
@@ -1,4 +1,4 @@
-import { nip19 } from 'nostr-tools';
+import * as nip19 from 'nostr-tools/nip19';
 import { hexToBytes } from '@noble/hashes/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { Card } from '../ui/Card';

--- a/apps/web/hooks/pool.ts
+++ b/apps/web/hooks/pool.ts
@@ -1,4 +1,4 @@
-import { SimplePool } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
 
 // Shared SimplePool instance for the web app
 const pool = new SimplePool();

--- a/apps/web/hooks/useFeed.ts
+++ b/apps/web/hooks/useFeed.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { SimplePool, Event as NostrEvent, Filter } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+import type { Filter } from 'nostr-tools/filter';
 import { VideoCardProps } from '../components/VideoCard';
 import { ADMIN_PUBKEYS } from '../utils/admin';
 

--- a/apps/web/hooks/useLightning.test.ts
+++ b/apps/web/hooks/useLightning.test.ts
@@ -5,7 +5,7 @@ vi.mock('./useAuth', () => ({
   useAuth: () => ({ state: { status: 'ready', pubkey: 'pk', signer: { signEvent: vi.fn(async (e: any) => ({ ...e, id: 'id', sig: 'sig', pubkey: 'pk' })) } } }),
 }));
 
-vi.mock('nostr-tools', () => ({
+vi.mock('nostr-tools/pool', () => ({
   SimplePool: class {
     get() {
       return Promise.resolve({

--- a/apps/web/hooks/useLightning.ts
+++ b/apps/web/hooks/useLightning.ts
@@ -1,4 +1,5 @@
-import { SimplePool, Filter } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Filter } from 'nostr-tools/filter';
 import { useAuth } from './useAuth';
 
 interface ZapArgs {

--- a/apps/web/hooks/useNotifications.tsx
+++ b/apps/web/hooks/useNotifications.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
-import { Event as NostrEvent } from 'nostr-tools';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
 import pool from './pool';
 import { toast } from 'react-hot-toast';
 

--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { kinds, type Filter } from 'nostr-tools';
+import * as kinds from 'nostr-tools/kinds';
+import type { Filter } from 'nostr-tools/filter';
 import { getPool, RELAYS } from '@/lib/nostr';
 
 export function useProfile(pubkey?: string) {

--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { SimplePool, Event as NostrEvent, Filter } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+import type { Filter } from 'nostr-tools/filter';
 import { VideoCardProps } from '../components/VideoCard';
 
 export interface CreatorResult {

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -1,6 +1,8 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
-import { Event, kinds, type Filter, finalizeEvent } from 'nostr-tools';
+import * as kinds from 'nostr-tools/kinds';
+import { finalizeEvent, type Event } from 'nostr-tools/pure';
+import type { Filter } from 'nostr-tools/filter';
 import { getPool, RELAYS, getMyPrivkey, getMyPubkey } from '@/lib/nostr';
 
 type Note = {
@@ -42,7 +44,7 @@ export function useThread(rootEventId?: string) {
     setNotes([]);
 
     // Filters: all kind-1 notes that reference rootEventId in 'e' tag
-    const filters: Filter[] = [{ kinds: [kinds.Text], '#e': [rootEventId], limit: 200 }];
+    const filters: Filter[] = [{ kinds: [kinds.ShortTextNote], '#e': [rootEventId], limit: 200 }];
 
     const sub = pool.subscribeMany(RELAYS, filters, {
       onevent: () => {},
@@ -77,7 +79,7 @@ export function useThread(rootEventId?: string) {
     if (parentId && parentId !== rootEventId) tags.push(['e', parentId]);
 
     const draft = {
-      kind: kinds.Text,
+      kind: kinds.ShortTextNote,
       created_at: now,
       tags,
       content,

--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -1,5 +1,6 @@
 'use client';
-import { SimplePool, getPublicKey } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import { getPublicKey } from 'nostr-tools/pure';
 
 let _pool: SimplePool | null = null;
 

--- a/apps/web/lib/signers/local.ts
+++ b/apps/web/lib/signers/local.ts
@@ -1,5 +1,6 @@
 import { bytesToHex } from '@noble/hashes/utils';
-import { finalizeEvent, generateSecretKey, getPublicKey, nip19 } from 'nostr-tools';
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import * as nip19 from 'nostr-tools/nip19';
 import type { Signer } from './types';
 
 const LS_KEY = 'pd.auth.v1';

--- a/apps/web/lib/signers/nip46.ts
+++ b/apps/web/lib/signers/nip46.ts
@@ -1,10 +1,6 @@
-import {
-  SimplePool,
-  generateSecretKey,
-  getPublicKey,
-  nip04,
-  type EventTemplate,
-} from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import { generateSecretKey, getPublicKey, type EventTemplate } from 'nostr-tools/pure';
+import * as nip04 from 'nostr-tools/nip04';
 import { Relay } from 'nostr-tools/relay';
 import type { Signer } from './types';
 

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -1,7 +1,9 @@
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
-import { SimplePool, Event as NostrEvent, Filter } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+import type { Filter } from 'nostr-tools/filter';
 import { toast } from 'react-hot-toast';
 import VideoCard, { VideoCardProps } from '../../../components/VideoCard';
 import useFollowing, { getFollowers } from '../../../hooks/useFollowing';

--- a/apps/web/pages/profile.tsx
+++ b/apps/web/pages/profile.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import SideNav from '../components/SideNav';
 import { Card } from '../components/ui/Card';
-import { nip19 } from 'nostr-tools';
+import * as nip19 from 'nostr-tools/nip19';
 import { hexToBytes } from '@noble/hashes/utils';
 
 export default function Profile() {

--- a/apps/web/pages/treasury.tsx
+++ b/apps/web/pages/treasury.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { SimplePool, Event as NostrEvent, Filter } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+import type { Filter } from 'nostr-tools/filter';
 
 function relayList(): string[] {
   if (typeof window === 'undefined') return ['wss://relay.damus.io', 'wss://nos.lol'];

--- a/apps/web/pages/v/[eventId].tsx
+++ b/apps/web/pages/v/[eventId].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { SimplePool, Event as NostrEvent } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
 import VideoCard, { VideoCardProps } from '../../components/VideoCard';
 
 function relayList(): string[] {

--- a/packages/mod-dashboard/pages/index.tsx
+++ b/packages/mod-dashboard/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
-import { SimplePool } from 'nostr-tools';
+import { SimplePool } from 'nostr-tools/pool';
 
 const ADMIN_PUBKEYS = (process.env.ADMIN_PUBKEYS || '').split(',').filter(Boolean);
 


### PR DESCRIPTION
## Summary
- replace root-level `nostr-tools` imports with subpath modules (`kinds`, `pure`, `pool`, `nip04`, `nip19`)
- update signer utilities and hooks to use new `nostr-tools` APIs
- adjust tests to mock new subpath modules

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web build` *(fails: Conflicting paths returned from getStaticPaths)*

------
https://chatgpt.com/codex/tasks/task_e_6895b10f4de483319d59571b0c17680e