### PR TITLE
feat: add semantic background tokens

### DIFF
--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -15,7 +15,7 @@ export default function NavBar() {
   return (
     <nav
       aria-label="Main navigation"
-      className="fixed bottom-0 inset-x-0 lg:hidden z-30 flex justify-around bg-card/95 backdrop-blur shadow-card"
+      className="fixed bottom-0 inset-x-0 lg:hidden z-30 flex justify-around bg-panel/95 backdrop-blur shadow-card"
     >
       {links.map(({ href, icon, label }) => {
         const active = asPath.startsWith(href);

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -14,7 +14,7 @@ export default function SideNav() {
   return (
     <nav
       aria-label="Main navigation"
-      className="hidden lg:flex lg:flex-col lg:w-48 lg:fixed lg:left-0 lg:inset-y-0 bg-card/95 backdrop-blur z-40 pl-4 pt-6"
+      className="hidden lg:flex lg:flex-col lg:w-48 lg:fixed lg:left-0 lg:inset-y-0 bg-panel/95 backdrop-blur z-40 pl-4 pt-6"
     >
       <h1 className="mb-8 text-2xl font-bold text-white">PaiDuan</h1>
       <ul className="space-y-2">

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -8,7 +8,7 @@ export default function AppShell({
 }: { left: React.ReactNode; center: React.ReactNode; right: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto w-full max-w-[1400px] grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
+    <div className="mx-auto w-full max-w-[1400px] bg-surface grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
         {/* Left column: menu/search/profile summary (sticky on desktop) */}
         <aside className="hidden lg:block border-r divider sticky top-0 h-screen overflow-y-auto">
           <div className="p-4">{left}</div>

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -104,7 +104,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
       <h1 className="text-2xl mb-4">Set up your profile</h1>
       <div className="w-full max-w-md space-y-3 flex flex-col items-center text-center">
         <input

--- a/apps/web/components/settings/LanguageCard.tsx
+++ b/apps/web/components/settings/LanguageCard.tsx
@@ -25,7 +25,7 @@ export function LanguageCard() {
       <select
         value={locale}
         onChange={handleLocaleChange}
-        className="rounded border border-white/30 bg-brand-panel px-3 py-1"
+        className="rounded border border-white/30 bg-panel px-3 py-1"
       >
         <option value="en">{t('language_english')}</option>
         <option value="zh">{t('language_chinese')}</option>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -7,6 +7,8 @@
   --background: 0 0% 100%;
   --foreground: 220 14% 12%;
   --card: 0 0% 100%;
+  --surface: 0 0% 100%;
+  --panel: 0 0% 98%;
   --muted: 220 9% 46%;
   --accent: 273 68% 59%;
   --border: 220 13% 91%;
@@ -15,6 +17,8 @@
   --background: 220 14% 8%;
   --foreground: 220 15% 92%;
   --card: 220 12% 12%;
+  --surface: 220 12% 12%;
+  --panel: 220 10% 16%;
   --muted: 220 10% 70%;
   --accent: 273 68% 59%;
   --border: 220 12% 20%;

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -15,11 +15,12 @@ module.exports = {
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
         card: 'hsl(var(--card))',
+        surface: 'hsl(var(--surface))',
+        panel: 'hsl(var(--panel))',
         accent: 'hsl(var(--accent))',
         border: 'hsl(var(--border))',
         brand: {
           DEFAULT: '#9d4edd',
-          panel: '#202125',
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- add background, surface, and panel theme tokens
- apply semantic background classes to shell, navigation, onboarding, and settings
- map new tokens to light and dark mode variables

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689686d5e2908331ad54eddf81ba9298