### PR TITLE
refactor: consolidate theme background utilities

### DIFF
--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -15,7 +15,7 @@ export default function NavBar() {
   return (
     <nav
       aria-label="Main navigation"
-      className="fixed bottom-0 inset-x-0 lg:hidden z-30 flex justify-around bg-brand-surface/95 backdrop-blur shadow-card"
+      className="fixed bottom-0 inset-x-0 lg:hidden z-30 flex justify-around bg-card/95 backdrop-blur shadow-card"
     >
       {links.map(({ href, icon, label }) => {
         const active = asPath.startsWith(href);

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -14,7 +14,7 @@ export default function SideNav() {
   return (
     <nav
       aria-label="Main navigation"
-      className="hidden lg:flex lg:flex-col lg:w-48 lg:fixed lg:left-0 lg:inset-y-0 bg-brand-surface/95 backdrop-blur z-40 pl-4 pt-6"
+      className="hidden lg:flex lg:flex-col lg:w-48 lg:fixed lg:left-0 lg:inset-y-0 bg-card/95 backdrop-blur z-40 pl-4 pt-6"
     >
       <h1 className="mb-8 text-2xl font-bold text-white">PaiDuan</h1>
       <ul className="space-y-2">

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -162,7 +162,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="relative h-full w-full overflow-hidden rounded-2xl bg-brand-surface text-white shadow-card"
+      className="relative h-full w-full overflow-hidden rounded-2xl bg-card text-white shadow-card"
       onDoubleClick={onLike}
       onClick={() => setSelectedVideo(eventId, pubkey)}
       onPointerDown={handlePointerDown}

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -7,7 +7,7 @@ export default function AppShell({
   right,
 }: { left: React.ReactNode; center: React.ReactNode; right: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-app text-foreground">
+    <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto w-full max-w-[1400px] grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
         {/* Left column: menu/search/profile summary (sticky on desktop) */}
         <aside className="hidden lg:block border-r divider sticky top-0 h-screen overflow-y-auto">

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -6,7 +6,7 @@
 :root {
   --background: 0 0% 100%;
   --foreground: 220 14% 12%;
-  --surface: 0 0% 100%;
+  --card: 0 0% 100%;
   --muted: 220 9% 46%;
   --accent: 273 68% 59%;
   --border: 220 13% 91%;
@@ -14,7 +14,7 @@
 .dark {
   --background: 220 14% 8%;
   --foreground: 220 15% 92%;
-  --surface: 220 12% 12%;
+  --card: 220 12% 12%;
   --muted: 220 10% 70%;
   --accent: 273 68% 59%;
   --border: 220 12% 20%;
@@ -29,8 +29,14 @@ body {
   .text-foreground {
     color: hsl(var(--foreground));
   }
-  .bg-app {
-    background: hsl(var(--background));
+  .text-muted-foreground {
+    @apply text-foreground opacity-60;
+  }
+  .border-token {
+    border-color: hsl(var(--border));
+  }
+  .divider {
+    border-color: hsl(var(--border));
   }
   .break-inside-avoid {
     break-inside: avoid;
@@ -56,50 +62,6 @@ body {
   .btn-ghost {
     background: transparent;
     color: hsl(var(--foreground));
-  }
-}
-
-@layer base {
-  :root {
-    --bg: 255 255 255;
-    --foreground: 17 24 39; /* slate-900-ish */
-    --muted-foreground: 107 114 128; /* slate-500 */
-    --card: 255 255 255;
-    --border: 229 231 235; /* gray-200 */
-  }
-  .dark {
-    --bg: 17 17 17;
-    --foreground: 243 244 246; /* gray-100 */
-    --muted-foreground: 156 163 175; /* gray-400 */
-    --card: 24 24 27; /* zinc-900 */
-    --border: 39 39 42; /* zinc-800 */
-  }
-
-  html,
-  body {
-    background-color: rgb(var(--bg));
-    color: rgb(var(--foreground));
-  }
-}
-
-@layer utilities {
-  .text-foreground {
-    color: rgb(var(--foreground));
-  }
-  .text-muted-foreground {
-    @apply text-foreground opacity-60;
-  }
-  .bg-app {
-    background-color: rgb(var(--bg));
-  }
-  .bg-card {
-    background-color: rgb(var(--card));
-  }
-  .border-token {
-    border-color: rgb(var(--border));
-  }
-  .divider {
-    border-color: hsl(var(--border));
   }
 }
 

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -14,11 +14,11 @@ module.exports = {
       colors: {
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
+        card: 'hsl(var(--card))',
         accent: 'hsl(var(--accent))',
         border: 'hsl(var(--border))',
         brand: {
           DEFAULT: '#9d4edd',
-          surface: '#1a1b1f',
           panel: '#202125',
         },
       },


### PR DESCRIPTION
## Summary
- remove legacy `--bg`/`--card` variables and duplicate `bg-app` utilities in global styles
- reference unified `background`, `foreground`, and `card` CSS variables in Tailwind config
- update components to use `bg-background` and `bg-card` classes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import `@/utils/trimVideoWebCodecs`)*

------
https://chatgpt.com/codex/tasks/task_e_6896809c69208331a59b609c9caacb49