### PR TITLE
feat: validate create form before publishing

### DIFF
--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../../hooks/useProfile', () => ({ useProfile: () => ({}) }));
 vi.mock('../../lib/nostr', () => ({ getRelays: () => [] }));
 
 describe('CreateVideoForm', () => {
-  it('enables posting after selecting a file', async () => {
+  it('keeps publish disabled until metadata is provided', async () => {
     (URL as any).createObjectURL = vi.fn(() => 'blob:mock');
 
     const container = document.createElement('div');
@@ -29,17 +29,19 @@ describe('CreateVideoForm', () => {
       root.render(<CreateVideoForm onCancel={() => {}} />);
     });
 
-    const postButton = container.querySelector('[data-testid="post-button"]') as HTMLButtonElement;
-    expect(postButton.disabled).toBe(true);
+    const publishButton = container.querySelector('[data-testid="publish-button"]') as HTMLButtonElement;
+    expect(publishButton.disabled).toBe(true);
 
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['dummy'], 'video.mp4', { type: 'video/mp4' });
     await act(async () => {
       Object.defineProperty(input, 'files', { value: [file] });
       input.dispatchEvent(new Event('change', { bubbles: true }));
-      await Promise.resolve();
     });
 
-    expect(postButton.disabled).toBe(false);
+    // Still disabled because required fields are empty
+    expect(
+      (container.querySelector('[data-testid="publish-button"]') as HTMLButtonElement).disabled,
+    ).toBe(true);
   });
 });

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -44,6 +44,12 @@ export function CreateVideoForm({ onCancel }: CreateVideoFormProps) {
     if (!lightningAddress && profile?.lud16) setLightningAddress(profile.lud16);
   }, [profile, lightningAddress]);
 
+  const topicList = topics
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+  const formValid = !!outBlob && !!lightningAddress.trim() && topicList.length > 0;
+
   async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0] ?? null;
     setFile(f);
@@ -67,10 +73,6 @@ export function CreateVideoForm({ onCancel }: CreateVideoFormProps) {
   }
 
   async function postVideo() {
-    const topicList = topics
-      .split(',')
-      .map((t) => t.trim())
-      .filter(Boolean);
 
     if (!outBlob) {
       alert('Please process a video first');
@@ -193,11 +195,11 @@ export function CreateVideoForm({ onCancel }: CreateVideoFormProps) {
       </label>
       <button
         className="btn btn-primary disabled:opacity-60"
-        data-testid="post-button"
-        disabled={!outBlob || posting}
+        data-testid="publish-button"
+        disabled={!formValid || posting}
         onClick={postVideo}
       >
-        {posting ? 'Posting…' : 'Post Video'}
+        {posting ? 'Publishing…' : 'Publish'}
       </button>
     </>
   );


### PR DESCRIPTION
## Summary
- enforce publish form validation in CreateVideoForm
- disable publish button until video conversion and metadata present
- test publish button remains disabled without metadata

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68968477826c83319592e5b8e10cc1ed