### PR TITLE
Wire feed page to useFeed hook

### DIFF
--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -1,17 +1,42 @@
 import AppShell from '@/components/layout/AppShell';
 import LeftNav from '@/components/layout/LeftNav';
 import RightPanel from '@/components/feed/RightPanel';
+import useFeed from '@/hooks/useFeed';
+import { useAuth } from '@/hooks/useAuth';
+import useFollowing, { getFollowers } from '@/hooks/useFollowing';
+import { useProfile } from '@/hooks/useProfile';
 import { useFeedSelection } from '@/store/feedSelection';
 
 export default function FeedPage() {
-  const { setFilterAuthor } = useFeedSelection();
-  // TODO: wire to your hooks/state
-  const me = { avatar: '/api/avatar/me', name: 'You', username: 'me', stats: { followers: 1234, following: 321 } };
-  const author = undefined; // or the author of the currently focused video
-  const videos: any[] = []; // your feed items
+  const { filterAuthor, setFilterAuthor, selectedVideoAuthor } = useFeedSelection();
+  const { items: videos } = useFeed(filterAuthor ? { author: filterAuthor } : 'all');
+
+  const { state: auth } = useAuth();
+  const { following } = useFollowing();
+  const meProfile = useProfile(auth.status === 'ready' ? auth.pubkey : undefined);
+  const me =
+    auth.status === 'ready'
+      ? {
+          avatar: meProfile?.picture || `/api/avatar/${auth.pubkey}`,
+          name: meProfile?.name || auth.pubkey.slice(0, 8),
+          username: meProfile?.name || auth.pubkey.slice(0, 8),
+          stats: { followers: getFollowers(auth.pubkey), following: following.length },
+        }
+      : { avatar: '/api/avatar/me', name: 'You', username: 'me', stats: { followers: 0, following: 0 } };
+
+  const authorProfile = useProfile(selectedVideoAuthor);
+  const author =
+    selectedVideoAuthor && authorProfile
+      ? {
+          avatar: authorProfile.picture || `/api/avatar/${selectedVideoAuthor}`,
+          name: authorProfile.name || selectedVideoAuthor.slice(0, 8),
+          username: authorProfile.name || selectedVideoAuthor.slice(0, 8),
+          pubkey: selectedVideoAuthor,
+          followers: getFollowers(selectedVideoAuthor),
+        }
+      : undefined;
 
   function filterByAuthor(pubkey: string) {
-    // switch your feed mode to that author (update useFeed or router query)
     setFilterAuthor(pubkey);
   }
 
@@ -24,7 +49,7 @@ export default function FeedPage() {
           {videos.length === 0 ? (
             <div className="text-center text-muted-foreground py-20">No videos yet.</div>
           ) : (
-            videos.map((v) => <div key={v.id}>{/* <VideoCard {...v} /> */}</div>)
+            videos.map((v) => <div key={v.eventId}>{/* <VideoCard {...v} /> */}</div>)
           )}
         </div>
       }


### PR DESCRIPTION
## Summary
- load feed items via `useFeed` and selection state
- derive current user and author info from auth and profile hooks
- filter feed when selecting an author

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68964ca6bcbc8331b1e9956318eb76cd