### PR TITLE
feat: add relay via Enter key

### DIFF
--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -36,10 +36,16 @@ export function NetworkCard() {
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addRelay();
+              }
+            }}
             placeholder="wss://relay.example.com"
             className="flex-1 rounded bg-foreground/10 p-2 text-sm outline-none"
           />
-          <button onClick={addRelay} className="btn btn-secondary">
+          <button type="button" onClick={addRelay} className="btn btn-secondary">
             Add
           </button>
         </div>


### PR DESCRIPTION
## Summary
- prevent NetworkCard add button from submitting forms by default
- allow adding relay URL via Enter key press for better accessibility

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689657b673548331a0f2ace8c8921b87