### PR TITLE
Refine nav typography and follower metrics styling

### DIFF
--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -23,7 +23,11 @@ export default function NavBar() {
           <Link
             key={href}
             href={href}
-            className="flex flex-col items-center py-2 text-sm text-white/80"
+            className={`flex flex-col items-center px-3 py-2 rounded-md text-[1.2rem] font-bold focus:outline-none focus-visible:bg-accent/20 focus-visible:text-accent ${
+              active
+                ? 'bg-accent/20 text-accent'
+                : 'text-muted-foreground hover:bg-accent/10 hover:text-accent'
+            }`}
             aria-current={active ? 'page' : undefined}
           >
             <motion.div
@@ -32,7 +36,7 @@ export default function NavBar() {
             >
               {icon}
             </motion.div>
-            <span className={active ? 'text-white' : ''}>{label}</span>
+            <span>{label}</span>
           </Link>
         );
       })}

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -24,8 +24,10 @@ export default function SideNav() {
             <li key={href} className={desktopOnly ? 'hidden lg:block' : ''}>
               <Link
                 href={href}
-                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm ${
-                  isActive ? 'bg-white/10 text-white' : 'text-muted-foreground hover:bg-white/5'
+                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-[1.2rem] font-bold focus:outline-none focus-visible:bg-accent/20 focus-visible:text-accent ${
+                  isActive
+                    ? 'bg-accent/20 text-accent'
+                    : 'text-muted-foreground hover:bg-accent/10 hover:text-accent'
                 }`}
                 aria-current={isActive ? 'page' : undefined}
               >

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -21,7 +21,9 @@ export default function RightPanel({
             <div>
               <div className="font-semibold">{author.name}</div>
               <div className="text-sm text-muted-foreground">@{author.username}</div>
-              <div className="text-xs text-muted-foreground mt-1">{author.followers.toLocaleString()} followers</div>
+              <div className="text-[0.9rem] font-light text-muted-foreground mt-1">
+                {author.followers.toLocaleString()} followers
+              </div>
               <div className="mt-3 flex gap-2">
                 <Link href={`/p/${author.pubkey}`} className="btn btn-secondary">
                   View profile

--- a/apps/web/components/layout/LeftNav.tsx
+++ b/apps/web/components/layout/LeftNav.tsx
@@ -5,6 +5,7 @@ import MiniProfileCard from '@/components/MiniProfileCard';
 import NotificationBell from '@/components/NotificationBell';
 import { useTheme } from '@/context/themeContext';
 import { Sun, Moon } from 'lucide-react';
+import { useRouter } from 'next/router';
 
 export default function LeftNav({
   me,
@@ -17,6 +18,7 @@ export default function LeftNav({
   };
 }) {
   const { mode, toggleMode } = useTheme();
+  const { asPath } = useRouter();
 
   return (
     <div className="space-y-6">
@@ -29,38 +31,29 @@ export default function LeftNav({
       {/* Nav */}
       <nav className="bg-card border border-token rounded-2xl p-2">
         <ul className="flex flex-col">
-          <li>
-            <Link
-              className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block"
-              href="/feed"
-            >
-              Home
-            </Link>
-          </li>
-          <li>
-            <Link
-              className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block"
-              href="/following"
-            >
-              Following
-            </Link>
-          </li>
-          <li>
-            <Link
-              className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block"
-              href="/create"
-            >
-              Create
-            </Link>
-          </li>
-          <li>
-            <Link
-              className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 inline-block"
-              href="/settings"
-            >
-              Settings
-            </Link>
-          </li>
+          {[
+            { href: '/feed', label: 'Home' },
+            { href: '/following', label: 'Following' },
+            { href: '/create', label: 'Create' },
+            { href: '/settings', label: 'Settings' },
+          ].map(({ href, label }) => {
+            const active = asPath.startsWith(href);
+            return (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={`px-3 py-2 rounded-lg text-[1.2rem] font-bold focus:outline-none focus-visible:bg-accent/20 focus-visible:text-accent ${
+                    active
+                      ? 'bg-accent/20 text-accent'
+                      : 'text-muted-foreground hover:bg-accent/10 hover:text-accent'
+                  }`}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {label}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       </nav>
 
@@ -79,11 +72,11 @@ export default function LeftNav({
       <div className="bg-card border border-token rounded-2xl p-4 text-sm">
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground">Followers</span>
-          <span className="font-medium">{me.stats.followers.toLocaleString()}</span>
+          <span className="text-[0.9rem] font-light">{me.stats.followers.toLocaleString()}</span>
         </div>
         <div className="flex items-center justify-between mt-1">
           <span className="text-muted-foreground">Following</span>
-          <span className="font-medium">{me.stats.following.toLocaleString()}</span>
+          <span className="text-[0.9rem] font-light">{me.stats.following.toLocaleString()}</span>
         </div>
         <Link href="/settings" className="mt-3 inline-block text-sm underline">
           Profile settings


### PR DESCRIPTION
## Summary
- Increase main nav item size to 1.2rem bold and highlight active links with accent background/colour
- Add focus-visible styles so nav links remain keyboard navigable
- Use lighter 0.9rem text for follower/following counts in nav and right panel

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68966cc347a083319f1465b5f72c51c4