### PR TITLE
Use parent sizing for video feed components

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -34,7 +34,7 @@ export const Feed: React.FC<FeedProps> = ({ items }) => {
 
   if (items.length === 0) {
     return (
-      <div className="flex h-screen flex-col items-center justify-center text-white">
+      <div className="flex h-full w-full flex-col items-center justify-center text-white">
         <EmptyState />
         <p className="mt-4">Be the first to upload!</p>
       </div>
@@ -42,13 +42,13 @@ export const Feed: React.FC<FeedProps> = ({ items }) => {
   }
 
   return (
-    <div {...bind()} className="relative h-screen w-screen overflow-hidden">
+    <div {...bind()} className="relative h-full w-full overflow-hidden">
       <animated.div
         style={{ transform: y.to((py) => `translateY(${py}%)`) }}
         className="h-full w-full"
       >
         {items.map((item, i) => (
-          <div key={i} className="h-screen w-screen">
+          <div key={i} className="h-full w-full">
             <VideoCard {...item} />
           </div>
         ))}

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -163,7 +163,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="relative h-screen w-screen overflow-hidden rounded-2xl bg-brand-surface text-white shadow-card"
+      className="relative h-full w-full overflow-hidden rounded-2xl bg-brand-surface text-white shadow-card"
       onDoubleClick={onLike}
       onClick={() => setSelectedVideo(eventId, pubkey)}
       onPointerDown={handlePointerDown}


### PR DESCRIPTION
## Summary
- rely on parent sizing in VideoCard
- remove viewport-locked sizing in feed wrappers

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68966826a5948331a2e03b7227a0bcca