### PR TITLE
feat(web): add accordion settings layout

### DIFF
--- a/apps/web/components/settings/AccountCard.tsx
+++ b/apps/web/components/settings/AccountCard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { Card } from '../ui/Card';
+
+export function AccountCard() {
+  const { signOut } = useAuth();
+  return (
+    <Card title="Account">
+      <button
+        onClick={() => {
+          signOut();
+          window.location.href = '/';
+        }}
+        className="btn btn-secondary"
+      >
+        🔓 Logout / Reset Identity
+      </button>
+    </Card>
+  );
+}
+
+export default AccountCard;

--- a/apps/web/components/settings/AppearanceCard.tsx
+++ b/apps/web/components/settings/AppearanceCard.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useTheme } from '@/context/themeContext';
+import useT from '../../hooks/useT';
+import { Card } from '../ui/Card';
+
+export function AppearanceCard() {
+  const { setMode, accent, setAccent } = useTheme();
+  const t = useT();
+  const colors = ['#7c5cff', '#22c55e', '#06b6d4', '#f59e0b', '#a855f7', '#ef4444'];
+  const isDark =
+    typeof document !== 'undefined' &&
+    document.documentElement.classList.contains('dark');
+
+  return (
+    <Card title="Appearance" desc="Theme and accent colour.">
+      <button
+        onClick={() => setMode(isDark ? 'light' : 'dark')}
+        className="btn btn-secondary"
+      >
+        {isDark ? t('switch_to_light') : t('switch_to_dark')}
+      </button>
+      <div className="flex flex-wrap gap-2 pt-2">
+        {colors.map((c) => (
+          <button
+            key={c}
+            aria-pressed={accent === c}
+            onClick={() => setAccent(c)}
+            className="relative h-7 w-7 rounded-full ring-offset-2 focus-visible:ring-2"
+            style={{ backgroundColor: c }}
+          >
+            {accent === c && (
+              <span className="absolute inset-0 grid place-items-center text-[10px]">✓</span>
+            )}
+          </button>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export default AppearanceCard;

--- a/apps/web/components/settings/DataCard.tsx
+++ b/apps/web/components/settings/DataCard.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import useAlwaysSD from '../../hooks/useAlwaysSD';
+import { Card } from '../ui/Card';
+
+export function DataCard() {
+  const { alwaysSD, setAlwaysSD } = useAlwaysSD();
+
+  return (
+    <Card title="Data" desc="Playback and usage data.">
+      <Row title="Always play SD (240p)" desc="Reduce data usage on mobile." control={<Switch checked={alwaysSD} onCheckedChange={setAlwaysSD} />} />
+    </Card>
+  );
+}
+
+function Row({ title, desc, control }: { title: string; desc: string; control: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between py-3">
+      <div>
+        <div className="font-medium text-sm">{title}</div>
+        <div className="text-xs text-muted-foreground">{desc}</div>
+      </div>
+      {control}
+    </div>
+  );
+}
+
+function Switch({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: (checked: boolean) => void }) {
+  return (
+    <button role="switch" aria-checked={checked} onClick={() => onCheckedChange(!checked)} className={`relative inline-flex h-6 w-10 items-center rounded-full transition-colors ring-offset-2 focus-visible:ring-2 ${checked ? 'bg-accent' : 'bg-foreground/20'}`}>
+      <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${checked ? 'translate-x-4' : 'translate-x-1'}`} />
+    </button>
+  );
+}
+
+export default DataCard;

--- a/apps/web/components/settings/LanguageCard.tsx
+++ b/apps/web/components/settings/LanguageCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import useT from '../../hooks/useT';
+import { Card } from '../ui/Card';
+
+export function LanguageCard() {
+  const t = useT();
+  const router = useRouter();
+  const locale = (router.query.locale as string) || 'en';
+
+  return (
+    <Card title="Language">
+      <select
+        value={locale}
+        onChange={(e) => {
+          const next = e.target.value;
+          if (typeof window !== 'undefined') {
+            localStorage.setItem('locale', next);
+            document.cookie = `locale=${next}; path=/; max-age=31536000`;
+            const path = router.asPath.replace(/^\/[a-zA-Z-]+/, '');
+            router.push(`/${next}${path}`);
+          }
+        }}
+        className="rounded border border-white/30 bg-brand-panel px-3 py-1"
+      >
+        <option value="en">{t('language_english')}</option>
+        <option value="zh">{t('language_chinese')}</option>
+        <option value="ar">{t('language_arabic')}</option>
+      </select>
+    </Card>
+  );
+}
+
+export default LanguageCard;

--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Card } from '../ui/Card';
+
+export function NetworkCard() {
+  return (
+    <Card title="Network" desc="Connectivity options.">
+      <div className="text-sm text-muted-foreground">No network settings available.</div>
+    </Card>
+  );
+}
+
+export default NetworkCard;

--- a/apps/web/components/settings/PrivacyCard.tsx
+++ b/apps/web/components/settings/PrivacyCard.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { Card } from '../ui/Card';
+
+export function PrivacyCard() {
+  const [analytics, setAnalytics] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setAnalytics(localStorage.getItem('analytics-consent') === '1');
+  }, []);
+
+  const toggleAnalytics = (next: boolean) => {
+    setAnalytics(next);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('analytics-consent', next ? '1' : '0');
+      window.location.reload();
+    }
+  };
+
+  return (
+    <Card title="Privacy" desc="Analytics and diagnostics.">
+      <Row title="Send anonymous usage data" desc="Helps us find crashes and slow spots." control={<Switch checked={analytics} onCheckedChange={toggleAnalytics} />} />
+    </Card>
+  );
+}
+
+function Row({ title, desc, control }: { title: string; desc: string; control: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between py-3">
+      <div>
+        <div className="font-medium text-sm">{title}</div>
+        <div className="text-xs text-muted-foreground">{desc}</div>
+      </div>
+      {control}
+    </div>
+  );
+}
+
+function Switch({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: (checked: boolean) => void }) {
+  return (
+    <button role="switch" aria-checked={checked} onClick={() => onCheckedChange(!checked)} className={`relative inline-flex h-6 w-10 items-center rounded-full transition-colors ring-offset-2 focus-visible:ring-2 ${checked ? 'bg-accent' : 'bg-foreground/20'}`}>
+      <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${checked ? 'translate-x-4' : 'translate-x-1'}`} />
+    </button>
+  );
+}
+
+export default PrivacyCard;

--- a/apps/web/components/settings/StorageCard.tsx
+++ b/apps/web/components/settings/StorageCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import useT from '../../hooks/useT';
+import { Card } from '../ui/Card';
+
+export function StorageCard() {
+  const t = useT();
+
+  const clearStorage = () => {
+    if (typeof window === 'undefined') return;
+    const keys = ['feed-tab', 'feed-tag', 'unseen-notifications', 'following'];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (k && k.startsWith('followers-')) keys.push(k);
+    }
+    keys.forEach((k) => window.localStorage.removeItem(k));
+  };
+
+  return (
+    <Card title="Storage" desc="Local caches and data.">
+      <button onClick={clearStorage} className="btn btn-secondary">
+        {t('clear_cached_data')}
+      </button>
+    </Card>
+  );
+}
+
+export default StorageCard;

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -1,170 +1,54 @@
-import React, { useEffect, useState } from 'react';
-import { useTheme } from '@/context/themeContext';
-import useT from '../hooks/useT';
-import { useRouter } from 'next/router';
-import useAlwaysSD from '../hooks/useAlwaysSD';
-import { useAuth } from '@/hooks/useAuth';
-import { KeysCard } from '../components/settings/KeysCard';
+import React from 'react';
 import SideNav from '../components/SideNav';
-import { Card } from '../components/ui/Card';
+import { Accordion } from '../components/ui/Accordion';
+import { KeysCard } from '../components/settings/KeysCard';
+import { AccountCard } from '../components/settings/AccountCard';
+import { NetworkCard } from '../components/settings/NetworkCard';
+import { AppearanceCard } from '../components/settings/AppearanceCard';
+import { LanguageCard } from '../components/settings/LanguageCard';
+import { StorageCard } from '../components/settings/StorageCard';
+import { DataCard } from '../components/settings/DataCard';
+import { PrivacyCard } from '../components/settings/PrivacyCard';
 
 export default function Settings() {
-  const { setMode, accent, setAccent } = useTheme();
-  const { signOut } = useAuth();
-  const [analytics, setAnalytics] = useState(false);
-  const { alwaysSD, setAlwaysSD } = useAlwaysSD();
-  const t = useT();
-  const router = useRouter();
-  const locale = (router.query.locale as string) || 'en';
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    setAnalytics(localStorage.getItem('analytics-consent') === '1');
-  }, []);
-
-  const toggleAnalytics = (next: boolean) => {
-    setAnalytics(next);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('analytics-consent', next ? '1' : '0');
-      window.location.reload();
-    }
-  };
-
-  const clearStorage = () => {
-    if (typeof window === 'undefined') return;
-    const keys = ['feed-tab', 'feed-tag', 'unseen-notifications', 'following'];
-    for (let i = 0; i < window.localStorage.length; i++) {
-      const k = window.localStorage.key(i);
-      if (k && k.startsWith('followers-')) keys.push(k);
-    }
-    keys.forEach((k) => window.localStorage.removeItem(k));
-  };
-
-  const colors = ['#7c5cff', '#22c55e', '#06b6d4', '#f59e0b', '#a855f7', '#ef4444'];
-
   return (
     <>
       <SideNav />
       <main className="max-w-3xl mx-auto px-4 py-10 space-y-6 lg:ml-48">
-        <KeysCard />
-
-        <Card title="Appearance" desc="Theme and accent colour.">
-          <button
-            onClick={() =>
-              setMode(
-                typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
-                  ? 'light'
-                  : 'dark'
-              )
-            }
-            className="btn btn-secondary"
-          >
-            {typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
-              ? t('switch_to_light')
-              : t('switch_to_dark')}
-          </button>
-          <div className="flex flex-wrap gap-2 pt-2">
-            {colors.map((c) => (
-              <button
-                aria-pressed={accent === c}
-                key={c}
-                onClick={() => setAccent(c)}
-                className="relative h-7 w-7 rounded-full ring-offset-2 focus-visible:ring-2"
-                style={{ backgroundColor: c }}
-              >
-                {accent === c && (
-                  <span className="absolute inset-0 grid place-items-center text-[10px]">✓</span>
-                )}
-              </button>
-            ))}
-          </div>
-        </Card>
-
-        <Card title="Storage" desc="Local caches and data.">
-          <button onClick={clearStorage} className="btn btn-secondary">
-            {t('clear_cached_data')}
-          </button>
-        </Card>
-
-        <Card title="Data" desc="Playback and usage data.">
-          <Row
-            title="Always play SD (240p)"
-            desc="Reduce data usage on mobile."
-            control={<Switch checked={alwaysSD} onCheckedChange={setAlwaysSD} />}
-          />
-        </Card>
-
-        <Card title="Privacy" desc="Analytics and diagnostics.">
-          <Row
-            title="Send anonymous usage data"
-            desc="Helps us find crashes and slow spots."
-            control={<Switch checked={analytics} onCheckedChange={toggleAnalytics} />}
-          />
-        </Card>
-
-        <Card title="Language">
-          <select
-            value={locale}
-            onChange={(e) => {
-              const next = e.target.value;
-              if (typeof window !== 'undefined') {
-                localStorage.setItem('locale', next);
-                document.cookie = `locale=${next}; path=/; max-age=31536000`;
-                const path = router.asPath.replace(/^\/[a-zA-Z-]+/, '');
-                router.push(`/${next}${path}`);
-              }
-            }}
-            className="rounded border border-white/30 bg-brand-panel px-3 py-1"
-          >
-            <option value="en">{t('language_english')}</option>
-            <option value="zh">{t('language_chinese')}</option>
-            <option value="ar">{t('language_arabic')}</option>
-          </select>
-        </Card>
-
-        <Card title="Account">
-          <button
-            onClick={() => {
-              signOut();
-              window.location.href = '/';
-            }}
-            className="btn btn-secondary"
-          >
-            🔓 Logout / Reset Identity
-          </button>
-        </Card>
+        <Accordion
+          items={[
+            {
+              title: 'Account & Keys',
+              content: (
+                <div className="space-y-6">
+                  <KeysCard />
+                  <AccountCard />
+                  <NetworkCard />
+                </div>
+              ),
+            },
+            {
+              title: 'Appearance & Language',
+              content: (
+                <div className="space-y-6">
+                  <AppearanceCard />
+                  <LanguageCard />
+                </div>
+              ),
+            },
+            {
+              title: 'Data, Storage & Privacy',
+              content: (
+                <div className="space-y-6">
+                  <StorageCard />
+                  <DataCard />
+                  <PrivacyCard />
+                </div>
+              ),
+            },
+          ]}
+        />
       </main>
     </>
-  );
-}
-
-function Row({ title, desc, control }: { title: string; desc: string; control: React.ReactNode }) {
-  return (
-    <div className="flex items-center justify-between py-3">
-      <div>
-        <div className="font-medium text-sm">{title}</div>
-        <div className="text-xs text-muted-foreground">{desc}</div>
-      </div>
-      {control}
-    </div>
-  );
-}
-
-function Switch({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: (checked: boolean) => void }) {
-  return (
-    <button
-      role="switch"
-      aria-checked={checked}
-      onClick={() => onCheckedChange(!checked)}
-      className={`relative inline-flex h-6 w-10 items-center rounded-full transition-colors ring-offset-2 focus-visible:ring-2 ${
-        checked ? 'bg-accent' : 'bg-foreground/20'
-      }`}
-    >
-      <span
-        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-          checked ? 'translate-x-4' : 'translate-x-1'
-        }`}
-      />
-    </button>
   );
 }


### PR DESCRIPTION
## Summary
- reorganize settings page with accordion sections
- extract account, appearance, language, data, storage, privacy, and network cards
- integrate new Accordion component

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm install` *(fails: No matching version found for @headlessui/react@^1.8.0)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f5f887c48331b91f2860aa773717