### PR TITLE
feat(web): add network section to settings

### DIFF
--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -45,9 +45,12 @@ export default function Settings() {
                   <KeysCard />
                   <AccountCard />
                   <LightningCard />
-                  <NetworkCard />
                 </div>
               ),
+            },
+            {
+              title: 'Network',
+              content: <NetworkCard />,
             },
             {
               title: 'Appearance & Language',


### PR DESCRIPTION
## Summary
- separate Network settings into its own accordion section

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689686ff755883319bb2782c45e4bee2