### PR TITLE
Add skeleton loading placeholders with shimmer animation

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 import { useSpring, animated, useGesture } from '@paiduan/ui';
 import { VideoCard, VideoCardProps } from './VideoCard';
 import EmptyState from './EmptyState';
+import { SkeletonVideoCard } from './ui/SkeletonVideoCard';
 
 interface FeedProps {
   items: VideoCardProps[];
+  loading?: boolean;
 }
 
-export const Feed: React.FC<FeedProps> = ({ items }) => {
+export const Feed: React.FC<FeedProps> = ({ items, loading }) => {
   const [index, setIndex] = useState(0);
   const [{ y }, api] = useSpring(() => ({ y: 0 }));
 
@@ -31,6 +33,14 @@ export const Feed: React.FC<FeedProps> = ({ items }) => {
   useEffect(() => {
     api.start({ y: -index * 100 });
   }, [index]);
+
+  if (loading) {
+    return (
+      <div className="h-full w-full">
+        <SkeletonVideoCard />
+      </div>
+    );
+  }
 
   if (items.length === 0) {
     return (

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -8,6 +8,7 @@ import CommentDrawer from './CommentDrawer';
 import ReportModal from './ReportModal';
 import Link from 'next/link';
 import Image from 'next/image';
+import { Skeleton } from './ui/Skeleton';
 import { SimplePool } from 'nostr-tools/pool';
 import useFollowing from '../hooks/useFollowing';
 import toast from 'react-hot-toast';
@@ -19,10 +20,9 @@ import { useCurrentVideo } from '../hooks/useCurrentVideo';
 import { useFeedSelection } from '@/store/feedSelection';
 import { getRelays } from '@/lib/nostr';
 
-const MoreVertical = dynamic(
-  () => import('lucide-react').then((mod) => mod.MoreVertical),
-  { ssr: false },
-);
+const MoreVertical = dynamic(() => import('lucide-react').then((mod) => mod.MoreVertical), {
+  ssr: false,
+});
 
 export interface VideoCardProps {
   videoUrl: string;
@@ -101,7 +101,6 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       setSelectedVideo(eventId, pubkey);
     }
   }, [inView, setCurrent, setSelectedVideo, eventId, pubkey, caption, posterUrl]);
-
 
   const bind = useGesture(
     {
@@ -226,7 +225,12 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           disabled={!online}
           title={!online ? 'Offline – reconnect to interact.' : undefined}
         />
-        <button onClick={handleShare} className="hover:text-accent disabled:opacity-50" disabled={!online} title={!online ? 'Offline – reconnect to interact.' : undefined}>
+        <button
+          onClick={handleShare}
+          className="hover:text-accent disabled:opacity-50"
+          disabled={!online}
+          title={!online ? 'Offline – reconnect to interact.' : undefined}
+        >
           <Share2 />
         </button>
       </div>
@@ -243,7 +247,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
               unoptimized
             />
           ) : (
-            <div className="h-10 w-10 rounded-full bg-foreground/20" />
+            <Skeleton className="h-10 w-10 rounded-full" />
           )}
           <div className="font-semibold">@{displayName}</div>
         </Link>

--- a/apps/web/components/comments/Thread.tsx
+++ b/apps/web/components/comments/Thread.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useThread } from '@/hooks/useThread';
 import { useProfile } from '@/hooks/useProfile';
+import { SkeletonComment } from '../ui/SkeletonComment';
 
 export default function Thread({
   rootId,
@@ -38,7 +39,12 @@ export default function Thread({
             <div className="text-sm">{n.content}</div>
           </div>
         ))}
-        {loading && <div className="text-sm text-muted-foreground">Loading…</div>}
+        {loading && (
+          <>
+            <SkeletonComment />
+            <SkeletonComment />
+          </>
+        )}
         {err && <div className="text-sm text-red-600">{err}</div>}
       </div>
 

--- a/apps/web/components/ui/Skeleton.tsx
+++ b/apps/web/components/ui/Skeleton.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export function Skeleton({ className = '' }: { className?: string }) {
+  return (
+    <div className={`relative overflow-hidden rounded bg-foreground/10 ${className}`}>
+      <div className="absolute inset-0 -translate-x-full animate-[shimmer_2s_infinite] bg-gradient-to-r from-transparent via-foreground/20 to-transparent" />
+    </div>
+  );
+}
+
+export default Skeleton;

--- a/apps/web/components/ui/SkeletonComment.tsx
+++ b/apps/web/components/ui/SkeletonComment.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Skeleton from './Skeleton';
+
+export function SkeletonComment() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-4 w-1/3" />
+      <Skeleton className="h-3 w-full" />
+    </div>
+  );
+}
+
+export default SkeletonComment;

--- a/apps/web/components/ui/SkeletonVideoCard.tsx
+++ b/apps/web/components/ui/SkeletonVideoCard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Skeleton from './Skeleton';
+
+export function SkeletonVideoCard() {
+  return (
+    <div className="relative h-full w-full overflow-hidden rounded-2xl bg-foreground/10">
+      <Skeleton className="h-full w-full" />
+      <div className="absolute bottom-0 left-0 w-full p-4">
+        <div className="flex items-center space-x-3">
+          <Skeleton className="h-10 w-10 rounded-full" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <Skeleton className="mt-2 h-4 w-3/4" />
+      </div>
+    </div>
+  );
+}
+
+export default SkeletonVideoCard;

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -20,58 +20,104 @@
   --border: 220 12% 20%;
 }
 
-body { background: hsl(var(--background)); color: hsl(var(--foreground)); }
+body {
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+}
 
 @layer utilities {
-  .text-foreground { color: hsl(var(--foreground)); }
-  .bg-app { background: hsl(var(--background)); }
-  .break-inside-avoid { break-inside: avoid; }
+  .text-foreground {
+    color: hsl(var(--foreground));
+  }
+  .bg-app {
+    background: hsl(var(--background));
+  }
+  .break-inside-avoid {
+    break-inside: avoid;
+  }
 }
 
 /* Button system — works in light & dark */
 @layer components {
-  .btn { @apply px-4 py-2.5 rounded-xl font-medium focus-visible:outline-none focus-visible:ring-2 ring-offset-2; }
-  .btn-primary {
-    background: hsl(var(--accent)); color: white;
+  .btn {
+    @apply px-4 py-2.5 rounded-xl font-medium focus-visible:outline-none focus-visible:ring-2 ring-offset-2;
   }
-  .btn-secondary { @apply border border-current text-current bg-transparent; }
+  .btn-primary {
+    background: hsl(var(--accent));
+    color: white;
+  }
+  .btn-secondary {
+    @apply border border-current text-current bg-transparent;
+  }
   .btn-danger {
-    background: #ef4444; color: white;
+    background: #ef4444;
+    color: white;
   }
   .btn-ghost {
-    background: transparent; color: hsl(var(--foreground));
+    background: transparent;
+    color: hsl(var(--foreground));
   }
 }
 
 @layer base {
   :root {
     --bg: 255 255 255;
-    --foreground: 17 24 39;         /* slate-900-ish */
+    --foreground: 17 24 39; /* slate-900-ish */
     --muted-foreground: 107 114 128; /* slate-500 */
     --card: 255 255 255;
-    --border: 229 231 235;           /* gray-200 */
+    --border: 229 231 235; /* gray-200 */
   }
   .dark {
     --bg: 17 17 17;
-    --foreground: 243 244 246;       /* gray-100 */
+    --foreground: 243 244 246; /* gray-100 */
     --muted-foreground: 156 163 175; /* gray-400 */
-    --card: 24 24 27;                /* zinc-900 */
-    --border: 39 39 42;              /* zinc-800 */
+    --card: 24 24 27; /* zinc-900 */
+    --border: 39 39 42; /* zinc-800 */
   }
 
-  html, body { background-color: rgb(var(--bg)); color: rgb(var(--foreground)); }
+  html,
+  body {
+    background-color: rgb(var(--bg));
+    color: rgb(var(--foreground));
+  }
 }
 
 @layer utilities {
-  .text-foreground { color: rgb(var(--foreground)); }
-  .text-muted-foreground { @apply text-foreground opacity-60; }
-  .bg-app { background-color: rgb(var(--bg)); }
-  .bg-card { background-color: rgb(var(--card)); }
-  .border-token { border-color: rgb(var(--border)); }
+  .text-foreground {
+    color: rgb(var(--foreground));
+  }
+  .text-muted-foreground {
+    @apply text-foreground opacity-60;
+  }
+  .bg-app {
+    background-color: rgb(var(--bg));
+  }
+  .bg-card {
+    background-color: rgb(var(--card));
+  }
+  .border-token {
+    border-color: rgb(var(--border));
+  }
 }
 
-:root { --accent: #7c3aed; }
-[data-accent="violet"] { --accent:#7c3aed; }
-[data-accent="blue"]   { --accent:#2563eb; }
-[data-accent="green"]  { --accent:#16a34a; }
-[data-accent="pink"]   { --accent:#db2777; }
+:root {
+  --accent: #7c3aed;
+}
+[data-accent='violet'] {
+  --accent: #7c3aed;
+}
+[data-accent='blue'] {
+  --accent: #2563eb;
+}
+[data-accent='green'] {
+  --accent: #16a34a;
+}
+[data-accent='pink'] {
+  --accent: #db2777;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `Skeleton`, `SkeletonVideoCard`, and `SkeletonComment` components with shimmer effect
- swap text loaders in feed, video card, and comment thread for skeleton placeholders
- define `shimmer` keyframes in global styles for animated skeletons

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68966c49324883318d014f152cb8c16c