### PR TITLE
refactor: use onevent callback in useProfile

### DIFF
--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -12,13 +12,14 @@ export function useProfile(pubkey?: string) {
     const sub = pool.subscribeMany(
       RELAYS,
       [{ kinds: [kinds.Metadata], authors: [pubkey], limit: 1 } as Filter],
-      {},
+      {
+        onevent: (ev) => {
+          try {
+            setMeta(JSON.parse(ev.content));
+          } catch {}
+        },
+      },
     );
-    sub.on('event', (ev) => {
-      try {
-        setMeta(JSON.parse(ev.content));
-      } catch {}
-    });
     return () => sub.close();
   }, [pubkey]);
   return meta as { name?: string; picture?: string; about?: string } | null;


### PR DESCRIPTION
## Summary
- refactor profile hook to use `onevent` callback in `pool.subscribeMany`

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6895ba0daaa48331a3d592c53cf9de2f