### PR TITLE
feat: add creator stats store

### DIFF
--- a/apps/web/lib/creatorStatsStore.ts
+++ b/apps/web/lib/creatorStatsStore.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+
+export interface Event {
+  kind: number;
+  pubkey: string;
+  created_at: number; // unix seconds
+  amount?: number;
+  content?: string;
+  tags?: string[][];
+}
+
+export interface Totals {
+  views: number;
+  zapsSats: number;
+  comments: number;
+  followerDelta: number;
+  revenueAud: number;
+}
+
+export interface DailyEntry extends Totals {
+  date: string;
+}
+
+export interface AggregatedStats {
+  totals: Totals;
+  dailySeries: DailyEntry[];
+}
+
+const DEFAULT_RATE = Number(process.env.SAT_TO_AUD || 0.0005);
+
+export class CreatorStatsStore {
+  constructor(private filePath: string) {}
+
+  read(): Record<string, AggregatedStats> {
+    try {
+      return JSON.parse(fs.readFileSync(this.filePath, 'utf8'));
+    } catch {
+      return {};
+    }
+  }
+
+  write(data: Record<string, AggregatedStats>): void {
+    fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
+  }
+
+  aggregate(events: Event[], rate: number = DEFAULT_RATE): AggregatedStats {
+    const daily: Record<string, Totals> = {};
+    const totals: Totals = {
+      views: 0,
+      zapsSats: 0,
+      comments: 0,
+      followerDelta: 0,
+      revenueAud: 0,
+    };
+
+    for (const ev of events) {
+      const date = new Date(ev.created_at * 1000).toISOString().slice(0, 10);
+      if (!daily[date]) {
+        daily[date] = {
+          views: 0,
+          zapsSats: 0,
+          comments: 0,
+          followerDelta: 0,
+          revenueAud: 0,
+        };
+      }
+      const d = daily[date];
+      switch (ev.kind) {
+        case 30023:
+          totals.views++;
+          d.views++;
+          break;
+        case 9735: {
+          const amt =
+            ev.amount ||
+            parseInt(ev.tags?.find((t) => t[0] === 'amount')?.[1] || '0', 10) ||
+            0;
+          totals.zapsSats += amt;
+          d.zapsSats += amt;
+          break;
+        }
+        case 9736: {
+          try {
+            const json = JSON.parse(ev.content || '{}');
+            const sats = Array.isArray(json.splits)
+              ? json.splits.reduce((s: number, sp: any) => s + Number(sp.sats || 0), 0)
+              : Number(json.sats || 0);
+            const aud = sats * rate;
+            totals.revenueAud += aud;
+            d.revenueAud += aud;
+          } catch {
+            /* ignore */
+          }
+          break;
+        }
+        case 1:
+          totals.comments++;
+          d.comments++;
+          break;
+        case 3:
+          totals.followerDelta++;
+          d.followerDelta++;
+          break;
+      }
+    }
+
+    const dailySeries: DailyEntry[] = Object.keys(daily)
+      .sort()
+      .map((date) => ({ date, ...daily[date] }));
+
+    return { totals, dailySeries };
+  }
+}

--- a/apps/web/pages/api/creator-stats.ts
+++ b/apps/web/pages/api/creator-stats.ts
@@ -1,19 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs';
 import path from 'path';
+import { CreatorStatsStore } from '../../lib/creatorStatsStore';
 
-interface Store {
-  [pubkey: string]: any;
-}
-
-function loadStore(): Store {
-  try {
-    const p = path.join(process.cwd(), 'scripts', 'creator-stats.json');
-    return JSON.parse(fs.readFileSync(p, 'utf8'));
-  } catch {
-    return {};
-  }
-}
+const store = new CreatorStatsStore(path.join(process.cwd(), 'scripts', 'creator-stats.json'));
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const pubkey = req.query.pubkey as string;
@@ -26,7 +15,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(403).json({ error: 'forbidden' });
     return;
   }
-  const store = loadStore();
-  const stats = store[pubkey] || { totals: { views: 0, zapsSats: 0, comments: 0, followerDelta: 0, revenueAud: 0 }, dailySeries: [] };
+  const data = store.read();
+  const stats =
+    data[pubkey] || {
+      totals: { views: 0, zapsSats: 0, comments: 0, followerDelta: 0, revenueAud: 0 },
+      dailySeries: [],
+    };
   res.status(200).json(stats);
 }

--- a/scripts/aggregate-creator-stats.test.ts
+++ b/scripts/aggregate-creator-stats.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { aggregateCreatorStats, Event } from './aggregate-creator-stats';
+import { CreatorStatsStore, Event } from '../apps/web/lib/creatorStatsStore';
 
-describe('aggregateCreatorStats', () => {
+describe('CreatorStatsStore.aggregate', () => {
   it('computes totals and daily series', () => {
     const ts = 1_700_000_000; // arbitrary timestamp
     const events: Event[] = [
@@ -16,7 +16,8 @@ describe('aggregateCreatorStats', () => {
       { kind: 1, pubkey: 'a', created_at: ts },
       { kind: 3, pubkey: 'a', created_at: ts },
     ];
-    const stats = aggregateCreatorStats(events, 0.001);
+    const store = new CreatorStatsStore('');
+    const stats = store.aggregate(events, 0.001);
     expect(stats.totals.views).toBe(1);
     expect(stats.totals.zapsSats).toBe(10);
     expect(stats.totals.comments).toBe(1);

--- a/scripts/aggregate-creator-stats.ts
+++ b/scripts/aggregate-creator-stats.ts
@@ -1,109 +1,15 @@
 import fs from 'fs';
 import path from 'path';
-
-export interface Event {
-  kind: number;
-  pubkey: string;
-  created_at: number; // unix seconds
-  amount?: number;
-  content?: string;
-  tags?: string[][];
-}
-
-export interface Totals {
-  views: number;
-  zapsSats: number;
-  comments: number;
-  followerDelta: number;
-  revenueAud: number;
-}
-
-export interface DailyEntry extends Totals {
-  date: string;
-}
-
-export interface AggregatedStats {
-  totals: Totals;
-  dailySeries: DailyEntry[];
-}
-
-const DEFAULT_RATE = Number(process.env.SAT_TO_AUD || 0.0005);
-
-export function aggregateCreatorStats(events: Event[], rate: number = DEFAULT_RATE): AggregatedStats {
-  const daily: Record<string, Totals> = {};
-  const totals: Totals = { views: 0, zapsSats: 0, comments: 0, followerDelta: 0, revenueAud: 0 };
-
-  for (const ev of events) {
-    const date = new Date(ev.created_at * 1000).toISOString().slice(0, 10);
-    if (!daily[date]) {
-      daily[date] = { views: 0, zapsSats: 0, comments: 0, followerDelta: 0, revenueAud: 0 };
-    }
-    const d = daily[date];
-    switch (ev.kind) {
-      case 30023:
-        totals.views++;
-        d.views++;
-        break;
-      case 9735: {
-        const amt =
-          ev.amount ||
-          parseInt(ev.tags?.find((t) => t[0] === 'amount')?.[1] || '0', 10) ||
-          0;
-        totals.zapsSats += amt;
-        d.zapsSats += amt;
-        break;
-      }
-      case 9736: {
-        try {
-          const json = JSON.parse(ev.content || '{}');
-          const sats = Array.isArray(json.splits)
-            ? json.splits.reduce((s: number, sp: any) => s + Number(sp.sats || 0), 0)
-            : Number(json.sats || 0);
-          const aud = sats * rate;
-          totals.revenueAud += aud;
-          d.revenueAud += aud;
-        } catch {
-          /* ignore */
-        }
-        break;
-      }
-      case 1:
-        totals.comments++;
-        d.comments++;
-        break;
-      case 3:
-        totals.followerDelta++;
-        d.followerDelta++;
-        break;
-    }
-  }
-
-  const dailySeries: DailyEntry[] = Object.keys(daily)
-    .sort()
-    .map((date) => ({ date, ...daily[date] }));
-
-  return { totals, dailySeries };
-}
+import { CreatorStatsStore, Event } from '../apps/web/lib/creatorStatsStore';
 
 const STORE_PATH = path.join(__dirname, 'creator-stats.json');
-
-export function readStore(): Record<string, AggregatedStats> {
-  try {
-    return JSON.parse(fs.readFileSync(STORE_PATH, 'utf8'));
-  } catch {
-    return {};
-  }
-}
-
-export function writeStore(data: Record<string, AggregatedStats>) {
-  fs.writeFileSync(STORE_PATH, JSON.stringify(data, null, 2));
-}
+const store = new CreatorStatsStore(STORE_PATH);
 
 export async function run(pubkey: string, events: Event[]) {
-  const stats = aggregateCreatorStats(events);
-  const store = readStore();
-  store[pubkey] = stats;
-  writeStore(store);
+  const stats = store.aggregate(events);
+  const data = store.read();
+  data[pubkey] = stats;
+  store.write(data);
   return stats;
 }
 


### PR DESCRIPTION
## Summary
- add CreatorStatsStore class for reading, writing and aggregating creator metrics
- refactor aggregation script to use CreatorStatsStore
- update creator stats API to read data through CreatorStatsStore

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68964eaef07483318bf89c0ad9816f51