### PR TITLE
feat(web): make Nostr relays configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Visit <http://localhost:3000/feed> for the swipeable video feed demo.
 
 Client-side video trimming now relies on the [WebCodecs API](https://developer.mozilla.org/docs/Web/API/WebCodecs_API) with a lightweight polyfill for browsers lacking native support, eliminating the previous `ffmpeg.wasm` dependency. Toast notifications are provided by [`react-hot-toast`](https://react-hot-toast.com/).
 
+## Relay configuration
+
+Override the default Nostr relays with the `NEXT_PUBLIC_RELAYS` environment variable or by editing `apps/web/relays.json`. The environment variable accepts a comma‑separated list or a JSON array. If neither is provided, the app falls back to `wss://relay.damus.io`, `wss://nos.lol` and `wss://relay.snort.social`.
+
 ## PWA features
 
 The web client ships as a Progressive Web App:

--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -1,6 +1,7 @@
 'use client';
 import { SimplePool } from 'nostr-tools/pool';
 import { getPublicKey } from 'nostr-tools/pure';
+import relaysConfig from '../relays.json';
 
 let _pool: SimplePool | null = null;
 
@@ -45,8 +46,34 @@ export function getMyPubkey(): string | undefined {
 }
 
 /** Relays you want to hit – tweak as needed */
-export const RELAYS = [
+const DEFAULT_RELAYS = [
   'wss://relay.damus.io',
   'wss://nos.lol',
   'wss://relay.snort.social',
 ];
+
+function parseRelays(input: unknown): string[] | undefined {
+  if (Array.isArray(input)) {
+    return input.filter((r): r is string => typeof r === 'string' && r.length > 0);
+  }
+  if (typeof input === 'string') {
+    try {
+      const parsed = JSON.parse(input);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((r): r is string => typeof r === 'string' && r.length > 0);
+      }
+    } catch {
+      // not JSON
+    }
+    return input
+      .split(',')
+      .map((r) => r.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+export const RELAYS: string[] =
+  parseRelays(process.env.NEXT_PUBLIC_RELAYS) ??
+  parseRelays(relaysConfig) ??
+  DEFAULT_RELAYS;

--- a/apps/web/relays.json
+++ b/apps/web/relays.json
@@ -1,0 +1,5 @@
+[
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://relay.snort.social"
+]


### PR DESCRIPTION
## Summary
- allow overriding Nostr relays via `NEXT_PUBLIC_RELAYS` env var or `apps/web/relays.json`
- document relay configuration in README

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68964ee5d5dc8331ba08e6c396520ee2