### PR TITLE
feat: soften accent color and improve nav highlights

### DIFF
--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -26,7 +26,7 @@ export default function NavBar() {
             className={`flex flex-col items-center px-3 py-2 rounded-md text-[1.2rem] font-bold focus:outline-none focus-visible:bg-accent/20 focus-visible:text-accent ${
               active
                 ? 'bg-accent/20 text-accent'
-                : 'text-muted-foreground hover:bg-accent/10 hover:text-accent'
+                : 'text-muted-foreground hover:bg-accent/20 hover:text-accent'
             }`}
             aria-current={active ? 'page' : undefined}
           >

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -27,7 +27,7 @@ export default function SideNav() {
                 className={`flex items-center gap-2 px-3 py-2 rounded-lg text-[1.2rem] font-bold focus:outline-none focus-visible:bg-accent/20 focus-visible:text-accent ${
                   isActive
                     ? 'bg-accent/20 text-accent'
-                    : 'text-muted-foreground hover:bg-accent/10 hover:text-accent'
+                    : 'text-muted-foreground hover:bg-accent/20 hover:text-accent'
                 }`}
                 aria-current={isActive ? 'page' : undefined}
               >

--- a/apps/web/components/layout/LeftNav.tsx
+++ b/apps/web/components/layout/LeftNav.tsx
@@ -45,7 +45,7 @@ export default function LeftNav({
                   className={`px-3 py-2 rounded-lg text-[1.2rem] font-bold focus:outline-none focus-visible:bg-accent/20 focus-visible:text-accent ${
                     active
                       ? 'bg-accent/20 text-accent'
-                      : 'text-muted-foreground hover:bg-accent/10 hover:text-accent'
+                      : 'text-muted-foreground hover:bg-accent/20 hover:text-accent'
                   }`}
                   aria-current={active ? 'page' : undefined}
                 >
@@ -61,7 +61,7 @@ export default function LeftNav({
       <div className="bg-card border border-token rounded-2xl p-2 flex items-center justify-between">
         <button
           onClick={toggleMode}
-          className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10"
+          className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 focus-visible:bg-white/50 dark:focus-visible:bg-white/10"
         >
           {mode === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
         </button>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -8,7 +8,7 @@
   --foreground: 220 14% 12%;
   --surface: 0 0% 100%;
   --muted: 220 9% 46%;
-  --accent: 262 83% 58%;
+  --accent: 273 68% 59%;
   --border: 220 13% 91%;
 }
 .dark {
@@ -16,7 +16,7 @@
   --foreground: 220 15% 92%;
   --surface: 220 12% 12%;
   --muted: 220 10% 70%;
-  --accent: 262 83% 58%;
+  --accent: 273 68% 59%;
   --border: 220 12% 20%;
 }
 
@@ -101,10 +101,10 @@ body {
 }
 
 :root {
-  --accent: #7c3aed;
+  --accent: #9d4edd;
 }
 [data-accent='violet'] {
-  --accent: #7c3aed;
+  --accent: #9d4edd;
 }
 [data-accent='blue'] {
   --accent: #2563eb;

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
         accent: 'hsl(var(--accent))',
         border: 'hsl(var(--border))',
         brand: {
-          DEFAULT: '#7c3aed',
+          DEFAULT: '#9d4edd',
           surface: '#1a1b1f',
           panel: '#202125',
         },


### PR DESCRIPTION
## Summary
- switch brand accent to softer purple (#9d4edd)
- add hover and focus-visible background cues for nav links and theme toggle

## Testing
- `pnpm lint`
- `pnpm test`
- `node contrast ratio script`

------
https://chatgpt.com/codex/tasks/task_e_68966eb7f8bc83318eab71ddad670d3f