### PR TITLE
feat: update upload step button

### DIFF
--- a/apps/web/components/create/UploadStep.tsx
+++ b/apps/web/components/create/UploadStep.tsx
@@ -87,7 +87,7 @@ export function UploadStep({ onBack, onCancel }: { onBack: () => void; onCancel:
           disabled={!file || busy}
           onClick={convert}
         >
-          {busy ? 'Processing…' : 'Convert to .webm'}
+          {busy ? 'Processing…' : file ? 'Next' : 'Convert to .webm'}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- update upload step to show "Next" once a file is chosen
- keep convert button disabled while processing to prevent duplicates

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68965da46c488331bb9de42fb059aa93