### PR TITLE
Refactor left nav layout

### DIFF
--- a/apps/web/components/layout/LeftNav.tsx
+++ b/apps/web/components/layout/LeftNav.tsx
@@ -1,36 +1,79 @@
 'use client';
 import Link from 'next/link';
+import SearchBar from '@/components/SearchBar';
+import MiniProfileCard from '@/components/MiniProfileCard';
+import NotificationBell from '@/components/NotificationBell';
+import { useTheme } from '@/context/themeContext';
+import { Sun, Moon } from 'lucide-react';
 
-export default function LeftNav({ me }: { me: { avatar: string; name: string; username: string; stats: { followers: number; following: number } } }) {
+export default function LeftNav({
+  me,
+}: {
+  me: {
+    avatar: string;
+    name: string;
+    username: string;
+    stats: { followers: number; following: number };
+  };
+}) {
+  const { mode, toggleMode } = useTheme();
+
   return (
     <div className="space-y-6">
-      {/* Profile mini card */}
-      <div className="bg-card border border-token rounded-2xl p-4 flex items-center gap-3">
-        <img src={me.avatar} alt="" className="w-12 h-12 rounded-full object-cover" />
-        <div>
-          <div className="font-semibold">{me.name}</div>
-          <div className="text-sm text-muted-foreground">@{me.username}</div>
-        </div>
-      </div>
-
       {/* Search */}
-      <div className="bg-card border border-token rounded-2xl p-3">
-        <input
-          type="search"
-          placeholder="Search creators, tags…"
-          className="w-full bg-transparent outline-none text-sm"
-        />
-      </div>
+      <SearchBar />
+
+      {/* Profile mini card */}
+      <MiniProfileCard />
 
       {/* Nav */}
       <nav className="bg-card border border-token rounded-2xl p-2">
         <ul className="flex flex-col">
-          <li><Link className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block" href="/feed">Home</Link></li>
-          <li><Link className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block" href="/following">Following</Link></li>
-          <li><Link className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block" href="/create">Create</Link></li>
-          <li><Link className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block" href="/settings">Settings</Link></li>
+          <li>
+            <Link
+              className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block"
+              href="/feed"
+            >
+              Home
+            </Link>
+          </li>
+          <li>
+            <Link
+              className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block"
+              href="/following"
+            >
+              Following
+            </Link>
+          </li>
+          <li>
+            <Link
+              className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block"
+              href="/create"
+            >
+              Create
+            </Link>
+          </li>
+          <li>
+            <Link
+              className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block"
+              href="/settings"
+            >
+              Settings
+            </Link>
+          </li>
         </ul>
       </nav>
+
+      {/* Actions */}
+      <div className="bg-card border border-token rounded-2xl p-2 flex items-center justify-between">
+        <button
+          onClick={toggleMode}
+          className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10"
+        >
+          {mode === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+        </button>
+        <NotificationBell />
+      </div>
 
       {/* Stats */}
       <div className="bg-card border border-token rounded-2xl p-4 text-sm">
@@ -42,7 +85,9 @@ export default function LeftNav({ me }: { me: { avatar: string; name: string; us
           <span className="text-muted-foreground">Following</span>
           <span className="font-medium">{me.stats.following.toLocaleString()}</span>
         </div>
-        <Link href="/settings" className="mt-3 inline-block text-sm underline">Profile settings</Link>
+        <Link href="/settings" className="mt-3 inline-block text-sm underline">
+          Profile settings
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- move search bar to top and show mini profile card beneath it
- add dark mode toggle and notifications after menu

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68965690e10083319872ad8c9fe7813c