### PR TITLE
refactor: add reusable card style

### DIFF
--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
+import { cardStyle } from '@/components/ui/Card';
 
 export default function MiniProfileCard() {
   const { state } = useAuth();
@@ -8,7 +9,7 @@ export default function MiniProfileCard() {
   const name = profile?.name || 'user';
 
   return (
-    <div className="rounded-xl border border-gray-200/60 dark:border-gray-700/60 p-3 text-center">
+    <div className={`${cardStyle} p-3 text-center`}>
       <div
         className="mx-auto mb-2 rounded-lg p-[2px]"
         style={{ background: 'linear-gradient(145deg, #2a2a2a, #1c1c1c)' }}

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Link from 'next/link';
 import Thread from '@/components/comments/Thread';
 import { useFeedSelection } from '@/store/feedSelection';
+import { cardStyle } from '@/components/ui/Card';
 
 export default function RightPanel({
   author,
@@ -15,7 +16,7 @@ export default function RightPanel({
   return (
     <div className="p-[1.2rem] space-y-4">
       {author && (
-        <div className="bg-card border border-token rounded-2xl p-4">
+        <div className={`${cardStyle} p-4`}>
           <div className="flex gap-3">
             <img src={author.avatar} className="w-12 h-12 rounded-full object-cover" alt="" />
             <div>
@@ -37,7 +38,7 @@ export default function RightPanel({
         </div>
       )}
 
-      <div className="bg-card border border-token rounded-2xl p-0">
+      <div className={`${cardStyle} p-0`}>
         <Thread rootId={selectedVideoId} authorPubkey={selectedVideoAuthor} />
       </div>
     </div>

--- a/apps/web/components/layout/LeftNav.tsx
+++ b/apps/web/components/layout/LeftNav.tsx
@@ -6,6 +6,7 @@ import NotificationBell from '@/components/NotificationBell';
 import { useTheme } from '@/context/themeContext';
 import { Sun, Moon } from 'lucide-react';
 import { useRouter } from 'next/router';
+import { cardStyle } from '@/components/ui/Card';
 
 export default function LeftNav({
   me,
@@ -29,7 +30,7 @@ export default function LeftNav({
       <MiniProfileCard />
 
       {/* Nav */}
-      <nav className="bg-card border border-token rounded-2xl p-2">
+      <nav className={`${cardStyle} p-2`}>
         <ul className="flex flex-col">
           {[
             { href: '/feed', label: 'Home' },
@@ -58,7 +59,7 @@ export default function LeftNav({
       </nav>
 
       {/* Actions */}
-      <div className="bg-card border border-token rounded-2xl p-2 flex items-center justify-between">
+      <div className={`${cardStyle} p-2 flex items-center justify-between`}>
         <button
           onClick={toggleMode}
           className="px-3 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 focus-visible:bg-white/50 dark:focus-visible:bg-white/10"
@@ -69,7 +70,7 @@ export default function LeftNav({
       </div>
 
       {/* Stats */}
-      <div className="bg-card border border-token rounded-2xl p-4 text-sm">
+      <div className={`${cardStyle} p-4 text-sm`}>
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground">Followers</span>
           <span className="text-[0.9rem] font-light">{me.stats.followers.toLocaleString()}</span>

--- a/apps/web/components/ui/Card.tsx
+++ b/apps/web/components/ui/Card.tsx
@@ -1,8 +1,22 @@
 import React from 'react';
+import clsx from 'clsx';
 
-export function Card({ title, desc, children }: { title: string; desc?: string; children: React.ReactNode }) {
+export const cardStyle =
+  'bg-[#1e1e1e] rounded-[10px] shadow-[0_2px_8px_rgba(0,0,0,0.3)]';
+
+export function Card({
+  title,
+  desc,
+  children,
+  className,
+}: {
+  title: string;
+  desc?: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
   return (
-    <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 shadow-sm space-y-4">
+    <section className={clsx(cardStyle, 'p-6 space-y-4', className)}>
       <header>
         <h2 className="text-lg font-semibold">{title}</h2>
         {desc && <p className="text-sm text-muted-foreground">{desc}</p>}


### PR DESCRIPTION
## Summary
- add reusable `cardStyle` utility for consistent cards
- update LeftNav, RightPanel, and MiniProfileCard to use new card style

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689672faec8c8331a56d1977585da6e4