### PR TITLE
feat: constrain preview height to avoid overflow

### DIFF
--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -220,11 +220,11 @@ export function CreateVideoForm({ onCancel }: CreateVideoFormProps) {
             className="block w-full text-sm border rounded px-3 py-2 bg-transparent"
           />
           {preview ? (
-            <div className="relative">
+            <div className="relative flex justify-center max-h-screen">
               <video
                 controls
                 src={preview}
-                className="rounded-xl w-full aspect-[9/16] object-cover bg-black"
+                className="rounded-xl w-full max-h-screen object-contain bg-black"
               />
               {progress > 0 && progress < 100 && (
                 <div
@@ -234,7 +234,7 @@ export function CreateVideoForm({ onCancel }: CreateVideoFormProps) {
               )}
             </div>
           ) : (
-            <PlaceholderVideo className="rounded-xl w-full aspect-[9/16] object-cover bg-black" />
+            <PlaceholderVideo className="rounded-xl w-full max-h-screen object-contain bg-black" />
           )}
           {err && <p className="text-sm text-red-500">{err}</p>}
         </div>

--- a/apps/web/components/create/CreatorWizard.tsx
+++ b/apps/web/components/create/CreatorWizard.tsx
@@ -10,7 +10,7 @@ export default function CreatorWizard() {
   };
 
   return (
-    <main className="mx-auto py-12 px-4 space-y-6">
+    <main className="mx-auto py-12 px-4 space-y-6 lg:py-4">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">Create Video</h1>
       </div>


### PR DESCRIPTION
## Summary
- limit video preview height and show placeholder before selection
- reduce desktop padding to keep create form within viewport

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689686c517408331a3d93a9590164185