### PR TITLE
Add lightning address management

### DIFF
--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -15,6 +15,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
   const [name, setName] = useState('');
   const [about, setAbout] = useState('');
   const [picture, setPicture] = useState<string>('');
+  const [lud16, setLud16] = useState('');
   const [rawImage, setRawImage] = useState<string>('');
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
@@ -26,6 +27,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
     if (!name) setName(meta.name || '');
     if (!about) setAbout(meta.about || '');
     if (!picture) setPicture(meta.picture || '');
+    if (!lud16) setLud16(meta.lud16 || '');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [meta]);
 
@@ -75,7 +77,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
     setRawImage('');
   }, [rawImage, croppedArea]);
 
-  async function setMetadata(data: { name?: string; about?: string; picture?: string }) {
+  async function setMetadata(data: { name?: string; about?: string; picture?: string; lud16?: string }) {
     if (state.status !== 'ready') throw new Error('Not signed in');
     const content = JSON.stringify(data);
     const tmpl: EventTemplate = {
@@ -92,7 +94,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
   async function saveProfile() {
     try {
       setLoading(true);
-      await setMetadata({ name, about, picture });
+      await setMetadata({ name, about, picture, lud16 });
       setLoading(false);
       onComplete();
     } catch (e: any) {
@@ -115,6 +117,12 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
           value={about}
           onChange={(e) => setAbout(e.target.value)}
           placeholder="Bio"
+          className="w-full rounded border-token border p-2 bg-card text-foreground"
+        />
+        <input
+          value={lud16}
+          onChange={(e) => setLud16(e.target.value)}
+          placeholder="Lightning Address"
           className="w-full rounded border-token border p-2 bg-card text-foreground"
         />
         <input type="file" accept="image/*" onChange={handleFile} />

--- a/apps/web/components/settings/LightningCard.tsx
+++ b/apps/web/components/settings/LightningCard.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import type { EventTemplate } from 'nostr-tools/pure';
+import { useAuth } from '@/hooks/useAuth';
+import { useProfile } from '@/hooks/useProfile';
+import { getPool, getRelays } from '@/lib/nostr';
+import { Card } from '../ui/Card';
+
+export function LightningCard() {
+  const { state } = useAuth();
+  const meta = useProfile(state.status === 'ready' ? state.pubkey : undefined);
+  const [addr, setAddr] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (meta?.lud16) setAddr(meta.lud16);
+  }, [meta]);
+
+  async function save() {
+    if (state.status !== 'ready') return;
+    try {
+      setSaving(true);
+      const content = JSON.stringify({ ...(meta || {}), lud16: addr });
+      const tmpl: EventTemplate = {
+        kind: 0,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [],
+        content,
+      };
+      const signed = await state.signer.signEvent({ ...tmpl });
+      const pool = getPool();
+      await pool.publish(getRelays(), signed as any);
+      setSaving(false);
+    } catch (e: any) {
+      alert(e.message || 'Failed to save');
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card title="Lightning Address" desc="Set your default lightning address.">
+      <div className="space-y-3">
+        <input
+          type="text"
+          value={addr}
+          onChange={(e) => setAddr(e.target.value)}
+          placeholder="name@example.com"
+          className="w-full rounded bg-foreground/10 p-2 text-sm outline-none"
+        />
+        <button
+          type="button"
+          onClick={save}
+          className="btn btn-secondary"
+          disabled={saving || state.status !== 'ready'}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </Card>
+  );
+}
+
+export default LightningCard;
+

--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -22,5 +22,5 @@ export function useProfile(pubkey?: string) {
     );
     return () => sub.close();
   }, [pubkey]);
-  return meta as { name?: string; picture?: string; about?: string } | null;
+  return meta as { name?: string; picture?: string; about?: string; lud16?: string } | null;
 }

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -3,6 +3,7 @@ import SideNav from '../components/SideNav';
 import { Accordion } from '../components/ui/Accordion';
 import { KeysCard } from '../components/settings/KeysCard';
 import { AccountCard } from '@/components/settings/AccountCard';
+import { LightningCard } from '../components/settings/LightningCard';
 import { NetworkCard } from '../components/settings/NetworkCard';
 import { AppearanceCard } from '../components/settings/AppearanceCard';
 import { LanguageCard } from '@/components/settings/LanguageCard';
@@ -23,6 +24,7 @@ export default function Settings() {
                 <div className="space-y-6">
                   <KeysCard />
                   <AccountCard />
+                  <LightningCard />
                   <NetworkCard />
                 </div>
               ),


### PR DESCRIPTION
## Summary
- extend onboarding profile setup with lightning address field
- expose lud16 in useProfile hook
- allow viewing and updating the lightning address in settings

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896716635f88331b11e856be5b039cc