### PR TITLE
Enable deep-linkable profile settings section

### DIFF
--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -25,7 +25,7 @@ export default function MiniProfileCard({
           {stats.followers.toLocaleString()} followers • {stats.following.toLocaleString()} following
         </div>
       )}
-      <Link href="/settings" className="text-xs text-[var(--accent)]">
+      <Link href="/settings#profile" className="text-xs text-[var(--accent)]">
         Manage profile
       </Link>
     </div>

--- a/apps/web/components/ui/Accordion.tsx
+++ b/apps/web/components/ui/Accordion.tsx
@@ -7,8 +7,19 @@ export interface AccordionItem {
   content: React.ReactNode;
 }
 
-export function Accordion({ items }: { items: AccordionItem[] }) {
-  const [openIndex, setOpenIndex] = React.useState<number | null>(null);
+interface AccordionProps {
+  items: AccordionItem[];
+  initialOpenIndex?: number | null;
+}
+
+export function Accordion({ items, initialOpenIndex = null }: AccordionProps) {
+  const [openIndex, setOpenIndex] = React.useState<number | null>(
+    initialOpenIndex,
+  );
+
+  React.useEffect(() => {
+    setOpenIndex(initialOpenIndex);
+  }, [initialOpenIndex]);
 
   return (
     <div className="space-y-2">

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -13,13 +13,31 @@ import { PrivacyCard } from '../components/settings/PrivacyCard';
 import { ProfileCard } from '../components/settings/ProfileCard';
 
 export default function Settings() {
+  const [initialOpenIndex, setInitialOpenIndex] = React.useState<number | null>(
+    null,
+  );
+
+  React.useEffect(() => {
+    if (window.location.hash === '#profile') {
+      setInitialOpenIndex(0);
+    }
+  }, []);
+
   return (
     <>
       <SideNav />
       <main className="max-w-3xl mx-auto px-4 py-10 space-y-6 lg:ml-48">
-        <ProfileCard />
         <Accordion
+          initialOpenIndex={initialOpenIndex}
           items={[
+            {
+              title: 'Profile',
+              content: (
+                <div id="profile">
+                  <ProfileCard />
+                </div>
+              ),
+            },
             {
               title: 'Account & Keys',
               content: (


### PR DESCRIPTION
## Summary
- add `initialOpenIndex` prop to Accordion for controlled open state
- move ProfileCard into Settings accordion and open based on `window.location.hash`
- update MiniProfileCard to link to `/settings#profile`

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689682837a888331aa536ccdbfff2b4d