### PR TITLE
refactor: use AppShell in settings layout

### DIFF
--- a/apps/web/components/SettingsLayout.tsx
+++ b/apps/web/components/SettingsLayout.tsx
@@ -1,11 +1,8 @@
+import AppShell from '@/components/layout/AppShell';
 import SideNav from './SideNav';
+
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <>
-      <SideNav />
-      <div className="lg:ml-48 pt-6 pb-24 flex justify-center">
-        <div className="w-full max-w-[640px] space-y-8 px-4">{children}</div>
-      </div>
-    </>
+    <AppShell left={<SideNav />} center={<div className="space-y-8">{children}</div>} right={<></>} />
   );
 }


### PR DESCRIPTION
## Summary
- use AppShell to wrap settings layout
- pass SideNav to AppShell and children to center slot

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689689a4dc8c8331a060b835abe6da35