### PR TITLE
feat(web): add analytics service

### DIFF
--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -1,0 +1,37 @@
+import { setTimeout as delay } from 'timers/promises';
+
+const DEFAULT_URLS = (process.env.ANALYTICS_URLS || 'https://stats.paiduan.app/api/event')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export class AnalyticsService {
+  constructor(private urls: string[] = DEFAULT_URLS, private retries = 3) {}
+
+  async post(body: unknown, headers: Record<string, string> = {}): Promise<void> {
+    for (const url of this.urls) {
+      let attempt = 0;
+      while (attempt < this.retries) {
+        try {
+          await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...headers },
+            body: JSON.stringify(body),
+          });
+          console.log(`Analytics event sent to ${url}`);
+          break;
+        } catch (err) {
+          attempt++;
+          console.error(`Analytics POST to ${url} failed (attempt ${attempt})`, err);
+          if (attempt >= this.retries) {
+            console.error(`Giving up on analytics POST to ${url}`);
+            break;
+          }
+          await delay(500);
+        }
+      }
+    }
+  }
+}
+
+export const analyticsService = new AnalyticsService();

--- a/apps/web/pages/api/event.test.ts
+++ b/apps/web/pages/api/event.test.ts
@@ -29,7 +29,7 @@ describe('event API', () => {
     const req = createReq({ event: 'test' }, { 'user-agent': 'ua', 'x-forwarded-for': 'ip' });
     const res = createRes();
     await handler(req, res);
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(res.statusCode).toBe(204);
   });
 });

--- a/apps/web/pages/api/event.ts
+++ b/apps/web/pages/api/event.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { analyticsService } from '../../lib/analytics';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (process.env.NEXT_PUBLIC_ANALYTICS !== 'enabled') {
@@ -6,14 +7,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
   try {
-    await fetch('https://stats.paiduan.app/api/event', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': req.headers['user-agent'] || '',
-        'X-Forwarded-For': (req.headers['x-forwarded-for'] as string) || '',
-      },
-      body: JSON.stringify(req.body),
+    await analyticsService.post(req.body, {
+      'User-Agent': req.headers['user-agent'] || '',
+      'X-Forwarded-For': (req.headers['x-forwarded-for'] as string) || '',
     });
   } catch (e) {
     // ignore errors

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["NODE_ENV", "ADMIN_PUBKEYS"],
+  "globalEnv": ["NODE_ENV", "ADMIN_PUBKEYS", "ANALYTICS_URLS", "SAT_TO_AUD"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- add analytics service with retry logic and env-based URLs
- use analytics service from event API
- declare analytics env vars in turbo config

## Testing
- `pnpm test apps/web/pages/api/event.test.ts`
- `pnpm --filter @paiduan/web lint`

------
https://chatgpt.com/codex/tasks/task_e_6896508907608331a4bd2a3666941b34