### PR TITLE
feat(web): add relay network settings

### DIFF
--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,12 +1,84 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card } from '../ui/Card';
 
 export function NetworkCard() {
+  const [relays, setRelays] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  // load relays from localStorage on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem('pd.relays');
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) setRelays(parsed);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  // persist relays to localStorage whenever they change
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem('pd.relays', JSON.stringify(relays));
+    } catch {
+      /* ignore */
+    }
+  }, [relays]);
+
+  const addRelay = () => {
+    const url = input.trim();
+    if (!url || relays.includes(url)) return;
+    setRelays((prev) => [...prev, url]);
+    setInput('');
+  };
+
+  const removeRelay = (url: string) => {
+    setRelays((prev) => prev.filter((r) => r !== url));
+  };
+
   return (
-    <Card title="Network" desc="Connectivity options.">
-      <div className="text-sm text-muted-foreground">No network settings available.</div>
+    <Card title="Network" desc="Configure relay connections.">
+      <div className="space-y-3">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="wss://relay.example.com"
+            className="flex-1 rounded bg-foreground/10 p-2 text-sm outline-none"
+          />
+          <button onClick={addRelay} className="btn btn-secondary">
+            Add
+          </button>
+        </div>
+        {relays.length > 0 ? (
+          <ul className="space-y-1">
+            {relays.map((r) => (
+              <li
+                key={r}
+                className="flex items-center justify-between rounded bg-foreground/5 px-2 py-1 text-sm"
+              >
+                <span className="break-all">{r}</span>
+                <button
+                  onClick={() => removeRelay(r)}
+                  className="text-xs text-red-500 hover:underline"
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="text-sm text-muted-foreground">No relays configured.</div>
+        )}
+      </div>
     </Card>
   );
 }
 
 export default NetworkCard;
+


### PR DESCRIPTION
## Summary
- allow configuration of relay URLs
- persist relays to localStorage
- add UI to add/remove relays

## Testing
- `pnpm test apps/web` *(fails: sh: 1: vitest: not found)*
- `pnpm install` *(fails: No matching version found for @headlessui/react@^1.8.0)*
- `pnpm lint --filter @paiduan/web` *(fails: sh: 1: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689644bf48bc8331a5c1ce67d13a3e30