### PR TITLE
feat: add cancel option to creator wizard

### DIFF
--- a/apps/web/components/create/CreatorWizard.tsx
+++ b/apps/web/components/create/CreatorWizard.tsx
@@ -1,25 +1,40 @@
-'use client'
-import { useState } from 'react'
-import { UploadStep } from './UploadStep'
-import { RecordStep } from './RecordStep'
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { UploadStep } from './UploadStep';
+import { RecordStep } from './RecordStep';
 
 export default function CreatorWizard() {
-  const [mode, setMode] = useState<'upload' | 'record' | null>(null)
+  const [mode, setMode] = useState<'upload' | 'record' | null>(null);
+  const router = useRouter();
+
+  const handleCancel = () => {
+    router.back();
+  };
 
   return (
     <main className="max-w-2xl mx-auto py-12 px-4 space-y-6">
-      <h1 className="text-3xl font-bold">Create Video</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Create Video</h1>
+        <button className="text-sm text-muted-foreground" onClick={handleCancel}>
+          Cancel
+        </button>
+      </div>
       {!mode && (
         <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-3">
           <p className="text-sm text-muted-foreground">Choose how you want to create:</p>
           <div className="flex gap-3 flex-wrap">
-            <button className="btn btn-primary" onClick={() => setMode('upload')}>📁 Upload a file</button>
-            <button className="btn btn-secondary" onClick={() => setMode('record')}>🎥 Record</button>
+            <button className="btn btn-primary" onClick={() => setMode('upload')}>
+              📁 Upload a file
+            </button>
+            <button className="btn btn-secondary" onClick={() => setMode('record')}>
+              🎥 Record
+            </button>
           </div>
         </section>
       )}
-      {mode === 'upload' && <UploadStep onBack={() => setMode(null)} />}
-      {mode === 'record' && <RecordStep onBack={() => setMode(null)} />}
+      {mode === 'upload' && <UploadStep onBack={() => setMode(null)} onCancel={handleCancel} />}
+      {mode === 'record' && <RecordStep onBack={() => setMode(null)} onCancel={handleCancel} />}
     </main>
-  )
+  );
 }

--- a/apps/web/components/create/MetadataStep.tsx
+++ b/apps/web/components/create/MetadataStep.tsx
@@ -1,42 +1,52 @@
-'use client'
-import { useState } from 'react'
+'use client';
+import { useState } from 'react';
 
 export interface MetadataStepProps {
-  blob: Blob
-  preview?: string
-  onBack: () => void
+  blob: Blob;
+  preview?: string;
+  onBack: () => void;
+  onCancel: () => void;
 }
 
-export function MetadataStep({ blob, preview, onBack }: MetadataStepProps) {
-  const [caption, setCaption] = useState('')
-  const [tags, setTags] = useState('')
-  const [copyright, setCopyright] = useState('')
-  const [nsfw, setNsfw] = useState(false)
-  const [busy, setBusy] = useState(false)
+export function MetadataStep({ blob, preview, onBack, onCancel }: MetadataStepProps) {
+  const [caption, setCaption] = useState('');
+  const [tags, setTags] = useState('');
+  const [copyright, setCopyright] = useState('');
+  const [nsfw, setNsfw] = useState(false);
+  const [busy, setBusy] = useState(false);
 
   async function upload() {
-    setBusy(true)
-    const form = new FormData()
-    form.append('file', blob, 'video.webm')
-    form.append('caption', caption)
-    form.append('tags', tags)
-    form.append('copyright', copyright)
-    form.append('nsfw', nsfw ? 'true' : 'false')
+    setBusy(true);
+    const form = new FormData();
+    form.append('file', blob, 'video.webm');
+    form.append('caption', caption);
+    form.append('tags', tags);
+    form.append('copyright', copyright);
+    form.append('nsfw', nsfw ? 'true' : 'false');
     // This is a stub for the real upload request
     alert(
-      'Ready to upload with metadata (stub): ' +
-        JSON.stringify({ caption, tags, copyright, nsfw })
-    )
-    setBusy(false)
+      'Ready to upload with metadata (stub): ' + JSON.stringify({ caption, tags, copyright, nsfw }),
+    );
+    setBusy(false);
+  }
+
+  function handleCancel() {
+    if ((caption || tags || copyright || nsfw) && !confirm('Discard your progress?')) return;
+    onCancel();
   }
 
   return (
     <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
-      <div className="flex items-center gap-2">
-        <button className="btn btn-secondary" onClick={onBack}>
-          ← Back
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <button className="btn btn-secondary" onClick={onBack}>
+            ← Back
+          </button>
+          <h2 className="text-lg font-semibold">Metadata</h2>
+        </div>
+        <button className="text-sm text-muted-foreground" onClick={handleCancel}>
+          Cancel
         </button>
-        <h2 className="text-lg font-semibold">Metadata</h2>
       </div>
       {preview && (
         <video
@@ -67,22 +77,14 @@ export function MetadataStep({ blob, preview, onBack }: MetadataStepProps) {
         className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
       />
       <label className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          checked={nsfw}
-          onChange={(e) => setNsfw(e.target.checked)}
-        />
+        <input type="checkbox" checked={nsfw} onChange={(e) => setNsfw(e.target.checked)} />
         <span className="text-sm">NSFW</span>
       </label>
-      <button
-        className="btn btn-primary disabled:opacity-60"
-        disabled={busy}
-        onClick={upload}
-      >
+      <button className="btn btn-primary disabled:opacity-60" disabled={busy} onClick={upload}>
         {busy ? 'Uploading…' : 'Upload'}
       </button>
     </section>
-  )
+  );
 }
 
-export default MetadataStep
+export default MetadataStep;

--- a/apps/web/components/create/RecordStep.tsx
+++ b/apps/web/components/create/RecordStep.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { MetadataStep } from './MetadataStep';
 
-export function RecordStep({ onBack }: { onBack: () => void }) {
+export function RecordStep({ onBack, onCancel }: { onBack: () => void; onCancel: () => void }) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const mediaRef = useRef<MediaRecorder | null>(null);
   const chunks = useRef<BlobPart[]>([]);
@@ -64,17 +64,34 @@ export function RecordStep({ onBack }: { onBack: () => void }) {
     setRec(false);
   }
 
+  function handleCancel() {
+    if ((blob || preview || rec) && !confirm('Discard your progress?')) return;
+    onCancel();
+  }
+
   if (step === 'metadata' && blob) {
-    return <MetadataStep blob={blob} preview={preview ?? undefined} onBack={() => setStep('record')} />;
+    return (
+      <MetadataStep
+        blob={blob}
+        preview={preview ?? undefined}
+        onBack={() => setStep('record')}
+        onCancel={onCancel}
+      />
+    );
   }
 
   return (
     <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
-      <div className="flex items-center gap-2">
-        <button className="btn btn-secondary" onClick={onBack}>
-          ← Back
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <button className="btn btn-secondary" onClick={onBack}>
+            ← Back
+          </button>
+          <h2 className="text-lg font-semibold">Record</h2>
+        </div>
+        <button className="text-sm text-muted-foreground" onClick={handleCancel}>
+          Cancel
         </button>
-        <h2 className="text-lg font-semibold">Record</h2>
       </div>
 
       <video

--- a/apps/web/components/create/UploadStep.tsx
+++ b/apps/web/components/create/UploadStep.tsx
@@ -1,52 +1,69 @@
-'use client'
-import { useState } from 'react'
-import { trimVideoWebCodecs } from '@/utils/trimVideoWebCodecs'
-import { MetadataStep } from './MetadataStep'
+'use client';
+import { useState } from 'react';
+import { trimVideoWebCodecs } from '@/utils/trimVideoWebCodecs';
+import { MetadataStep } from './MetadataStep';
 
-export function UploadStep({ onBack }: { onBack: () => void }) {
-  const [file, setFile] = useState<File | null>(null)
-  const [outBlob, setOutBlob] = useState<Blob | null>(null)
-  const [preview, setPreview] = useState<string | null>(null)
-  const [err, setErr] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
-  const [step, setStep] = useState<'process' | 'metadata'>('process')
+export function UploadStep({ onBack, onCancel }: { onBack: () => void; onCancel: () => void }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [outBlob, setOutBlob] = useState<Blob | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [step, setStep] = useState<'process' | 'metadata'>('process');
 
   function onPick(e: React.ChangeEvent<HTMLInputElement>) {
-    const f = e.target.files?.[0] ?? null
-    setFile(f)
-    setOutBlob(null)
-    setPreview(f ? URL.createObjectURL(f) : null)
-    setStep('process')
+    const f = e.target.files?.[0] ?? null;
+    setFile(f);
+    setOutBlob(null);
+    setPreview(f ? URL.createObjectURL(f) : null);
+    setStep('process');
   }
 
   async function convert() {
-    if (!file) return
-    setBusy(true)
-    setErr(null)
+    if (!file) return;
+    setBusy(true);
+    setErr(null);
     try {
-      const blob = await trimVideoWebCodecs(file, 0)
-      setOutBlob(blob)
-      setPreview(URL.createObjectURL(blob))
-      setStep('metadata')
+      const blob = await trimVideoWebCodecs(file, 0);
+      setOutBlob(blob);
+      setPreview(URL.createObjectURL(blob));
+      setStep('metadata');
     } catch (e) {
-      console.error(e)
-      setErr('Conversion failed.')
+      console.error(e);
+      setErr('Conversion failed.');
     } finally {
-      setBusy(false)
+      setBusy(false);
     }
   }
 
+  function handleCancel() {
+    if ((file || outBlob || preview) && !confirm('Discard your progress?')) return;
+    onCancel();
+  }
+
   if (step === 'metadata' && outBlob) {
-    return <MetadataStep blob={outBlob} preview={preview ?? undefined} onBack={() => setStep('process')} />
+    return (
+      <MetadataStep
+        blob={outBlob}
+        preview={preview ?? undefined}
+        onBack={() => setStep('process')}
+        onCancel={onCancel}
+      />
+    );
   }
 
   return (
     <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
-      <div className="flex items-center gap-2">
-        <button className="btn btn-secondary" onClick={onBack}>
-          ← Back
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <button className="btn btn-secondary" onClick={onBack}>
+            ← Back
+          </button>
+          <h2 className="text-lg font-semibold">Upload a file</h2>
+        </div>
+        <button className="text-sm text-muted-foreground" onClick={handleCancel}>
+          Cancel
         </button>
-        <h2 className="text-lg font-semibold">Upload a file</h2>
       </div>
 
       <input
@@ -80,7 +97,7 @@ export function UploadStep({ onBack }: { onBack: () => void }) {
         </div>
       )}
     </section>
-  )
+  );
 }
 
-export default UploadStep
+export default UploadStep;


### PR DESCRIPTION
## Summary
- add cancel button to creator wizard and each creation step
- prompt before discarding unsaved progress

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689659c74e548331b16a68d6101d5ca3