### PR TITLE
feat: add sidebar navigation and responsive search bar

### DIFF
--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -39,7 +39,7 @@ const SearchBar: React.FC = () => {
 
   return (
     <>
-      <div className="fixed top-0 left-0 right-0 z-20 flex h-12 items-center space-x-2 bg-background/80 p-2 text-foreground">
+      <div className="fixed top-0 left-0 right-0 z-20 flex h-12 w-full items-center space-x-2 bg-background/80 p-2 text-foreground lg:relative lg:left-auto lg:right-auto lg:top-auto lg:w-full">
         <input
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -61,7 +61,7 @@ const SearchBar: React.FC = () => {
         <NotificationBell />
       </div>
       <div
-        className={`fixed inset-x-0 bottom-0 z-20 max-h-1/2 overflow-y-auto bg-background text-foreground transition-transform duration-300 ${
+        className={`fixed inset-x-0 bottom-0 z-20 max-h-1/2 overflow-y-auto bg-background text-foreground transition-transform duration-300 lg:hidden ${
           showDrawer ? 'translate-y-0' : 'translate-y-full'
         }`}
       >

--- a/apps/web/pages/en/feed.tsx
+++ b/apps/web/pages/en/feed.tsx
@@ -1,4 +1,7 @@
 import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Home, Users, Plus, Cog } from 'lucide-react';
 import SearchBar from '@/components/SearchBar';
 import MiniProfileCard from '@/components/MiniProfileCard';
 import FeedTabs from '@/components/FeedTabs';
@@ -9,6 +12,14 @@ import ThreadedComments from '@/components/ThreadedComments';
 export default function FeedPage() {
   const [author, setAuthor] = useState<string | undefined>();
   const [currentNoteId, setCurrentNoteId] = useState<string | undefined>();
+  const { asPath, query } = useRouter();
+  const locale = (query.locale as string) || 'en';
+  const links = [
+    { href: `/${locale}/feed`, icon: Home, label: 'Home' },
+    { href: `/${locale}/feed?tab=following`, icon: Users, label: 'Following' },
+    { href: `/${locale}/create`, icon: Plus, label: 'Create' },
+    { href: `/${locale}/settings`, icon: Cog, label: 'Settings' },
+  ];
 
   return (
     <main className="mx-auto max-w-[1400px] px-4">
@@ -16,6 +27,25 @@ export default function FeedPage() {
         <aside className="hidden lg:block self-start sticky top-20 space-y-4">
           <SearchBar />
           <MiniProfileCard />
+          <nav>
+            <ul className="space-y-2">
+              {links.map(({ href, icon: Icon, label }) => {
+                const isActive = asPath.startsWith(href);
+                return (
+                  <li key={href}>
+                    <Link
+                      href={href}
+                      className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm ${
+                        isActive ? 'bg-white/10 text-white' : 'text-muted-foreground hover:bg-white/5'
+                      }`}
+                    >
+                      <Icon size={20} /> {label}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
         </aside>
 
         <section>


### PR DESCRIPTION
## Summary
- show navigation links below the mini profile on the feed page
- make search bar fixed only on small screens and hide drawer on desktop

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6895cf1451d08331aafe210b78770ed8