### PR TITLE
feat: apply responsive grid layout to create page

### DIFF
--- a/apps/web/pages/create.tsx
+++ b/apps/web/pages/create.tsx
@@ -1,6 +1,22 @@
-import dynamic from 'next/dynamic'
-const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'), { ssr: false })
+import dynamic from 'next/dynamic';
+import SearchBar from '@/components/SearchBar';
+import MiniProfileCard from '@/components/MiniProfileCard';
+
+const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'), { ssr: false });
 
 export default function CreatePage() {
-  return <CreatorWizard />
+  return (
+    <main className="mx-auto max-w-[1400px] px-4">
+      <div className="grid gap-6 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[280px_minmax(0,1fr)_340px]">
+        <aside className="hidden lg:block self-start sticky top-20 space-y-4">
+          <SearchBar />
+          <MiniProfileCard />
+        </aside>
+
+        <section className="xl:col-span-2">
+          <CreatorWizard />
+        </section>
+      </div>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap CreatorWizard in feed-style responsive grid layout
- show SearchBar and MiniProfileCard in sidebar

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web lint`


------
https://chatgpt.com/codex/tasks/task_e_689657d0672c833191b4f198cf855310