### PR TITLE
Centralize Nostr relay configuration

### DIFF
--- a/apps/web/components/CommentBox.tsx
+++ b/apps/web/components/CommentBox.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { SimplePool } from 'nostr-tools/pool';
 import type { Event } from 'nostr-tools/pure';
 import { useAuth } from '@/hooks/useAuth';
-
-const relays = ['wss://relay.damus.io', 'wss://nos.lol'];
+import { getRelays } from '@/lib/nostr';
 
 interface CommentBoxProps {
   videoId: string;
@@ -26,7 +25,7 @@ export default function CommentBox({ videoId, onSend }: CommentBoxProps) {
         pubkey: state.pubkey,
       };
       const signed = await state.signer.signEvent(event);
-      await new SimplePool().publish(relays, signed);
+      await new SimplePool().publish(getRelays(), signed);
       setInput('');
       onSend?.(signed);
     } catch {

--- a/apps/web/components/CreatorWizard.tsx
+++ b/apps/web/components/CreatorWizard.tsx
@@ -6,6 +6,7 @@ import { VideoCardProps } from './VideoCard';
 import { trimVideoWebCodecs } from '../utils/trimVideoWebCodecs';
 import { toast } from 'react-hot-toast';
 import { useAuth } from '@/hooks/useAuth';
+import { getRelays } from '@/lib/nostr';
 
 interface CreatorWizardProps {
   onClose: () => void;
@@ -167,7 +168,7 @@ export const CreatorWizard: React.FC<CreatorWizardProps> = ({ onClose, onPublish
       }
       if (state.status !== 'ready') throw new Error('signer required');
       const signed = await state.signer.signEvent(event);
-      await pool.publish(['wss://relay.damus.io', 'wss://nos.lol'], signed);
+      await pool.publish(getRelays(), signed);
       const newItem: VideoCardProps = {
         videoUrl: uploadRes.video,
         posterUrl: uploadRes.poster,

--- a/apps/web/components/ReportModal.tsx
+++ b/apps/web/components/ReportModal.tsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import { SimplePool } from 'nostr-tools/pool';
 import toast from 'react-hot-toast';
 import { useAuth } from '@/hooks/useAuth';
-
-const relays = ['wss://relay.damus.io', 'wss://nos.lol'];
+import { getRelays } from '@/lib/nostr';
 
 interface Props {
   targetId: string;
@@ -29,7 +28,7 @@ const ReportModal: React.FC<Props> = ({ targetId, targetKind, open, onClose }) =
       const event = { kind: 30041, created_at: ts, content: JSON.stringify(report), pubkey: reporterPubKey };
       const signed = await state.signer.signEvent(event);
       const pool: any = new SimplePool();
-      await pool.publish(relays, signed);
+      await pool.publish(getRelays(), signed);
       await fetch('/api/modqueue', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/apps/web/components/ThreadedComments.tsx
+++ b/apps/web/components/ThreadedComments.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import type { Event } from 'nostr-tools/pure';
-import { getPool, RELAYS } from '@/lib/nostr';
+import { getPool, getRelays } from '@/lib/nostr';
 
 export default function ThreadedComments({ noteId }: { noteId?: string }) {
   const [events, setEvents] = useState<Event[]>([]);
@@ -11,7 +11,7 @@ export default function ThreadedComments({ noteId }: { noteId?: string }) {
     if (!noteId) return;
     const pool = getPool();
     setEvents([]);
-    const sub = pool.subscribeMany(RELAYS, [{ kinds: [1], '#e': [noteId] }], {
+    const sub = pool.subscribeMany(getRelays(), [{ kinds: [1], '#e': [noteId] }], {
       onevent: (ev: Event) =>
         setEvents((prev) =>
           prev.find((e) => e.id === ev.id)

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -17,6 +17,7 @@ import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { useCurrentVideo } from '../hooks/useCurrentVideo';
 import { useFeedSelection } from '@/store/feedSelection';
+import { getRelays } from '@/lib/nostr';
 
 const MoreVertical = dynamic(
   () => import('lucide-react').then((mod) => mod.MoreVertical),
@@ -77,7 +78,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
 
   useEffect(() => {
     const pool: any = new SimplePool();
-    const relays = ['wss://relay.damus.io', 'wss://nos.lol'];
+    const relays = getRelays();
     const sub = pool.subscribeMany(relays, [{ kinds: [0], authors: [pubkey], limit: 1 }], {
       onevent: (ev: any) => {
         try {

--- a/apps/web/components/VideoInfoPane.tsx
+++ b/apps/web/components/VideoInfoPane.tsx
@@ -4,8 +4,7 @@ import type { Event } from 'nostr-tools/pure';
 import { useCurrentVideo } from '../hooks/useCurrentVideo';
 import { useFollowing } from '../hooks/useFollowing';
 import ZapButton from './ZapButton';
-
-const relays = ['wss://relay.damus.io', 'wss://nos.lol'];
+import { getRelays } from '@/lib/nostr';
 
 export default function VideoInfoPane() {
   const { current } = useCurrentVideo();
@@ -17,6 +16,7 @@ export default function VideoInfoPane() {
     if (!current) return;
     (async () => {
       const pool = new SimplePool();
+      const relays = getRelays();
       try {
         const [m] = await pool.list(relays, [{ kinds: [0], authors: [current.pubkey], limit: 1 }]);
         setMeta(m ? JSON.parse(m.content) : null);

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -6,7 +6,7 @@ import type { Area } from 'react-easy-crop';
 import type { EventTemplate } from 'nostr-tools/pure';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
-import { getPool, RELAYS } from '@/lib/nostr';
+import { getPool, getRelays } from '@/lib/nostr';
 import { Button } from '@paiduan/ui';
 
 export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
@@ -86,7 +86,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
     };
     const signed = await state.signer.signEvent({ ...tmpl });
     const pool = getPool();
-    await pool.publish(RELAYS, signed as any);
+    await pool.publish(getRelays(), signed as any);
   }
 
   async function saveProfile() {

--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,29 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { Card } from '../ui/Card';
+import { getRelays } from '@/lib/nostr';
 
 export function NetworkCard() {
-  const [relays, setRelays] = useState<string[]>([]);
+  const [relays, setRelays] = useState<string[]>(getRelays);
   const [input, setInput] = useState('');
-
-  // load relays from localStorage on mount
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      const stored = window.localStorage.getItem('pd.relays');
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (Array.isArray(parsed)) setRelays(parsed);
-      }
-    } catch {
-      /* ignore */
-    }
-  }, []);
 
   // persist relays to localStorage whenever they change
   useEffect(() => {
     if (typeof window === 'undefined') return;
     try {
       window.localStorage.setItem('pd.relays', JSON.stringify(relays));
+      window.dispatchEvent(new Event('pd.relays')); // notify listeners
     } catch {
       /* ignore */
     }

--- a/apps/web/hooks/useLightning.ts
+++ b/apps/web/hooks/useLightning.ts
@@ -1,6 +1,7 @@
 import { SimplePool } from 'nostr-tools/pool';
 import type { Filter } from 'nostr-tools/filter';
 import { useAuth } from './useAuth';
+import { getRelays } from '../lib/nostr';
 
 interface ZapArgs {
   lightningAddress: string;
@@ -13,21 +14,6 @@ interface ZapArgs {
 interface Split {
   lnaddr: string;
   pct: number;
-}
-
-function relayList(): string[] {
-  if (typeof window === 'undefined') return ['wss://relay.damus.io', 'wss://nos.lol'];
-  const nostr = (window as any).nostr;
-  if (nostr?.getRelays) {
-    try {
-      const relays = nostr.getRelays();
-      if (Array.isArray(relays)) return relays;
-      if (relays && typeof relays === 'object') return Object.keys(relays);
-    } catch {
-      /* ignore */
-    }
-  }
-  return ['wss://relay.damus.io', 'wss://nos.lol'];
 }
 
 export default function useLightning() {
@@ -52,7 +38,7 @@ export default function useLightning() {
     let splits: Split[] = [];
     if (pubkey) {
       try {
-        const ev = await pool.get(relayList(), {
+        const ev = await pool.get(getRelays(), {
           kinds: [0],
           authors: [pubkey],
           limit: 1,
@@ -102,7 +88,7 @@ export default function useLightning() {
           pubkey: state.pubkey,
         };
         const signed = await state.signer.signEvent(event);
-        pool.publish(relayList(), signed);
+        pool.publish(getRelays(), signed);
       } catch (err: any) {
         alert(err.message || 'Sign-in required');
       }

--- a/apps/web/hooks/useNotifications.tsx
+++ b/apps/web/hooks/useNotifications.tsx
@@ -2,8 +2,7 @@ import React, { createContext, useContext, useEffect, useRef, useState } from 'r
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import pool from './pool';
 import { toast } from 'react-hot-toast';
-
-const relays = ['wss://relay.damus.io', 'wss://nos.lol'];
+import { getRelays } from '@/lib/nostr';
 
 export interface Notification {
   id: string;
@@ -95,6 +94,7 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
     (async () => {
       try {
         const pubkey = await nostr.getPublicKey();
+        const relays = getRelays();
 
         // fetch my video ids (kind 30023)
         let myVideos: NostrEvent[] = [];

--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 import * as nostrKinds from 'nostr-tools/kinds';
 import type { Filter } from 'nostr-tools/filter';
-import { getPool, RELAYS } from '@/lib/nostr';
+import { getPool, getRelays } from '@/lib/nostr';
 
 export function useProfile(pubkey?: string) {
   const [meta, setMeta] = useState<any>(null);
@@ -10,7 +10,7 @@ export function useProfile(pubkey?: string) {
     if (!pubkey) return;
     const pool = getPool();
     const sub = pool.subscribeMany(
-      RELAYS,
+      getRelays(),
       [{ kinds: [nostrKinds.Metadata], authors: [pubkey], limit: 1 } as Filter],
       {
         onevent: (ev) => {

--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -3,6 +3,7 @@ import { SimplePool } from 'nostr-tools/pool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
 import { VideoCardProps } from '../components/VideoCard';
+import { getRelays } from '@/lib/nostr';
 
 export interface CreatorResult {
   pubkey: string;
@@ -15,20 +16,6 @@ export interface SearchResults {
   creators: CreatorResult[];
 }
 
-function relayList(): string[] {
-  if (typeof window === 'undefined') return ['wss://relay.damus.io', 'wss://nos.lol'];
-  const nostr = (window as any).nostr;
-  if (nostr?.getRelays) {
-    try {
-      const relays = nostr.getRelays();
-      if (Array.isArray(relays)) return relays;
-      if (relays && typeof relays === 'object') return Object.keys(relays);
-    } catch {
-      /* ignore */
-    }
-  }
-  return ['wss://relay.damus.io', 'wss://nos.lol'];
-}
 
 export function useSearch(query: string): SearchResults {
   const [videos, setVideos] = useState<VideoCardProps[]>([]);
@@ -49,7 +36,7 @@ export function useSearch(query: string): SearchResults {
     subRef.current?.close();
     if (timerRef.current) clearTimeout(timerRef.current);
 
-    const relays = relayList();
+    const relays = getRelays();
     const filters: Filter[] = [];
     const q = query.startsWith('@') || query.startsWith('#') ? query.slice(1) : query;
 

--- a/apps/web/hooks/useThread.ts
+++ b/apps/web/hooks/useThread.ts
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Event, type Filter, finalizeEvent } from 'nostr-tools';
 import * as nostrKinds from 'nostr-tools/kinds';
-import { getPool, RELAYS, getMyPrivkey, getMyPubkey } from '@/lib/nostr';
+import { getPool, getRelays, getMyPrivkey, getMyPubkey } from '@/lib/nostr';
 
 type Note = {
   id: string;
@@ -46,7 +46,7 @@ export function useThread(rootEventId?: string) {
     const evs: Event[] = [];
     const filters: Filter[] = [{ kinds: [nostrKinds.ShortTextNote], '#e': [rootEventId], limit: 200 }];
 
-    const sub = pool.subscribeMany(RELAYS, filters, {
+    const sub = pool.subscribeMany(getRelays(), filters, {
       onevent: (ev: Event) => {
         evs.push(ev);
         setNotes(parseThread(evs));
@@ -97,7 +97,7 @@ export function useThread(rootEventId?: string) {
       },
     ]);
 
-    await pool.publish(RELAYS, ev);
+    await pool.publish(getRelays(), ev);
     return ev.id;
   }
 

--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -73,7 +73,15 @@ function parseRelays(input: unknown): string[] | undefined {
   return undefined;
 }
 
-export const RELAYS: string[] =
-  parseRelays(process.env.NEXT_PUBLIC_RELAYS) ??
-  parseRelays(relaysConfig) ??
-  DEFAULT_RELAYS;
+export function getRelays(): string[] {
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = localStorage.getItem('pd.relays');
+      const parsed = parseRelays(stored);
+      if (parsed && parsed.length > 0) return parsed;
+    } catch {
+      /* ignore */
+    }
+  }
+  return parseRelays(relaysConfig) ?? DEFAULT_RELAYS;
+}

--- a/apps/web/lib/signers/nip46.ts
+++ b/apps/web/lib/signers/nip46.ts
@@ -3,6 +3,7 @@ import { generateSecretKey, getPublicKey, type EventTemplate } from 'nostr-tools
 import * as nip04 from 'nostr-tools/nip04';
 import { Relay } from 'nostr-tools/relay';
 import type { Signer } from './types';
+import { getRelays } from '@/lib/nostr';
 
 type Nip46Session = {
   remotePubkey: string;
@@ -32,9 +33,7 @@ export class Nip46Signer implements Signer {
     const secret = params.get('secret') || undefined;
     return {
       remotePubkey,
-      relays: relays.length
-        ? relays
-        : ['wss://relay.damus.io', 'wss://relay.primal.net'],
+      relays: relays.length ? relays : getRelays(),
       secret,
     };
   }

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -9,21 +9,7 @@ import VideoCard, { VideoCardProps } from '../../../components/VideoCard';
 import useFollowing, { getFollowers } from '../../../hooks/useFollowing';
 import SearchBar from '../../../components/SearchBar';
 import { useAuth } from '@/hooks/useAuth';
-
-function relayList(): string[] {
-  if (typeof window === 'undefined') return ['wss://relay.damus.io', 'wss://nos.lol'];
-  const nostr = (window as any).nostr;
-  if (nostr?.getRelays) {
-    try {
-      const relays = nostr.getRelays();
-      if (Array.isArray(relays)) return relays;
-      if (relays && typeof relays === 'object') return Object.keys(relays);
-    } catch {
-      /* ignore */
-    }
-  }
-  return ['wss://relay.damus.io', 'wss://nos.lol'];
-}
+import { getRelays } from '@/lib/nostr';
 
 export default function ProfilePage() {
   const router = useRouter();
@@ -56,7 +42,7 @@ export default function ProfilePage() {
   useEffect(() => {
     if (!pubkey) return;
     const pool = (poolRef.current ||= new SimplePool());
-    const relays = relayList();
+    const relays = getRelays();
 
     const metaSub = pool.subscribeMany(
       relays,
@@ -164,7 +150,7 @@ export default function ProfilePage() {
       };
       const signed = await state.signer.signEvent(event);
       const pool = (poolRef.current ||= new SimplePool());
-      await pool.publish(relayList(), signed);
+      await pool.publish(getRelays(), signed);
       toast.success('Revenue share updated');
     } catch (err) {
       console.error(err);

--- a/apps/web/pages/treasury.tsx
+++ b/apps/web/pages/treasury.tsx
@@ -2,21 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { SimplePool } from 'nostr-tools/pool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
-
-function relayList(): string[] {
-  if (typeof window === 'undefined') return ['wss://relay.damus.io', 'wss://nos.lol'];
-  const nostr = (window as any).nostr;
-  if (nostr?.getRelays) {
-    try {
-      const relays = nostr.getRelays();
-      if (Array.isArray(relays)) return relays;
-      if (relays && typeof relays === 'object') return Object.keys(relays);
-    } catch {
-      /* ignore */
-    }
-  }
-  return ['wss://relay.damus.io', 'wss://nos.lol'];
-}
+import { getRelays } from '@/lib/nostr';
 
 export default function TreasuryPage() {
   const [authorised, setAuthorised] = useState(false);
@@ -36,7 +22,7 @@ export default function TreasuryPage() {
       setAuthorised(true);
       const pool = (poolRef.current ||= new SimplePool());
       const since = Math.floor(new Date().setHours(0, 0, 0, 0) / 1000);
-      sub = pool.subscribeMany(relayList(), [{ kinds: [9736], since } as Filter], {
+      sub = pool.subscribeMany(getRelays(), [{ kinds: [9736], since } as Filter], {
         onevent: (ev: NostrEvent) => {
           try {
             const content = JSON.parse(ev.content);

--- a/apps/web/pages/v/[eventId].tsx
+++ b/apps/web/pages/v/[eventId].tsx
@@ -3,21 +3,7 @@ import { useEffect, useState } from 'react';
 import { SimplePool } from 'nostr-tools/pool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import VideoCard, { VideoCardProps } from '../../components/VideoCard';
-
-function relayList(): string[] {
-  if (typeof window === 'undefined') return ['wss://relay.damus.io', 'wss://nos.lol'];
-  const nostr = (window as any).nostr;
-  if (nostr?.getRelays) {
-    try {
-      const relays = nostr.getRelays();
-      if (Array.isArray(relays)) return relays;
-      if (relays && typeof relays === 'object') return Object.keys(relays);
-    } catch {
-      /* ignore */
-    }
-  }
-  return ['wss://relay.damus.io', 'wss://nos.lol'];
-}
+import { getRelays } from '@/lib/nostr';
 
 export default function VideoPage() {
   const router = useRouter();
@@ -28,7 +14,7 @@ export default function VideoPage() {
     if (!eventId) return;
     document.body.style.overflow = 'hidden';
     const pool = new SimplePool();
-    const relays = relayList();
+    const relays = getRelays();
     pool.get(relays, { ids: [eventId] }).then((ev: NostrEvent | null) => {
       if (!ev) return;
       const videoTag = ev.tags.find((t) => t[0] === 'v');

--- a/packages/mod-dashboard/pages/index.tsx
+++ b/packages/mod-dashboard/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { SimplePool } from 'nostr-tools/pool';
+import { getRelays } from '../../apps/web/lib/nostr';
 
 const ADMIN_PUBKEYS = (process.env.ADMIN_PUBKEYS || '').split(',').filter(Boolean);
 
@@ -55,7 +56,7 @@ export default function Dashboard({ allowed }: Props) {
     const event = { kind: 9001, created_at: ts, content: JSON.stringify(hide) };
     const signed = await nostr.signEvent(event);
     const pool: any = new SimplePool();
-    await pool.publish(['wss://relay.damus.io', 'wss://nos.lol'], signed);
+    await pool.publish(getRelays(), signed);
     await approve(id);
   };
 


### PR DESCRIPTION
## Summary
- add `getRelays()` to load relay list from `localStorage` with fallbacks
- replace hard-coded relay arrays with `getRelays()` across hooks and components
- have `NetworkCard` persist and broadcast relay list updates

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689653ba387c8331b092c85a60a21d77