### PR TITLE
refactor: unify nostr kind imports

### DIFF
--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import * as kinds from 'nostr-tools/kinds';
+import * as nostrKinds from 'nostr-tools/kinds';
 import type { Filter } from 'nostr-tools/filter';
 import { getPool, RELAYS } from '@/lib/nostr';
 
@@ -11,7 +11,7 @@ export function useProfile(pubkey?: string) {
     const pool = getPool();
     const sub = pool.subscribeMany(
       RELAYS,
-      [{ kinds: [kinds.Metadata], authors: [pubkey], limit: 1 } as Filter],
+      [{ kinds: [nostrKinds.Metadata], authors: [pubkey], limit: 1 } as Filter],
       {
         onevent: (ev) => {
           try {


### PR DESCRIPTION
## Summary
- use consistent `nostrKinds` alias for nostr kind constants in profile hook

## Testing
- `pnpm test`
- `npx eslint hooks/useProfile.ts --format json` (in apps/web)
- `node -e "import('nostr-tools/kinds').then(m=>console.log('Metadata:', m.Metadata))"`


------
https://chatgpt.com/codex/tasks/task_e_6895c0dbe04c8331b5375c520543b7be