### PR TITLE
Use standard button styles on landing page CTA

### DIFF
--- a/apps/web/pages/en/index.tsx
+++ b/apps/web/pages/en/index.tsx
@@ -18,10 +18,7 @@ export default function LandingPage() {
           Built on Nostr. Own your keys, your audience, your revenue.
         </p>
         <div className="mt-8 flex justify-center gap-3">
-          <Link
-            href="/onboarding/key"
-            className="rounded-xl px-4 py-2 font-medium bg-[var(--accent)] text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
-          >
+          <Link href="/onboarding/key" className="btn btn-primary">
             Get Started
           </Link>
           <Link href="/en/feed" className="btn btn-secondary">


### PR DESCRIPTION
## Summary
- Replace custom-styled Link on English landing page with `btn btn-primary` classes
- Ensures call-to-action styling aligns with other buttons across feed and settings pages

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6896848457dc8331802de833e47b47c9