### PR TITLE
Wrap passphrase prompt in form

### DIFF
--- a/apps/web/utils/promptPassphrase.ts
+++ b/apps/web/utils/promptPassphrase.ts
@@ -5,34 +5,36 @@ export async function promptPassphrase(message: string): Promise<string | null> 
     overlay.innerHTML = `
       <div class="rounded bg-background p-4 text-foreground">
         <div class="mb-2">${message}</div>
-        <input type="password" class="mb-3 w-full rounded border p-2" />
-        <div class="flex justify-end space-x-2">
-          <button class="cancel px-3 py-1">Cancel</button>
-          <button class="ok rounded bg-accent px-3 py-1 text-white">OK</button>
-        </div>
+        <form>
+          <input type="password" class="mb-3 w-full rounded border p-2" />
+          <div class="flex justify-end space-x-2">
+            <button type="button" class="cancel px-3 py-1">Cancel</button>
+            <button type="submit" class="ok rounded bg-accent px-3 py-1 text-white">OK</button>
+          </div>
+        </form>
       </div>
     `;
     document.body.appendChild(overlay);
 
     const input = overlay.querySelector('input') as HTMLInputElement;
+    const form = overlay.querySelector('form') as HTMLFormElement;
     const cleanup = () => document.body.removeChild(overlay);
 
-    overlay.querySelector('.ok')?.addEventListener('click', () => {
+    const okHandler = () => {
       const val = input.value;
       cleanup();
       resolve(val);
+    };
+    overlay.querySelector('.ok')?.addEventListener('click', okHandler);
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      okHandler();
     });
 
     overlay.querySelector('.cancel')?.addEventListener('click', () => {
       cleanup();
       resolve(null);
-    });
-
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        overlay.querySelector('.ok')?.dispatchEvent(new Event('click'));
-      }
     });
 
     input.focus();


### PR DESCRIPTION
## Summary
- wrap passphrase prompt fields and buttons in a form
- submit form to trigger OK action and prevent default behavior

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895bed4756c8331a0b4db40ea7157a9