### PR TITLE
feat: combine upload and metadata on large screens

### DIFF
--- a/apps/web/components/create/MetadataStep.tsx
+++ b/apps/web/components/create/MetadataStep.tsx
@@ -10,9 +10,10 @@ export interface MetadataStepProps {
   preview?: string;
   onBack: () => void;
   onCancel: () => void;
+  inline?: boolean;
 }
 
-export function MetadataStep({ blob, preview, onBack, onCancel }: MetadataStepProps) {
+export function MetadataStep({ blob, preview, onBack, onCancel, inline }: MetadataStepProps) {
   const [caption, setCaption] = useState('');
   const [topics, setTopics] = useState('');
   const [copyright, setCopyright] = useState('');
@@ -110,6 +111,66 @@ export function MetadataStep({ blob, preview, onBack, onCancel }: MetadataStepPr
     onCancel();
   }
 
+  const form = (
+    <>
+      <input
+        type="text"
+        value={caption}
+        onChange={(e) => setCaption(e.target.value)}
+        placeholder="Caption"
+        className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
+      />
+      <input
+        type="text"
+        value={topics}
+        onChange={(e) => setTopics(e.target.value)}
+        placeholder="Topic tags (comma separated)"
+        className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
+      />
+      <label className="block text-sm">
+        <span className="mb-1 block">Lightning address</span>
+        {showZapSelect && (
+          <select
+            value={selectedZapOption}
+            onChange={(e) => setLightningAddress(e.target.value)}
+            className="block w-full border rounded px-3 py-2 bg-transparent mb-2"
+          >
+            {zapOptions.map((addr) => (
+              <option key={addr} value={addr}>
+                {addr}
+              </option>
+            ))}
+            <option value="">Other...</option>
+          </select>
+        )}
+        <input
+          type="text"
+          value={lightningAddress}
+          onChange={(e) => setLightningAddress(e.target.value)}
+          className="block w-full border rounded px-3 py-2 bg-transparent"
+        />
+      </label>
+      <input
+        type="text"
+        value={copyright}
+        onChange={(e) => setCopyright(e.target.value)}
+        placeholder="Copyright information"
+        className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
+      />
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={nsfw} onChange={(e) => setNsfw(e.target.checked)} />
+        <span className="text-sm">NSFW</span>
+      </label>
+      <button className="btn btn-primary disabled:opacity-60" disabled={busy} onClick={postVideo}>
+        {busy ? 'Posting…' : 'Post Video'}
+      </button>
+    </>
+  );
+
+  if (inline) {
+    return <div className="space-y-4">{form}</div>;
+  }
+
   return (
     <section className="max-w-4xl mx-auto rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
       <div className="flex items-center justify-between">
@@ -131,59 +192,7 @@ export function MetadataStep({ blob, preview, onBack, onCancel }: MetadataStepPr
             className="rounded-xl w-full aspect-[9/16] object-cover bg-black lg:col-span-1"
           />
         )}
-        <div className="space-y-4 col-span-2 lg:col-span-1">
-          <input
-            type="text"
-            value={caption}
-            onChange={(e) => setCaption(e.target.value)}
-            placeholder="Caption"
-            className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
-          />
-          <input
-            type="text"
-            value={topics}
-            onChange={(e) => setTopics(e.target.value)}
-            placeholder="Topic tags (comma separated)"
-            className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
-          />
-          <label className="block text-sm">
-            <span className="mb-1 block">Lightning address</span>
-            {showZapSelect && (
-              <select
-                value={selectedZapOption}
-                onChange={(e) => setLightningAddress(e.target.value)}
-                className="block w-full border rounded px-3 py-2 bg-transparent mb-2"
-              >
-                {zapOptions.map((addr) => (
-                  <option key={addr} value={addr}>
-                    {addr}
-                  </option>
-                ))}
-                <option value="">Other...</option>
-              </select>
-            )}
-            <input
-              type="text"
-              value={lightningAddress}
-              onChange={(e) => setLightningAddress(e.target.value)}
-              className="block w-full border rounded px-3 py-2 bg-transparent"
-            />
-          </label>
-          <input
-            type="text"
-            value={copyright}
-            onChange={(e) => setCopyright(e.target.value)}
-            placeholder="Copyright information"
-            className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
-          />
-          <label className="flex items-center gap-2">
-            <input type="checkbox" checked={nsfw} onChange={(e) => setNsfw(e.target.checked)} />
-            <span className="text-sm">NSFW</span>
-          </label>
-          <button className="btn btn-primary disabled:opacity-60" disabled={busy} onClick={postVideo}>
-            {busy ? 'Posting…' : 'Post Video'}
-          </button>
-        </div>
+        <div className="space-y-4 col-span-2 lg:col-span-1">{form}</div>
       </div>
     </section>
   );

--- a/apps/web/components/create/UploadStep.tsx
+++ b/apps/web/components/create/UploadStep.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { trimVideoWebCodecs } from '@/utils/trimVideoWebCodecs';
 import { MetadataStep } from './MetadataStep';
 
@@ -10,6 +10,15 @@ export function UploadStep({ onBack, onCancel }: { onBack: () => void; onCancel:
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [step, setStep] = useState<'process' | 'metadata'>('process');
+  const [isLarge, setIsLarge] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 1024px)');
+    const listener = (e: MediaQueryListEvent) => setIsLarge(e.matches);
+    setIsLarge(mq.matches);
+    mq.addEventListener('change', listener);
+    return () => mq.removeEventListener('change', listener);
+  }, []);
 
   function onPick(e: React.ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0] ?? null;
@@ -27,7 +36,7 @@ export function UploadStep({ onBack, onCancel }: { onBack: () => void; onCancel:
       const blob = await trimVideoWebCodecs(file, 0);
       setOutBlob(blob);
       setPreview(URL.createObjectURL(blob));
-      setStep('metadata');
+      if (!isLarge) setStep('metadata');
     } catch (e) {
       console.error(e);
       setErr('Conversion failed.');
@@ -41,10 +50,10 @@ export function UploadStep({ onBack, onCancel }: { onBack: () => void; onCancel:
     onCancel();
   }
 
-  if (step === 'metadata' && outBlob) {
+  if (!isLarge && step === 'metadata' && outBlob) {
     return (
       <MetadataStep
-        blob={outBlob}
+        blob={outBlob!}
         preview={preview ?? undefined}
         onBack={() => setStep('process')}
         onCancel={onCancel}
@@ -52,49 +61,65 @@ export function UploadStep({ onBack, onCancel }: { onBack: () => void; onCancel:
     );
   }
 
+  const showMetadata = isLarge && outBlob;
+  const buttonLabel = busy
+    ? 'Processing…'
+    : isLarge
+    ? outBlob
+      ? 'Process Again'
+      : 'Process Video'
+    : file
+    ? 'Next'
+    : 'Convert to .webm';
+
   return (
-    <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <button className="btn btn-secondary" onClick={onBack}>
-            ← Back
+    <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4 lg:grid lg:grid-cols-2 lg:gap-6 lg:space-y-0">
+      <div className={`space-y-4 ${isLarge && !showMetadata ? 'lg:col-span-2' : ''}`}>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <button className="btn btn-secondary" onClick={onBack}>
+              ← Back
+            </button>
+            <h2 className="text-lg font-semibold">Upload a file</h2>
+          </div>
+          <button className="text-sm text-muted-foreground" onClick={handleCancel}>
+            Cancel
           </button>
-          <h2 className="text-lg font-semibold">Upload a file</h2>
         </div>
-        <button className="text-sm text-muted-foreground" onClick={handleCancel}>
-          Cancel
-        </button>
-      </div>
 
-      <input
-        type="file"
-        accept="video/*"
-        onChange={onPick}
-        className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
-      />
-
-      {preview && (
-        <video
-          controls
-          src={preview}
-          className="rounded-xl w-full aspect-[9/16] object-cover bg-black"
+        <input
+          type="file"
+          accept="video/*"
+          onChange={onPick}
+          className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
         />
-      )}
 
-      <div className="flex gap-3">
-        <button
-          className="btn btn-primary disabled:opacity-60"
-          disabled={!file || busy}
-          onClick={convert}
-        >
-          {busy ? 'Processing…' : file ? 'Next' : 'Convert to .webm'}
-        </button>
-      </div>
+        {preview && (
+          <video
+            controls
+            src={preview}
+            className="rounded-xl w-full aspect-[9/16] object-cover bg-black"
+          />
+        )}
 
-      {err && (
-        <div className="space-y-2">
-          <p className="text-sm text-red-500">{err}</p>
+        <div className="flex gap-3">
+          <button
+            className="btn btn-primary disabled:opacity-60"
+            disabled={!file || busy}
+            onClick={convert}
+          >
+            {buttonLabel}
+          </button>
         </div>
+
+        {err && (
+          <div className="space-y-2">
+            <p className="text-sm text-red-500">{err}</p>
+          </div>
+        )}
+      </div>
+      {showMetadata && (
+        <MetadataStep blob={outBlob!} onBack={() => {}} onCancel={onCancel} inline />
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
- Render upload and metadata steps side by side on `lg` screens
- Detect large screens with `matchMedia` and keep wizard on smaller viewports
- Add inline mode to `MetadataStep` for embedding its form

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web lint`


------
https://chatgpt.com/codex/tasks/task_e_689675ec2114833180d9a37bb3b059ea