### PR TITLE
Improve focus management and navigation accessibility

### DIFF
--- a/apps/web/components/CommentDrawer.tsx
+++ b/apps/web/components/CommentDrawer.tsx
@@ -9,6 +9,7 @@ import ReportModal from './ReportModal';
 import { ADMIN_PUBKEYS } from '../utils/admin';
 import { useAuth } from '@/hooks/useAuth';
 import { getRelays } from '@/lib/nostr';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 interface CommentDrawerProps {
   videoId: string;
@@ -24,6 +25,7 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
   onCountChange,
 }) => {
   const poolRef = useRef(new SimplePool());
+  const drawerRef = useRef<HTMLDivElement>(null);
   const { state } = useAuth();
   const [events, setEvents] = useState<NostrEvent[]>([]);
   const [input, setInput] = useState('');
@@ -34,6 +36,8 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
   const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
 
   const [{ y }, api] = useSpring(() => ({ y: 100 }));
+
+  useFocusTrap(open, drawerRef);
 
   useEffect(() => {
     api.start({ y: open ? 0 : 100 });
@@ -181,13 +185,17 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
 
   return (
     <animated.div
+      ref={drawerRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Comments"
       style={{ transform: y.to((py) => `translateY(${py}%)`) }}
       className="fixed inset-x-0 bottom-0 z-50 h-1/2 bg-background text-foreground"
       {...bind()}
     >
       <div className="flex items-center justify-between border-b border-foreground/10 p-2">
         <span className="font-semibold">Comments</span>
-        <button onClick={onClose} className="p-1 hover:text-accent">
+        <button onClick={onClose} className="p-1 hover:text-accent" aria-label="Close comments">
           <X />
         </button>
       </div>
@@ -207,7 +215,11 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
                 </button>
               </div>
               <div className="relative">
-                <button onClick={() => setMenuFor(c.id)} className="p-1 text-foreground/50">
+                <button
+                  onClick={() => setMenuFor(c.id)}
+                  className="p-1 text-foreground/50"
+                  aria-label="Comment options"
+                >
                   <MoreVertical size={16} />
                 </button>
                 {menuFor === c.id && (
@@ -239,10 +251,14 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
                     Reply
                   </button>
                 </div>
-                <div className="relative">
-                  <button onClick={() => setMenuFor(r.id)} className="p-1 text-foreground/50">
-                    <MoreVertical size={16} />
-                  </button>
+              <div className="relative">
+                <button
+                  onClick={() => setMenuFor(r.id)}
+                  className="p-1 text-foreground/50"
+                  aria-label="Comment options"
+                >
+                  <MoreVertical size={16} />
+                </button>
                   {menuFor === r.id && (
                     <div className="absolute right-0 mt-1 w-24 rounded bg-background p-1 shadow">
                       <button

--- a/apps/web/components/InstallBanner.tsx
+++ b/apps/web/components/InstallBanner.tsx
@@ -1,12 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import useInstallPrompt from '../hooks/useInstallPrompt';
 import { trackEvent } from '../utils/analytics';
 import useT from '../hooks/useT';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 export default function InstallBanner() {
   const { canInstall, showPrompt } = useInstallPrompt();
   const [visible, setVisible] = useState(false);
+  const bannerRef = useRef<HTMLDivElement>(null);
   const t = useT();
+
+  useFocusTrap(visible, bannerRef);
 
   useEffect(() => {
     const dismissed = localStorage.getItem('installDismissed');
@@ -30,7 +34,13 @@ export default function InstallBanner() {
   };
 
   return (
-    <div className="fixed bottom-0 inset-x-0 z-50 bg-background/90 p-4 flex items-center justify-between">
+    <div
+      ref={bannerRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('install_paiduan')}
+      className="fixed bottom-0 inset-x-0 z-50 bg-background/90 p-4 flex items-center justify-between"
+    >
       <span>{t('install_paiduan')}</span>
       <div className="space-x-2">
         <button onClick={handleInstall} className="rounded bg-accent px-3 py-1 text-white">

--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -13,11 +13,19 @@ export default function NavBar() {
     { href: `/${locale}/profile`, icon: <User />, label: 'Profile' },
   ];
   return (
-    <nav className="fixed bottom-0 inset-x-0 lg:hidden z-30 flex justify-around bg-brand-surface/95 backdrop-blur shadow-card">
+    <nav
+      aria-label="Main navigation"
+      className="fixed bottom-0 inset-x-0 lg:hidden z-30 flex justify-around bg-brand-surface/95 backdrop-blur shadow-card"
+    >
       {links.map(({ href, icon, label }) => {
         const active = asPath.startsWith(href);
         return (
-          <Link key={href} href={href} className="flex flex-col items-center py-2 text-sm text-white/80">
+          <Link
+            key={href}
+            href={href}
+            className="flex flex-col items-center py-2 text-sm text-white/80"
+            aria-current={active ? 'page' : undefined}
+          >
             <motion.div
               animate={{ scale: active ? 1.2 : 1 }}
               transition={{ type: 'spring', stiffness: 300 }}

--- a/apps/web/components/NotificationBell.tsx
+++ b/apps/web/components/NotificationBell.tsx
@@ -13,7 +13,11 @@ const NotificationBell: React.FC = () => {
   const count = mounted ? unreadCount : 0;
 
   return (
-    <button onClick={() => setOpen(true)} className="relative text-foreground hover:text-accent">
+    <button
+      onClick={() => setOpen(true)}
+      className="relative text-foreground hover:text-accent"
+      aria-label="Notifications"
+    >
       <Bell className="h-5 w-5" />
       <span
         className={`absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-accent text-xs text-white  ${

--- a/apps/web/components/NotificationDrawer.tsx
+++ b/apps/web/components/NotificationDrawer.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useNotifications } from '../hooks/useNotifications';
 import { useRouter } from 'next/router';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 const NotificationDrawer: React.FC = () => {
   const { notifications, open, setOpen, markAsRead, markAllAsRead } = useNotifications();
   const router = useRouter();
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(open, drawerRef);
 
   const handleClick = (id: string, noteId: string) => {
     markAsRead(id);
@@ -16,6 +20,10 @@ const NotificationDrawer: React.FC = () => {
 
   return (
     <div
+      ref={drawerRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Notifications"
       className={`fixed top-12 left-0 right-0 z-30 max-h-1/2 transform overflow-y-auto bg-background text-foreground transition-transform duration-300 ${
         open ? 'translate-y-0' : '-translate-y-full'
       }`}

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -12,7 +12,10 @@ export default function SideNav() {
     { href: `/${locale}/settings`, icon: Cog, label: 'Settings' },
   ];
   return (
-    <nav className="hidden lg:flex lg:flex-col lg:w-48 lg:fixed lg:left-0 lg:inset-y-0 bg-brand-surface/95 backdrop-blur z-40 pl-4 pt-6">
+    <nav
+      aria-label="Main navigation"
+      className="hidden lg:flex lg:flex-col lg:w-48 lg:fixed lg:left-0 lg:inset-y-0 bg-brand-surface/95 backdrop-blur z-40 pl-4 pt-6"
+    >
       <h1 className="mb-8 text-2xl font-bold text-white">PaiDuan</h1>
       <ul className="space-y-2">
         {links.map(({ href, icon: Icon, label, desktopOnly }) => {
@@ -24,6 +27,7 @@ export default function SideNav() {
                 className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm ${
                   isActive ? 'bg-white/10 text-white' : 'text-muted-foreground hover:bg-white/5'
                 }`}
+                aria-current={isActive ? 'page' : undefined}
               >
                 <Icon size={20} /> {label}
               </Link>

--- a/apps/web/hooks/useFocusTrap.ts
+++ b/apps/web/hooks/useFocusTrap.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+export default function useFocusTrap(active: boolean, ref: React.RefObject<HTMLElement>) {
+  useEffect(() => {
+    if (!active || !ref.current) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const node = ref.current;
+    const focusable = node.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          (last || first).focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          (first || last).focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    first?.focus();
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [active, ref]);
+}
+


### PR DESCRIPTION
## Summary
- add reusable `useFocusTrap` hook and apply to install banner, notification drawer, and comment drawer
- label main navigation and active links
- provide descriptive labels for notification bell and dialog close buttons

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689669f5ef548331afb4c6e729e09f6e