### PR TITLE
Refine upload step button labels

### DIFF
--- a/apps/web/components/create/UploadStep.tsx
+++ b/apps/web/components/create/UploadStep.tsx
@@ -70,7 +70,7 @@ export function UploadStep({ onBack, onCancel }: { onBack: () => void; onCancel:
       : 'Process Video'
     : file
     ? 'Next'
-    : 'Convert to .webm';
+    : 'Select a file';
 
   return (
     <section className="rounded-2xl border bg-white/5 dark:bg-neutral-900 p-6 space-y-4 lg:grid lg:grid-cols-2 lg:gap-6 lg:space-y-0">


### PR DESCRIPTION
## Summary
- Replace confusing "Convert to .webm" default with "Select a file" in upload step
- Preserve clean transitions to "Processing…" and "Next" as the file is handled

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689677c87a808331af51c94b86c00e94