### PR TITLE
feat: enlarge profile avatars and center layout

### DIFF
--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -9,11 +9,16 @@ export default function MiniProfileCard() {
 
   return (
     <div className="rounded-xl border border-gray-200/60 dark:border-gray-700/60 p-3 text-center">
-      <img
-        src={profile?.picture || '/avatar.svg'}
-        alt="Profile avatar"
-        className="mx-auto mb-2 h-12 w-12 rounded-full"
-      />
+      <div
+        className="mx-auto mb-2 rounded-lg p-[2px]"
+        style={{ background: 'linear-gradient(145deg, #2a2a2a, #1c1c1c)' }}
+      >
+        <img
+          src={profile?.picture || '/avatar.svg'}
+          alt="Profile avatar"
+          className="h-20 w-20 rounded-lg"
+        />
+      </div>
       <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">@{name}</div>
       <Link href="/en/settings#profile" className="text-xs text-[var(--accent)]">
         Manage profile

--- a/apps/web/components/ProfileHeader.tsx
+++ b/apps/web/components/ProfileHeader.tsx
@@ -14,17 +14,28 @@ interface ProfileHeaderProps {
 export const ProfileHeader: React.FC<ProfileHeaderProps> = ({ avatarUrl, name, lightningAddress, pubkey, zapTotal }) => {
   const online = useOffline();
   return (
-    <div className="flex items-center space-x-3 p-4">
-      <Image
-        src={avatarUrl}
-        alt={name}
-        width={48}
-        height={48}
-        className="h-12 w-12 rounded-full"
-        unoptimized
+    <div className="flex flex-col items-center space-y-3 p-4 text-center">
+      <div
+        className="rounded-lg p-[2px]"
+        style={{ background: 'linear-gradient(145deg, #2a2a2a, #1c1c1c)' }}
+      >
+        <Image
+          src={avatarUrl}
+          alt={name}
+          width={80}
+          height={80}
+          className="h-20 w-20 rounded-lg"
+          unoptimized
+        />
+      </div>
+      <div className="font-semibold">{name}</div>
+      <ZapButton
+        lightningAddress={lightningAddress}
+        pubkey={pubkey}
+        total={zapTotal}
+        disabled={!online}
+        title={!online ? 'Offline – reconnect to interact.' : undefined}
       />
-      <div className="flex-1 font-semibold">{name}</div>
-      <ZapButton lightningAddress={lightningAddress} pubkey={pubkey} total={zapTotal} disabled={!online} title={!online ? 'Offline – reconnect to interact.' : undefined} />
     </div>
   );
 };

--- a/apps/web/components/TopNavProfile.tsx
+++ b/apps/web/components/TopNavProfile.tsx
@@ -16,11 +16,16 @@ export default function TopNavProfile() {
   };
 
   return (
-    <img
-      src={profile?.picture || '/avatar.svg'}
-      alt="Profile avatar"
-      className="h-8 w-8 rounded-full cursor-pointer"
+    <div
       onClick={handleClick}
-    />
+      className="cursor-pointer rounded-lg p-[2px]"
+      style={{ background: 'linear-gradient(145deg, #2a2a2a, #1c1c1c)' }}
+    >
+      <img
+        src={profile?.picture || '/avatar.svg'}
+        alt="Profile avatar"
+        className="h-20 w-20 rounded-lg"
+      />
+    </div>
   );
 }

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -104,7 +104,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-4">
       <h1 className="text-2xl mb-4">Set up your profile</h1>
-      <div className="w-full max-w-md space-y-3">
+      <div className="w-full max-w-md space-y-3 flex flex-col items-center text-center">
         <input
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -134,7 +134,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
           </div>
         )}
         {rawImage && (
-          <div className="flex gap-2">
+          <div className="flex gap-2 justify-center">
             <input
               type="range"
               min={1}
@@ -149,7 +149,12 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
           </div>
         )}
         {!rawImage && picture && (
-          <img src={picture} alt="avatar" className="h-24 w-24 rounded-full object-cover" />
+          <div
+            className="rounded-lg p-[2px]"
+            style={{ background: 'linear-gradient(145deg, #2a2a2a, #1c1c1c)' }}
+          >
+            <img src={picture} alt="avatar" className="h-20 w-20 rounded-lg object-cover" />
+          </div>
         )}
         <Button
           onClick={saveProfile}


### PR DESCRIPTION
## Summary
- enlarge profile avatar to 80px and wrap in gradient container
- center profile headers and cards for balanced layout

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68966b5a91b48331a89e2bdc83dffbea