### PR TITLE
Render comments only when a video is selected

### DIFF
--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -38,9 +38,11 @@ export default function RightPanel({
         </div>
       )}
 
-      <div className={`${cardStyle} p-0`}>
-        <Thread rootId={selectedVideoId} authorPubkey={selectedVideoAuthor} />
-      </div>
+      {selectedVideoId && (
+        <div className={`${cardStyle} p-0`}>
+          <Thread rootId={selectedVideoId} authorPubkey={selectedVideoAuthor} />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Show the comment thread only when a video is selected so `Thread` gets valid IDs

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689684e93eb88331937705f5c7a342a4