### PR TITLE
Remove profile fragment from settings links

### DIFF
--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -25,7 +25,7 @@ export default function MiniProfileCard({
           {stats.followers.toLocaleString()} followers • {stats.following.toLocaleString()} following
         </div>
       )}
-      <Link href="/settings#profile" className="text-xs text-[var(--accent)]">
+      <Link href="/settings" className="text-xs text-[var(--accent)]">
         Manage profile
       </Link>
     </div>

--- a/apps/web/components/layout/LeftNav.tsx
+++ b/apps/web/components/layout/LeftNav.tsx
@@ -36,7 +36,7 @@ export default function LeftNav({
             { href: '/feed', label: 'Home', icon: Home },
             { href: '/following', label: 'Following', icon: Users },
             { href: '/create', label: 'Create', icon: Plus },
-            { href: '/settings#profile', label: 'Profile settings', icon: User },
+            { href: '/settings', label: 'Settings', icon: User },
           ].map(({ href, label, icon: Icon }) => {
             const active = asPath.startsWith(href);
             return (


### PR DESCRIPTION
## Summary
- Simplify navigation by linking to the main settings page instead of the profile subsection
- Update mini profile card to point to `/settings`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import "@/utils/trimVideoWebCodecs")*


------
https://chatgpt.com/codex/tasks/task_e_689680f97fe8833186aec067a1b060f4