### PR TITLE
refactor: use shared button in onboarding

### DIFF
--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { encryptPrivkeyHex } from '@/utils/cryptoVault';
 import { saveKey } from '@/utils/keyStorage';
 import { promptPassphrase } from '@/utils/promptPassphrase';
+import { Button } from '@paiduan/ui';
 
 function privHexFrom(input: string): string {
   const s = input.trim();
@@ -83,13 +84,13 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
 
   return (
     <div className="flex flex-col gap-3 w-full max-w-xs">
-      <button
-        className="btn btn-primary w-full"
+      <Button
+        className="btn-primary w-full"
         onClick={connectExtension}
         disabled={!(globalThis as any).nostr}
       >
         Continue with Nostr Extension
-      </button>
+      </Button>
 
       <div className="space-y-2 rounded-xl border p-4">
         <label className="text-sm font-medium">Remote signer (NIP‑46)</label>
@@ -99,17 +100,17 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
           placeholder="nostrconnect:..."
           className="input w-full"
         />
-        <button className="btn btn-secondary w-full" onClick={connectRemote}>
+        <Button className="btn-secondary w-full" onClick={connectRemote}>
           Connect remote signer
-        </button>
+        </Button>
       </div>
 
-      <button className="btn btn-secondary w-full" onClick={importKey}>
+      <Button className="btn-secondary w-full" onClick={importKey}>
         Import nsec / hex
-      </button>
-      <button className="btn btn-secondary w-full" onClick={generateKey}>
+      </Button>
+      <Button className="btn-secondary w-full" onClick={generateKey}>
         Generate new key
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -7,6 +7,7 @@ import type { EventTemplate } from 'nostr-tools/pure';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { getPool, RELAYS } from '@/lib/nostr';
+import { Button } from '@paiduan/ui';
 
 export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
   const { state } = useAuth();
@@ -142,21 +143,21 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
               value={zoom}
               onChange={(e) => setZoom(parseFloat(e.target.value))}
             />
-            <button className="btn btn-secondary" onClick={finishCrop}>
+            <Button className="btn-secondary" onClick={finishCrop}>
               Done
-            </button>
+            </Button>
           </div>
         )}
         {!rawImage && picture && (
           <img src={picture} alt="avatar" className="h-24 w-24 rounded-full object-cover" />
         )}
-        <button
+        <Button
           onClick={saveProfile}
           disabled={loading}
-          className="btn btn-primary disabled:opacity-50"
+          className="btn-primary disabled:opacity-50"
         >
           {loading ? 'Saving…' : 'Save'}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 
-export interface ButtonProps {
-  label?: string;
-}
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
-export const Button: React.FC<ButtonProps> = ({ label = 'Shared Button' }) => {
+export const Button: React.FC<ButtonProps> = ({
+  className = '',
+  children,
+  ...props
+}) => {
   return (
-    <button className="px-4 py-2 bg-blue-500 text-white rounded">{label}</button>
+    <button className={`btn ${className}`} {...props}>
+      {children}
+    </button>
   );
 };


### PR DESCRIPTION
## Summary
- use shared `Button` component in profile setup step
- use shared `Button` component in key setup step
- expand UI `Button` to accept standard props and default `btn` styling

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e446892083319c9b2b854f8a5349