### PR TITLE
refactor: simplify creator wizard

### DIFF
--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
-import { CreateVideoForm } from './CreateVideoForm';
+import CreateVideoForm from './CreateVideoForm';
 
 (globalThis as any).React = React;
 
@@ -18,6 +18,7 @@ vi.mock('../../hooks/useAuth', () => ({
 vi.mock('../../hooks/useProfile', () => ({ useProfile: () => ({}) }));
 
 vi.mock('../../lib/nostr', () => ({ getRelays: () => [] }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ back: vi.fn() }) }));
 
 describe('CreateVideoForm', () => {
   it('keeps publish disabled until metadata is provided', async () => {
@@ -26,7 +27,7 @@ describe('CreateVideoForm', () => {
     const container = document.createElement('div');
     const root = createRoot(container);
     await act(async () => {
-      root.render(<CreateVideoForm onCancel={() => {}} />);
+      root.render(<CreateVideoForm />);
     });
 
     const publishButton = container.querySelector('[data-testid="publish-button"]') as HTMLButtonElement;

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import PlaceholderVideo from '../PlaceholderVideo';
 import { trimVideoWebCodecs } from '../../utils/trimVideoWebCodecs';
 import { SimplePool } from 'nostr-tools/pool';
@@ -7,11 +8,8 @@ import { useAuth } from '../../hooks/useAuth';
 import { useProfile } from '../../hooks/useProfile';
 import { getRelays } from '../../lib/nostr';
 
-interface CreateVideoFormProps {
-  onCancel: () => void;
-}
-
-export function CreateVideoForm({ onCancel }: CreateVideoFormProps) {
+export default function CreateVideoForm() {
+  const router = useRouter();
   const [file, setFile] = useState<File | null>(null);
   const [outBlob, setOutBlob] = useState<Blob | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
@@ -136,11 +134,18 @@ export function CreateVideoForm({ onCancel }: CreateVideoFormProps) {
 
   function handleCancel() {
     if (
-      (file || outBlob || preview || caption || topics || copyright || nsfw || lightningAddress) &&
+      (file ||
+        outBlob ||
+        preview ||
+        caption ||
+        topics ||
+        copyright ||
+        nsfw ||
+        lightningAddress) &&
       !confirm('Discard your progress?')
     )
       return;
-    onCancel();
+    router.back();
   }
 
   const form = (
@@ -243,5 +248,3 @@ export function CreateVideoForm({ onCancel }: CreateVideoFormProps) {
     </section>
   );
 }
-
-export default CreateVideoForm;

--- a/apps/web/components/create/CreatorWizard.tsx
+++ b/apps/web/components/create/CreatorWizard.tsx
@@ -1,20 +1,13 @@
 'use client';
-import { useRouter } from 'next/navigation';
-import { CreateVideoForm } from './CreateVideoForm';
+import CreateVideoForm from './CreateVideoForm';
 
 export default function CreatorWizard() {
-  const router = useRouter();
-
-  const handleCancel = () => {
-    router.back();
-  };
-
   return (
     <main className="mx-auto py-12 px-4 space-y-6 lg:py-4">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">Create Video</h1>
       </div>
-      <CreateVideoForm onCancel={handleCancel} />
+      <CreateVideoForm />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- simplify creator wizard to render new create video form
- handle cancel via router.back inside create video form
- update unit test for create video form

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6896817427348331abcf248fb5e34f41