### PR TITLE
test: add e2e coverage for api endpoints

### DIFF
--- a/apps/web/pages/api/event.test.ts
+++ b/apps/web/pages/api/event.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler from './event';
+import { createRes } from './test-utils';
+
+function createReq(body: any = {}, headers: any = {}) {
+  return { method: 'POST', body, headers } as any;
+}
+
+describe('event API', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_ANALYTICS;
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_ANALYTICS = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('returns 204 when analytics disabled', async () => {
+    delete process.env.NEXT_PUBLIC_ANALYTICS;
+    const req = createReq();
+    const res = createRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(204);
+    expect(res.endCalled).toBe(true);
+  });
+
+  it('still ends when fetch fails', async () => {
+    process.env.NEXT_PUBLIC_ANALYTICS = 'enabled';
+    const fetchMock = vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network'));
+    const req = createReq({ event: 'test' }, { 'user-agent': 'ua', 'x-forwarded-for': 'ip' });
+    const res = createRes();
+    await handler(req, res);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(204);
+  });
+});

--- a/apps/web/pages/api/modqueue.test.ts
+++ b/apps/web/pages/api/modqueue.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createRes } from './test-utils';
+
+function createReq(method: string, body: any = {}) {
+  return { method, body } as any;
+}
+
+describe('modqueue API', () => {
+  let tempDir: string;
+  let cwdSpy: any;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'modqueue-'));
+    const dataDir = path.join(tempDir, 'apps', 'web', 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, 'modqueue.json'), '[]');
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('adds and removes reports', async () => {
+    const { default: handler } = await import('./modqueue');
+    const report = { targetId: '1', targetKind: 'video', reason: 'spam', reporterPubKey: 'a', ts: 1 };
+    let res = createRes();
+    await handler(createReq('POST', report), res);
+    expect(res.statusCode).toBe(200);
+
+    let data = JSON.parse(fs.readFileSync(path.join(tempDir, 'apps/web/data/modqueue.json'), 'utf8'));
+    expect(data.length).toBe(1);
+
+    res = createRes();
+    await handler(createReq('DELETE', { targetId: '1' }), res);
+    expect(res.statusCode).toBe(200);
+    data = JSON.parse(fs.readFileSync(path.join(tempDir, 'apps/web/data/modqueue.json'), 'utf8'));
+    expect(data.length).toBe(0);
+  });
+});

--- a/apps/web/pages/api/test-utils.ts
+++ b/apps/web/pages/api/test-utils.ts
@@ -1,0 +1,20 @@
+export function createRes() {
+  const res: any = {};
+  res.statusCode = 200;
+  res.headers = {};
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.jsonData = null;
+  res.json = (data: any) => {
+    res.jsonData = data;
+    return res;
+  };
+  res.endCalled = false;
+  res.end = () => {
+    res.endCalled = true;
+    return res;
+  };
+  return res;
+}

--- a/apps/web/pages/api/transcode.test.ts
+++ b/apps/web/pages/api/transcode.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import handler from './transcode';
+import { createRes } from './test-utils';
+
+function createReq(body: any = {}, method = 'POST') {
+  return { method, body } as any;
+}
+
+describe('transcode API', () => {
+  it('fails when src missing', async () => {
+    const req = createReq({});
+    const res = createRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonData).toEqual({ error: 'missing src' });
+  });
+
+  it('returns manifest url', async () => {
+    const req = createReq({ src: 'https://example.com/video.mp4' });
+    const res = createRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonData.manifest).toMatch(/manifest.json$/);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper for API response mocking in tests
- add event API tests including error-handling scenario
- add modqueue API tests for report add/remove
- add transcode API tests for success and failure paths

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895bb1144b8833195f006c8a3b9ba5d