### PR TITLE
Display profile follower stats in mini card

### DIFF
--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -3,7 +3,11 @@ import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { cardStyle } from '@/components/ui/Card';
 
-export default function MiniProfileCard() {
+export default function MiniProfileCard({
+  stats,
+}: {
+  stats?: { followers: number; following: number };
+}) {
   const { state } = useAuth();
   const profile = useProfile(state.status === 'ready' ? state.pubkey : undefined);
   const name = profile?.name || 'user';
@@ -16,6 +20,11 @@ export default function MiniProfileCard() {
         className="mx-auto mb-2 h-20 w-20 rounded-full"
       />
       <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">@{name}</div>
+      {stats && (
+        <div className="mt-1 text-xs text-muted-foreground">
+          {stats.followers.toLocaleString()} followers • {stats.following.toLocaleString()} following
+        </div>
+      )}
       <Link href="/en/settings#profile" className="text-xs text-[var(--accent)]">
         Manage profile
       </Link>

--- a/apps/web/components/layout/LeftNav.tsx
+++ b/apps/web/components/layout/LeftNav.tsx
@@ -27,7 +27,7 @@ export default function LeftNav({
       <SearchBar showActions={false} />
 
       {/* Profile mini card */}
-      <MiniProfileCard />
+      <MiniProfileCard stats={me.stats} />
 
       {/* Nav */}
       <nav className={`${cardStyle} p-2`}>
@@ -69,20 +69,6 @@ export default function LeftNav({
         <NotificationBell />
       </div>
 
-      {/* Stats */}
-      <div className={`${cardStyle} p-4 text-sm`}>
-        <div className="flex items-center justify-between">
-          <span className="text-muted-foreground">Followers</span>
-          <span className="text-[0.9rem] font-light">{me.stats.followers.toLocaleString()}</span>
-        </div>
-        <div className="flex items-center justify-between mt-1">
-          <span className="text-muted-foreground">Following</span>
-          <span className="text-[0.9rem] font-light">{me.stats.following.toLocaleString()}</span>
-        </div>
-        <Link href="/settings" className="mt-3 inline-block text-sm underline">
-          Profile settings
-        </Link>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- pass `me.stats` to `MiniProfileCard` from `LeftNav`
- remove sidebar stats block and show follower/following counts in `MiniProfileCard`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896767d2dc483319c51c0b47d7ad8f1