### PR TITLE
refactor: encapsulate crypto vault

### DIFF
--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -5,7 +5,7 @@ import * as nip19 from 'nostr-tools/nip19';
 import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { bytesToHex } from '@noble/hashes/utils';
 import { useAuth } from '@/hooks/useAuth';
-import { encryptPrivkeyHex } from '@/utils/cryptoVault';
+import { cryptoVault } from '@/utils/cryptoVault';
 import { saveKey } from '@/utils/keyStorage';
 import { promptPassphrase } from '@/utils/promptPassphrase';
 import { Button } from '@paiduan/ui';
@@ -29,7 +29,7 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
     const pass = await promptPassphrase('Set a passphrase to encrypt your key');
     if (!pass) return;
     try {
-      const encPriv = await encryptPrivkeyHex(priv, pass);
+      const encPriv = await cryptoVault.encryptPrivkeyHex(priv, pass);
       const pubkey = getPublicKey(priv);
       saveKey({ method, pubkey, encPriv });
       signInWithLocal(priv);

--- a/apps/web/utils/cryptoVault.ts
+++ b/apps/web/utils/cryptoVault.ts
@@ -1,64 +1,83 @@
-const te = new TextEncoder();
-const td = new TextDecoder();
-const b64 = (b: ArrayBuffer) => btoa(String.fromCharCode(...new Uint8Array(b)));
-const ub64 = (s: string) =>
-  Uint8Array.from(atob(s), (c) => c.charCodeAt(0)).buffer;
+export class CryptoVault {
+  private static te = new TextEncoder();
+  private static td = new TextDecoder();
 
-async function deriveKey(pass: string, salt: ArrayBuffer, iter = 250_000) {
-  const base = await crypto.subtle.importKey(
-    'raw',
-    te.encode(pass),
-    'PBKDF2',
-    false,
-    ['deriveKey']
-  );
-  return crypto.subtle.deriveKey(
-    { name: 'PBKDF2', hash: 'SHA-256', salt, iterations: iter },
-    base,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt', 'decrypt']
-  );
+  private static b64(b: ArrayBuffer) {
+    return btoa(String.fromCharCode(...new Uint8Array(b)));
+  }
+
+  private static ub64(s: string) {
+    return Uint8Array.from(atob(s), (c) => c.charCodeAt(0)).buffer;
+  }
+
+  private static async deriveKey(
+    pass: string,
+    salt: ArrayBuffer,
+    iter = 250_000
+  ) {
+    const base = await crypto.subtle.importKey(
+      'raw',
+      this.te.encode(pass),
+      'PBKDF2',
+      false,
+      ['deriveKey']
+    );
+    return crypto.subtle.deriveKey(
+      { name: 'PBKDF2', hash: 'SHA-256', salt, iterations: iter },
+      base,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  async encryptPrivkeyHex(privHex: string, pass: string) {
+    if (!/^[0-9a-f]{64}$/i.test(privHex))
+      throw new Error('privkey must be 64-hex');
+    const salt = crypto.getRandomValues(new Uint8Array(16)).buffer;
+    const iv = crypto.getRandomValues(new Uint8Array(12)).buffer;
+    const k = await CryptoVault.deriveKey(pass, salt);
+    const ct = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      k,
+      CryptoVault.te.encode(privHex.toLowerCase())
+    );
+    return {
+      v: 1,
+      kdf: 'pbkdf2' as const,
+      iter: 250_000,
+      salt: CryptoVault.b64(salt),
+      iv: CryptoVault.b64(iv),
+      ct: CryptoVault.b64(ct),
+    };
+  }
+
+  async decryptPrivkeyHex(
+    vault: {
+      v: number;
+      kdf: 'pbkdf2';
+      iter: number;
+      salt: string;
+      iv: string;
+      ct: string;
+    },
+    pass: string
+  ) {
+    const k = await CryptoVault.deriveKey(
+      pass,
+      CryptoVault.ub64(vault.salt),
+      vault.iter
+    );
+    const pt = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: CryptoVault.ub64(vault.iv) },
+      k,
+      CryptoVault.ub64(vault.ct)
+    );
+    return CryptoVault.td.decode(pt);
+  }
 }
 
-export async function encryptPrivkeyHex(privHex: string, pass: string) {
-  if (!/^[0-9a-f]{64}$/i.test(privHex))
-    throw new Error('privkey must be 64-hex');
-  const salt = crypto.getRandomValues(new Uint8Array(16)).buffer;
-  const iv = crypto.getRandomValues(new Uint8Array(12)).buffer;
-  const k = await deriveKey(pass, salt);
-  const ct = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv },
-    k,
-    te.encode(privHex.toLowerCase())
-  );
-  return {
-    v: 1,
-    kdf: 'pbkdf2' as const,
-    iter: 250_000,
-    salt: b64(salt),
-    iv: b64(iv),
-    ct: b64(ct),
-  };
-}
+export const cryptoVault = new CryptoVault();
 
-export async function decryptPrivkeyHex(
-  vault: {
-    v: number;
-    kdf: 'pbkdf2';
-    iter: number;
-    salt: string;
-    iv: string;
-    ct: string;
-  },
-  pass: string
-) {
-  const k = await deriveKey(pass, ub64(vault.salt), vault.iter);
-  const pt = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: ub64(vault.iv) },
-    k,
-    ub64(vault.ct)
-  );
-  return td.decode(pt);
-}
+export default cryptoVault;
 


### PR DESCRIPTION
## Summary
- add CryptoVault class with methods to encrypt/decrypt private key hex
- export singleton cryptoVault and update KeySetupStep to use it

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68964d0b71788331bf630867f483e409