### PR TITLE
feat: standardize divider borders

### DIFF
--- a/apps/web/components/CommentDrawer.tsx
+++ b/apps/web/components/CommentDrawer.tsx
@@ -193,7 +193,7 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
       className="fixed inset-x-0 bottom-0 z-50 h-1/2 bg-background text-foreground"
       {...bind()}
     >
-      <div className="flex items-center justify-between border-b border-foreground/10 p-2">
+      <div className="flex items-center justify-between border-b divider p-2">
         <span className="font-semibold">Comments</span>
         <button onClick={onClose} className="p-1 hover:text-accent" aria-label="Close comments">
           <X />
@@ -279,7 +279,7 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
           </div>
         ))}
       </div>
-      <div className="absolute bottom-0 left-0 right-0 border-t border-foreground/10 p-2">
+      <div className="absolute bottom-0 left-0 right-0 border-t divider p-2">
         {replyTo && (
           <div className="mb-1 text-xs text-foreground/50">
             Replying to @{replyTo.pubkey.slice(0, 8)}{' '}

--- a/apps/web/components/NotificationDrawer.tsx
+++ b/apps/web/components/NotificationDrawer.tsx
@@ -28,7 +28,7 @@ const NotificationDrawer: React.FC = () => {
         open ? 'translate-y-0' : '-translate-y-full'
       }`}
     >
-      <div className="flex items-center justify-between border-b border-foreground/20 p-2">
+      <div className="flex items-center justify-between border-b divider p-2">
         <span className="font-semibold">Notifications</span>
         <button
           className="text-sm text-accent"
@@ -43,7 +43,7 @@ const NotificationDrawer: React.FC = () => {
       {notifications.map((n) => (
         <div
           key={n.id}
-          className="cursor-pointer border-b border-foreground/20 p-3"
+          className="cursor-pointer border-b divider p-3"
           onClick={() => handleClick(n.id, n.noteId)}
         >
           <div className="flex items-start space-x-3">

--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -74,7 +74,7 @@ const SearchBar: React.FC<{ showActions?: boolean }> = ({ showActions = true }) 
         }`}
       >
         {creators.length > 0 && (
-          <div className="p-4 border-b border-foreground/20">
+          <div className="p-4 border-b divider">
             <div className="mb-2 text-sm">{t('creators')}</div>
             {creators.map((c) => (
               <div

--- a/apps/web/components/comments/Thread.tsx
+++ b/apps/web/components/comments/Thread.tsx
@@ -47,7 +47,7 @@ export default function Thread({
         )}
         {err && <div className="text-sm text-red-600">{err}</div>}
       </div>
-      <hr className="border-token my-4" />
+      <hr className="divider my-4" />
 
       <div className="mt-4 flex gap-2">
         <input

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -10,7 +10,7 @@ export default function AppShell({
     <div className="min-h-screen bg-app text-foreground">
       <div className="mx-auto w-full max-w-[1400px] grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
         {/* Left column: menu/search/profile summary (sticky on desktop) */}
-        <aside className="hidden lg:block border-r border-token sticky top-0 h-screen overflow-y-auto">
+        <aside className="hidden lg:block border-r divider sticky top-0 h-screen overflow-y-auto">
           <div className="p-4">{left}</div>
         </aside>
 
@@ -20,7 +20,7 @@ export default function AppShell({
         </main>
 
         {/* Right column: author info & comments (sticky on desktop) */}
-        <aside className="hidden lg:block border-l border-token sticky top-0 h-screen overflow-y-auto">
+        <aside className="hidden lg:block border-l divider sticky top-0 h-screen overflow-y-auto">
           <div className="p-4">{right}</div>
         </aside>
       </div>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -98,6 +98,9 @@ body {
   .border-token {
     border-color: rgb(var(--border));
   }
+  .divider {
+    border-color: hsl(var(--border));
+  }
 }
 
 :root {


### PR DESCRIPTION
## Summary
- add `.divider` utility using `var(--border)` color token
- replace hardcoded divider colors with `.divider` across layout and drawers

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896787cb1988331823932333947a287