### PR TITLE
refactor: add key storage class

### DIFF
--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -6,7 +6,7 @@ import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { bytesToHex } from '@noble/hashes/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { cryptoVault } from '@/utils/cryptoVault';
-import { saveKey } from '@/utils/keyStorage';
+import { keyStore } from '@/utils/keyStorage';
 import { promptPassphrase } from '@/utils/promptPassphrase';
 import { Button } from '@paiduan/ui';
 
@@ -31,7 +31,7 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
     try {
       const encPriv = await cryptoVault.encryptPrivkeyHex(priv, pass);
       const pubkey = getPublicKey(priv);
-      saveKey({ method, pubkey, encPriv });
+      keyStore.save({ method, pubkey, encPriv });
       signInWithLocal(priv);
       // remove plaintext storage from auth hook
       try {
@@ -64,7 +64,7 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
       await signInWithNip46(uri);
       if (state.status === 'ready') {
         try {
-          saveKey({ method: 'remote', pubkey: state.pubkey, relay: uri });
+          keyStore.save({ method: 'remote', pubkey: state.pubkey, relay: uri });
         } catch {}
       }
       onComplete();

--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -3,6 +3,7 @@ import { LocalSigner } from '@/lib/signers/local';
 import { Nip07Signer } from '@/lib/signers/nip07';
 import { Nip46Signer } from '@/lib/signers/nip46';
 import type { Signer } from '@/lib/signers/types';
+import { keyStore } from '@/utils/keyStorage';
 
 type AuthState =
   | { status: 'signedOut' }
@@ -18,7 +19,7 @@ export function useAuth() {
   useEffect(() => {
     function refreshFlags() {
       if (typeof localStorage === 'undefined') return;
-      setHasKeys(!!localStorage.getItem(LS_KEY) || !!localStorage.getItem('nostr-auth'));
+      setHasKeys(!!localStorage.getItem(LS_KEY) || !!keyStore.load());
       setHasProfile(localStorage.getItem('pd.onboarded') === '1');
     }
 

--- a/apps/web/utils/keyStorage.ts
+++ b/apps/web/utils/keyStorage.ts
@@ -15,19 +15,36 @@ export type AuthState =
       };
     };
 
-const KEY = 'nostr-auth';
+class KeyStore {
+  private readonly KEY = 'nostr-auth';
 
-export function saveKey(data: AuthState) {
-  if ((data as any).privkey) throw new Error('Refusing to store plaintext privkey');
-  localStorage.setItem(KEY, JSON.stringify(data));
+  save(data: AuthState) {
+    if (
+      typeof (data as any).privkey === 'string' ||
+      typeof (data as any).privkeyHex === 'string'
+    )
+      throw new Error('Refusing to store plaintext privkey');
+
+    try {
+      localStorage.setItem(this.KEY, JSON.stringify(data));
+    } catch {}
+  }
+
+  load(): AuthState | null {
+    try {
+      const raw = localStorage.getItem(this.KEY);
+      return raw ? (JSON.parse(raw) as AuthState) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  clear() {
+    try {
+      localStorage.removeItem(this.KEY);
+    } catch {}
+  }
 }
 
-export function getStoredKey(): AuthState | null {
-  const raw = localStorage.getItem(KEY);
-  return raw ? JSON.parse(raw) : null;
-}
-
-export function clearKey() {
-  localStorage.removeItem(KEY);
-}
+export const keyStore = new KeyStore();
 


### PR DESCRIPTION
## Summary
- encapsulate auth key persistence in a `KeyStore` class
- use `KeyStore` for onboarding and auth state checks

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68964ea58f588331aa247c8a5cc486e2