### PR TITLE
Adjust navigation spacing and add empty feed CTA

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -3,6 +3,7 @@ import { useSpring, animated, useGesture } from '@paiduan/ui';
 import { VideoCard, VideoCardProps } from './VideoCard';
 import EmptyState from './EmptyState';
 import { SkeletonVideoCard } from './ui/SkeletonVideoCard';
+import Link from 'next/link';
 
 interface FeedProps {
   items: VideoCardProps[];
@@ -46,7 +47,9 @@ export const Feed: React.FC<FeedProps> = ({ items, loading }) => {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center text-white">
         <EmptyState />
-        <p className="mt-4">Be the first to upload!</p>
+        <Link href="/create" className="btn btn-primary mt-4">
+          Upload your first video
+        </Link>
       </div>
     );
   }

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -13,7 +13,7 @@ export default function RightPanel({
 }) {
   const { selectedVideoId, selectedVideoAuthor } = useFeedSelection();
   return (
-    <div className="space-y-6">
+    <div className="p-[1.2rem] space-y-4">
       {author && (
         <div className="bg-card border border-token rounded-2xl p-4">
           <div className="flex gap-3">

--- a/apps/web/components/layout/LeftNav.tsx
+++ b/apps/web/components/layout/LeftNav.tsx
@@ -21,7 +21,7 @@ export default function LeftNav({
   const { asPath } = useRouter();
 
   return (
-    <div className="space-y-6">
+    <div className="p-[1.2rem] space-y-4">
       {/* Search */}
       <SearchBar showActions={false} />
 


### PR DESCRIPTION
## Summary
- tighten spacing and add padding for left navigation and right panel containers
- show illustration with call-to-action button when feed is empty

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896712a8bcc83319ca8d5e33a16e6fd