### PR TITLE
Fix onboarding theming and button styles

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,9 +1,12 @@
 import '../styles/globals.css';
+import Providers from './providers';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { ThemeProvider } from '@/context/themeContext';
+import { GestureProvider } from '@paiduan/ui';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider>
+      <GestureProvider>{children}</GestureProvider>
+    </ThemeProvider>
+  );
+}

--- a/apps/web/components/NostrLogin.tsx
+++ b/apps/web/components/NostrLogin.tsx
@@ -58,7 +58,7 @@ export function NostrLogin() {
   return (
     <div className="flex flex-col gap-3 w-full max-w-xs">
       <button
-        className="btn-primary w-full"
+        className="btn btn-primary w-full"
         onClick={connectExtension}
         disabled={!(globalThis as any).nostr}
       >
@@ -73,15 +73,15 @@ export function NostrLogin() {
           placeholder="nostrconnect:..."
           className="input w-full"
         />
-        <button className="btn-secondary w-full" onClick={connectRemote}>
+        <button className="btn btn-secondary w-full" onClick={connectRemote}>
           Connect remote signer
         </button>
       </div>
 
-      <button className="btn-secondary w-full" onClick={importKey}>
+      <button className="btn btn-secondary w-full" onClick={importKey}>
         Import nsec / hex
       </button>
-      <button className="btn-secondary w-full" onClick={generateKey}>
+      <button className="btn btn-secondary w-full" onClick={generateKey}>
         Generate new key
       </button>
     </div>

--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -84,7 +84,7 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
   return (
     <div className="flex flex-col gap-3 w-full max-w-xs">
       <button
-        className="btn-primary w-full"
+        className="btn btn-primary w-full"
         onClick={connectExtension}
         disabled={!(globalThis as any).nostr}
       >
@@ -99,15 +99,15 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
           placeholder="nostrconnect:..."
           className="input w-full"
         />
-        <button className="btn-secondary w-full" onClick={connectRemote}>
+        <button className="btn btn-secondary w-full" onClick={connectRemote}>
           Connect remote signer
         </button>
       </div>
 
-      <button className="btn-secondary w-full" onClick={importKey}>
+      <button className="btn btn-secondary w-full" onClick={importKey}>
         Import nsec / hex
       </button>
-      <button className="btn-secondary w-full" onClick={generateKey}>
+      <button className="btn btn-secondary w-full" onClick={generateKey}>
         Generate new key
       </button>
     </div>

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -108,13 +108,13 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Name"
-          className="w-full rounded border p-2 text-black"
+          className="w-full rounded border-token border p-2 bg-card text-foreground"
         />
         <textarea
           value={about}
           onChange={(e) => setAbout(e.target.value)}
           placeholder="Bio"
-          className="w-full rounded border p-2 text-black"
+          className="w-full rounded border-token border p-2 bg-card text-foreground"
         />
         <input type="file" accept="image/*" onChange={handleFile} />
         {rawImage && (
@@ -142,7 +142,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
               value={zoom}
               onChange={(e) => setZoom(parseFloat(e.target.value))}
             />
-            <button className="btn-secondary" onClick={finishCrop}>
+            <button className="btn btn-secondary" onClick={finishCrop}>
               Done
             </button>
           </div>
@@ -153,7 +153,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
         <button
           onClick={saveProfile}
           disabled={loading}
-          className="px-4 py-2 rounded-xl border bg-yellow-100/70 hover:bg-yellow-100 text-gray-900 disabled:opacity-50"
+          className="btn btn-primary disabled:opacity-50"
         >
           {loading ? 'Saving…' : 'Save'}
         </button>


### PR DESCRIPTION
## Summary
- Wrap app router layout with theme providers so onboarding pages receive theme context
- Use shared `btn` styles in onboarding and login buttons for consistent styling
- Make profile onboarding inputs theme-aware and simplify save/done buttons

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b81dca18833187baed6e1116d167