### PR TITLE
feat: add persistent following store

### DIFF
--- a/apps/web/hooks/useFollowing.ts
+++ b/apps/web/hooks/useFollowing.ts
@@ -1,57 +1,7 @@
-import { useEffect, useState } from 'react';
-
-const STORAGE_KEY = 'following';
-
-function readLocal(): string[] {
-  if (typeof window === 'undefined') return [];
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as string[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeLocal(list: string[]) {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
-  } catch {
-    /* ignore */
-  }
-}
-
-export function follow(pubkey: string) {
-  const current = readLocal();
-  if (!current.includes(pubkey)) {
-    current.push(pubkey);
-    writeLocal(current);
-  }
-}
-
-export function unfollow(pubkey: string) {
-  const current = readLocal().filter((p) => p !== pubkey);
-  writeLocal(current);
-}
+import { useFollowingStore } from '@/store/following';
 
 export function useFollowing() {
-  const [following, setFollowing] = useState<string[]>([]);
-
-  useEffect(() => {
-    setFollowing(readLocal());
-  }, []);
-
-  const add = (pubkey: string) => {
-    follow(pubkey);
-    setFollowing(readLocal());
-  };
-
-  const remove = (pubkey: string) => {
-    unfollow(pubkey);
-    setFollowing(readLocal());
-  };
-
-  return { following, follow: add, unfollow: remove };
+  return useFollowingStore();
 }
 
 export default useFollowing;

--- a/apps/web/store/following.ts
+++ b/apps/web/store/following.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type FollowingState = {
+  following: string[];
+  follow: (pubkey: string) => void;
+  unfollow: (pubkey: string) => void;
+};
+
+export const useFollowingStore = create<FollowingState>()(
+  persist(
+    (set) => ({
+      following: [],
+      follow: (pubkey) =>
+        set((state) =>
+          state.following.includes(pubkey)
+            ? state
+            : { following: [...state.following, pubkey] },
+        ),
+      unfollow: (pubkey) =>
+        set((state) => ({
+          following: state.following.filter((p) => p !== pubkey),
+        })),
+    }),
+    {
+      name: 'following',
+    },
+  ),
+);
+
+export const follow = (pubkey: string) =>
+  useFollowingStore.getState().follow(pubkey);
+export const unfollow = (pubkey: string) =>
+  useFollowingStore.getState().unfollow(pubkey);
+export const following = () => useFollowingStore.getState().following;


### PR DESCRIPTION
## Summary
- add Zustand store to manage following authors with localStorage persistence
- refactor useFollowing hook to use shared store

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689689f250fc83318c0c1b118b951346