### PR TITLE
refactor: update Nostr kinds import for useThread

### DIFF
--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -1,8 +1,7 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
-import * as kinds from 'nostr-tools/kinds';
-import { finalizeEvent, type Event } from 'nostr-tools/pure';
-import type { Filter } from 'nostr-tools/filter';
+import { Event, type Filter, finalizeEvent } from 'nostr-tools';
+import * as nostrKinds from 'nostr-tools/kinds';
 import { getPool, RELAYS, getMyPrivkey, getMyPubkey } from '@/lib/nostr';
 
 type Note = {
@@ -44,7 +43,7 @@ export function useThread(rootEventId?: string) {
     setNotes([]);
 
     // Filters: all kind-1 notes that reference rootEventId in 'e' tag
-    const filters: Filter[] = [{ kinds: [kinds.ShortTextNote], '#e': [rootEventId], limit: 200 }];
+    const filters: Filter[] = [{ kinds: [nostrKinds.ShortTextNote], '#e': [rootEventId], limit: 200 }];
 
     const sub = pool.subscribeMany(RELAYS, filters, {
       onevent: () => {},
@@ -79,7 +78,7 @@ export function useThread(rootEventId?: string) {
     if (parentId && parentId !== rootEventId) tags.push(['e', parentId]);
 
     const draft = {
-      kind: kinds.ShortTextNote,
+      kind: nostrKinds.ShortTextNote,
       created_at: now,
       tags,
       content,


### PR DESCRIPTION
## Summary
- import types and finalizeEvent from `nostr-tools` and use `nostr-tools/kinds` as `nostrKinds`
- replace `kinds.ShortTextNote` usage with `nostrKinds.ShortTextNote`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b8e9393c83319a3571eea6881f8c