### PR TITLE
Add metadata step before uploading videos

### DIFF
--- a/apps/web/components/create/MetadataStep.tsx
+++ b/apps/web/components/create/MetadataStep.tsx
@@ -1,0 +1,88 @@
+'use client'
+import { useState } from 'react'
+
+export interface MetadataStepProps {
+  blob: Blob
+  preview?: string
+  onBack: () => void
+}
+
+export function MetadataStep({ blob, preview, onBack }: MetadataStepProps) {
+  const [caption, setCaption] = useState('')
+  const [tags, setTags] = useState('')
+  const [copyright, setCopyright] = useState('')
+  const [nsfw, setNsfw] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  async function upload() {
+    setBusy(true)
+    const form = new FormData()
+    form.append('file', blob, 'video.webm')
+    form.append('caption', caption)
+    form.append('tags', tags)
+    form.append('copyright', copyright)
+    form.append('nsfw', nsfw ? 'true' : 'false')
+    // This is a stub for the real upload request
+    alert(
+      'Ready to upload with metadata (stub): ' +
+        JSON.stringify({ caption, tags, copyright, nsfw })
+    )
+    setBusy(false)
+  }
+
+  return (
+    <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <button className="btn btn-secondary" onClick={onBack}>
+          ← Back
+        </button>
+        <h2 className="text-lg font-semibold">Metadata</h2>
+      </div>
+      {preview && (
+        <video
+          controls
+          src={preview}
+          className="rounded-xl w-full aspect-[9/16] object-cover bg-black"
+        />
+      )}
+      <input
+        type="text"
+        value={caption}
+        onChange={(e) => setCaption(e.target.value)}
+        placeholder="Caption"
+        className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
+      />
+      <input
+        type="text"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        placeholder="Tags (comma separated)"
+        className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
+      />
+      <input
+        type="text"
+        value={copyright}
+        onChange={(e) => setCopyright(e.target.value)}
+        placeholder="Copyright information"
+        className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
+      />
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={nsfw}
+          onChange={(e) => setNsfw(e.target.checked)}
+        />
+        <span className="text-sm">NSFW</span>
+      </label>
+      <button
+        className="btn btn-primary disabled:opacity-60"
+        disabled={busy}
+        onClick={upload}
+      >
+        {busy ? 'Uploading…' : 'Upload'}
+      </button>
+    </section>
+  )
+}
+
+export default MetadataStep

--- a/apps/web/components/create/RecordStep.tsx
+++ b/apps/web/components/create/RecordStep.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
+import { MetadataStep } from './MetadataStep';
 
 export function RecordStep({ onBack }: { onBack: () => void }) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -9,6 +10,7 @@ export function RecordStep({ onBack }: { onBack: () => void }) {
   const [blob, setBlob] = useState<Blob | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [rec, setRec] = useState(false);
+  const [step, setStep] = useState<'record' | 'metadata'>('record');
 
   useEffect(() => {
     (async () => {
@@ -45,6 +47,7 @@ export function RecordStep({ onBack }: { onBack: () => void }) {
       const b = new Blob(chunks.current, { type: 'video/webm' });
       setBlob(b);
       setPreview(URL.createObjectURL(b));
+      setStep('metadata');
     };
     mr.start();
     setRec(true);
@@ -61,9 +64,8 @@ export function RecordStep({ onBack }: { onBack: () => void }) {
     setRec(false);
   }
 
-  async function upload() {
-    if (!blob) return;
-    alert('Ready to upload recorded .webm (stub).');
+  if (step === 'metadata' && blob) {
+    return <MetadataStep blob={blob} preview={preview ?? undefined} onBack={() => setStep('record')} />;
   }
 
   return (
@@ -93,9 +95,6 @@ export function RecordStep({ onBack }: { onBack: () => void }) {
             ■ Stop
           </button>
         )}
-        <button className="btn btn-secondary" onClick={upload} disabled={!blob}>
-          Upload
-        </button>
       </div>
 
       {preview && (

--- a/apps/web/components/create/UploadStep.tsx
+++ b/apps/web/components/create/UploadStep.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { trimVideoWebCodecs } from '@/utils/trimVideoWebCodecs'
+import { MetadataStep } from './MetadataStep'
 
 export function UploadStep({ onBack }: { onBack: () => void }) {
   const [file, setFile] = useState<File | null>(null)
@@ -8,12 +9,14 @@ export function UploadStep({ onBack }: { onBack: () => void }) {
   const [preview, setPreview] = useState<string | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
+  const [step, setStep] = useState<'process' | 'metadata'>('process')
 
   function onPick(e: React.ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0] ?? null
     setFile(f)
     setOutBlob(null)
     setPreview(f ? URL.createObjectURL(f) : null)
+    setStep('process')
   }
 
   async function convert() {
@@ -24,6 +27,7 @@ export function UploadStep({ onBack }: { onBack: () => void }) {
       const blob = await trimVideoWebCodecs(file, 0)
       setOutBlob(blob)
       setPreview(URL.createObjectURL(blob))
+      setStep('metadata')
     } catch (e) {
       console.error(e)
       setErr('Conversion failed.')
@@ -32,9 +36,8 @@ export function UploadStep({ onBack }: { onBack: () => void }) {
     }
   }
 
-  async function upload() {
-    if (!outBlob) return
-    alert('Ready to upload .webm (stub).')
+  if (step === 'metadata' && outBlob) {
+    return <MetadataStep blob={outBlob} preview={preview ?? undefined} onBack={() => setStep('process')} />
   }
 
   return (
@@ -68,13 +71,6 @@ export function UploadStep({ onBack }: { onBack: () => void }) {
           onClick={convert}
         >
           {busy ? 'Processing…' : 'Convert to .webm'}
-        </button>
-        <button
-          className="btn btn-secondary disabled:opacity-60"
-          disabled={!outBlob || busy}
-          onClick={upload}
-        >
-          Upload
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- introduce metadata entry step with caption, tags, copyright, and NSFW toggle
- route upload and recording flows through metadata collection before upload
- include metadata values in upload payload

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896556c3c508331b96af6af78188933