### PR TITLE
Relax creator wizard width for responsive metadata layout

### DIFF
--- a/apps/web/components/create/CreatorWizard.tsx
+++ b/apps/web/components/create/CreatorWizard.tsx
@@ -10,7 +10,7 @@ export default function CreatorWizard() {
   };
 
   return (
-    <main className="max-w-2xl mx-auto py-12 px-4 space-y-6">
+    <main className="mx-auto py-12 px-4 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">Create Video</h1>
       </div>

--- a/apps/web/components/create/MetadataStep.tsx
+++ b/apps/web/components/create/MetadataStep.tsx
@@ -80,7 +80,7 @@ export function MetadataStep({ blob, preview, onBack, onCancel }: MetadataStepPr
   }
 
   return (
-    <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
+    <section className="max-w-4xl mx-auto rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <button className="btn btn-secondary" onClick={onBack}>

--- a/project_spec.md
+++ b/project_spec.md
@@ -52,8 +52,7 @@ Modernise Creator Wizard UI, fix tool loading/trim bugs, add recording option, a
 | 7   | Poster capture     | Frame capture via `<canvas>`; store as JPEG/WebP; attach to upload payload.                                                                                                        |
 | 8   | Upload flow        | POST video + poster to `nostr.media/api/upload`; show progress; capture `video`, `poster` & `manifest` URLs and publish kind‑30023 event with `v`, `image`, `vman`, optional `zap` and one `t` tag per topic.                                                                                  |
 | 9   | Error handling     | Toasts for FFmpeg load failure, file type issues, upload errors.                                                                                                                   |
-| 10  | Responsive design  | Wizard, video preview, and controls adapt cleanly to mobile/desktop.                                                                                                               |
-
+| 10  | Responsive design  | Wizard lets steps manage their own widths; metadata step displays preview and fields side-by-side on large (`lg`) screens. |
 ### Acceptance Criteria
 
 - CreatorWizard first screen is option chooser.


### PR DESCRIPTION
## Summary
- Allow creator wizard to stretch to full width so individual steps can size themselves
- Center metadata step with its own max width and keep preview/fields side by side on large screens
- Document responsive layout expectation in project spec

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68966d6a1724833195bf550e1f93a3f6