### PR TITLE
feat: fetch follower counts from nostr network

### DIFF
--- a/apps/web/hooks/useFollowers.ts
+++ b/apps/web/hooks/useFollowers.ts
@@ -1,0 +1,30 @@
+'use client';
+import { useEffect, useState } from 'react';
+import * as nostrKinds from 'nostr-tools/kinds';
+import type { Filter } from 'nostr-tools/filter';
+import { getPool, getRelays } from '@/lib/nostr';
+
+export function useFollowers(pubkey?: string) {
+  const [followers, setFollowers] = useState<string[]>([]);
+  useEffect(() => {
+    if (!pubkey) return;
+    const pool = getPool();
+    const seen = new Set<string>();
+    const sub = pool.subscribeMany(
+      getRelays(),
+      [{ kinds: [nostrKinds.Contacts], '#p': [pubkey] } as Filter],
+      {
+        onevent: (ev) => {
+          if (!seen.has(ev.pubkey)) {
+            seen.add(ev.pubkey);
+            setFollowers(Array.from(seen));
+          }
+        },
+      },
+    );
+    return () => sub.close();
+  }, [pubkey]);
+  return followers;
+}
+
+export default useFollowers;

--- a/apps/web/hooks/useFollowing.ts
+++ b/apps/web/hooks/useFollowing.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 const STORAGE_KEY = 'following';
-const FOLLOWERS_PREFIX = 'followers-';
 
 function readLocal(): string[] {
   if (typeof window === 'undefined') return [];
@@ -22,48 +21,17 @@ function writeLocal(list: string[]) {
   }
 }
 
-function followersKey(pubkey: string) {
-  return `${FOLLOWERS_PREFIX}${pubkey}`;
-}
-
-function readFollowers(pubkey: string): number {
-  if (typeof window === 'undefined') return 0;
-  const raw = window.localStorage.getItem(followersKey(pubkey));
-  const n = raw ? parseInt(raw, 10) : 0;
-  return isNaN(n) ? 0 : n;
-}
-
-function writeFollowers(pubkey: string, count: number) {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(followersKey(pubkey), String(count));
-  } catch {
-    /* ignore */
-  }
-}
-
-function updateFollowers(pubkey: string, delta: number) {
-  const next = Math.max(0, readFollowers(pubkey) + delta);
-  writeFollowers(pubkey, next);
-}
-
-export function getFollowers(pubkey: string): number {
-  return readFollowers(pubkey);
-}
-
 export function follow(pubkey: string) {
   const current = readLocal();
   if (!current.includes(pubkey)) {
     current.push(pubkey);
     writeLocal(current);
-    updateFollowers(pubkey, 1);
   }
 }
 
 export function unfollow(pubkey: string) {
   const current = readLocal().filter((p) => p !== pubkey);
   writeLocal(current);
-  updateFollowers(pubkey, -1);
 }
 
 export function useFollowing() {

--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -3,7 +3,8 @@ import LeftNav from '@/components/layout/LeftNav';
 import RightPanel from '@/components/feed/RightPanel';
 import useFeed from '@/hooks/useFeed';
 import { useAuth } from '@/hooks/useAuth';
-import useFollowing, { getFollowers } from '@/hooks/useFollowing';
+import useFollowing from '@/hooks/useFollowing';
+import useFollowers from '@/hooks/useFollowers';
 import { useProfile } from '@/hooks/useProfile';
 import { useFeedSelection } from '@/store/feedSelection';
 
@@ -13,6 +14,8 @@ export default function FeedPage() {
 
   const { state: auth } = useAuth();
   const { following } = useFollowing();
+  const myFollowers = useFollowers(auth.status === 'ready' ? auth.pubkey : undefined);
+  const authorFollowers = useFollowers(selectedVideoAuthor);
   const meProfile = useProfile(auth.status === 'ready' ? auth.pubkey : undefined);
   const me =
     auth.status === 'ready'
@@ -20,7 +23,7 @@ export default function FeedPage() {
           avatar: meProfile?.picture || `/api/avatar/${auth.pubkey}`,
           name: meProfile?.name || auth.pubkey.slice(0, 8),
           username: meProfile?.name || auth.pubkey.slice(0, 8),
-          stats: { followers: getFollowers(auth.pubkey), following: following.length },
+          stats: { followers: myFollowers.length, following: following.length },
         }
       : { avatar: '/api/avatar/me', name: 'You', username: 'me', stats: { followers: 0, following: 0 } };
 
@@ -32,7 +35,7 @@ export default function FeedPage() {
           name: authorProfile.name || selectedVideoAuthor.slice(0, 8),
           username: authorProfile.name || selectedVideoAuthor.slice(0, 8),
           pubkey: selectedVideoAuthor,
-          followers: getFollowers(selectedVideoAuthor),
+          followers: authorFollowers.length,
         }
       : undefined;
 

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -6,7 +6,8 @@ import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
 import { toast } from 'react-hot-toast';
 import VideoCard, { VideoCardProps } from '../../../components/VideoCard';
-import useFollowing, { getFollowers } from '../../../hooks/useFollowing';
+import useFollowing from '../../../hooks/useFollowing';
+import useFollowers from '@/hooks/useFollowers';
 import SearchBar from '../../../components/SearchBar';
 import { useAuth } from '@/hooks/useAuth';
 import { getRelays } from '@/lib/nostr';
@@ -24,16 +25,11 @@ export default function ProfilePage() {
   const [videos, setVideos] = useState<VideoCardProps[]>([]);
   const [selected, setSelected] = useState<VideoCardProps | null>(null);
   const { following, follow, unfollow } = useFollowing();
-  const [followers, setFollowers] = useState(0);
+  const followers = useFollowers(pubkey);
 
   const isFollowing = pubkey ? following.includes(pubkey) : false;
 
   const isOwner = pubkey === myPubkey;
-
-  useEffect(() => {
-    if (!pubkey) return;
-    setFollowers(getFollowers(pubkey));
-  }, [pubkey]);
 
   useEffect(() => {
     if (state.status === 'ready') setMyPubkey(state.pubkey);
@@ -110,7 +106,6 @@ export default function ProfilePage() {
     } else {
       follow(pubkey);
     }
-    setFollowers(getFollowers(pubkey));
   };
 
   const totalPct = zapSplits.reduce((sum, s) => sum + s.pct, 0);
@@ -183,7 +178,7 @@ export default function ProfilePage() {
             >
               {isFollowing ? 'Unfollow' : 'Follow'}
             </button>
-            <div className="text-sm">{followers} followers</div>
+            <div className="text-sm">{followers.length} followers</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `useFollowers` hook that subscribes to Nostr kind 3 events
- remove local follower storage and use hook in feed and profile pages

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689684b1f4608331b830fe0aa8118177