### PR TITLE
feat(web): add mobile bottom navigation

### DIFF
--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React from 'react';
+import BottomNav from './BottomNav';
 
 export default function AppShell({
   left,
@@ -8,7 +9,7 @@ export default function AppShell({
 }: { left: React.ReactNode; center: React.ReactNode; right: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-background text-foreground">
-    <div className="mx-auto w-full max-w-[1400px] bg-surface grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
+      <div className="mx-auto w-full max-w-[1400px] bg-surface grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
         {/* Left column: menu/search/profile summary (sticky on desktop) */}
         <aside className="hidden lg:block border-r divider sticky top-0 h-screen overflow-y-auto">
           <div className="p-4">{left}</div>
@@ -24,6 +25,7 @@ export default function AppShell({
           <div className="p-4">{right}</div>
         </aside>
       </div>
+      <BottomNav />
     </div>
   );
 }

--- a/apps/web/components/layout/BottomNav.tsx
+++ b/apps/web/components/layout/BottomNav.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { navItems } from './nav';
+
+export default function BottomNav() {
+  const { asPath } = useRouter();
+
+  return (
+    <nav className="fixed bottom-0 inset-x-0 flex justify-around border-t bg-surface lg:hidden">
+      {navItems.map(({ href, label, icon: Icon }) => {
+        const active = asPath.startsWith(href);
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`flex flex-col items-center justify-center flex-1 p-3 focus:outline-none focus-visible:text-accent ${
+              active ? 'text-accent' : 'text-muted-foreground hover:text-accent'
+            }`}
+            aria-label={label}
+            aria-current={active ? 'page' : undefined}
+          >
+            <Icon size={24} />
+            <span className="sr-only">{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+

--- a/apps/web/components/layout/MainNav.tsx
+++ b/apps/web/components/layout/MainNav.tsx
@@ -4,10 +4,11 @@ import SearchBar from '@/components/SearchBar';
 import MiniProfileCard from '@/components/MiniProfileCard';
 import NotificationBell from '@/components/NotificationBell';
 import { useTheme } from '@/context/themeContext';
-import { Sun, Moon, Home, Users, Plus, User } from 'lucide-react';
+import { Sun, Moon } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { cardStyle } from '@/components/ui/Card';
 import Logo from '@/components/branding/Logo';
+import { navItems } from './nav';
 
 interface MainNavProps {
   me?: {
@@ -43,12 +44,7 @@ export default function MainNav({
       {/* Nav */}
       <nav className={`${cardStyle} p-2`}>
         <ul className="flex flex-col">
-          {[
-            { href: '/feed', label: 'Home', icon: Home },
-            { href: '/following', label: 'Following', icon: Users },
-            { href: '/create', label: 'Create', icon: Plus },
-            { href: '/settings', label: 'Settings', icon: User },
-          ].map(({ href, label, icon: Icon }) => {
+          {navItems.map(({ href, label, icon: Icon }) => {
             const active = asPath.startsWith(href);
             return (
               <li key={href}>

--- a/apps/web/components/layout/nav.ts
+++ b/apps/web/components/layout/nav.ts
@@ -1,0 +1,16 @@
+import { Home, Users, Plus, User } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+export const navItems: NavItem[] = [
+  { href: '/feed', label: 'Home', icon: Home },
+  { href: '/following', label: 'Following', icon: Users },
+  { href: '/create', label: 'Create', icon: Plus },
+  { href: '/settings', label: 'Settings', icon: User },
+];
+

--- a/apps/web/pages/profile.tsx
+++ b/apps/web/pages/profile.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
+import AppShell from '@/components/layout/AppShell';
 import MainNav from '@/components/layout/MainNav';
 import { Card } from '../components/ui/Card';
 import * as nip19 from 'nostr-tools/nip19';
@@ -20,45 +21,53 @@ export default function Profile() {
     alert('nsec copied to clipboard');
   };
 
+  const nav = <MainNav showSearch={false} showProfile={false} />;
+
   if (state.status !== 'ready') {
     return (
-      <>
-        <MainNav showSearch={false} showProfile={false} />
-        <main className="max-w-3xl mx-auto px-4 py-10 space-y-6 lg:ml-48">
-          <Card title="Profile" desc="Sign in to view your profile.">
-            <div>Not signed in.</div>
-          </Card>
-        </main>
-      </>
+      <AppShell
+        left={nav}
+        center={
+          <div className="max-w-3xl mx-auto px-4 py-10 space-y-6">
+            <Card title="Profile" desc="Sign in to view your profile.">
+              <div>Not signed in.</div>
+            </Card>
+          </div>
+        }
+        right={<></>}
+      />
     );
   }
 
   return (
-    <>
-      <MainNav showSearch={false} showProfile={false} />
-      <main className="max-w-3xl mx-auto px-4 py-10 space-y-6 lg:ml-48">
-        <Card title="Profile" desc="Your public profile information.">
-          <div className="flex items-center gap-4">
-            <img
-              src={meta?.picture || '/avatar.svg'}
-              alt="avatar"
-              className="h-24 w-24 rounded-full object-cover"
-            />
-            <div className="text-lg font-semibold">{meta?.name || 'Anonymous'}</div>
-          </div>
-          <div className="flex flex-wrap gap-3 pt-2">
-            <button className="btn-secondary" onClick={() => router.push('/onboarding/profile')}>
-              Edit
-            </button>
-            {state.method === 'local' && (
-              <button className="btn-secondary" onClick={exportKey}>
-                Export key
+    <AppShell
+      left={nav}
+      center={
+        <div className="max-w-3xl mx-auto px-4 py-10 space-y-6">
+          <Card title="Profile" desc="Your public profile information.">
+            <div className="flex items-center gap-4">
+              <img
+                src={meta?.picture || '/avatar.svg'}
+                alt="avatar"
+                className="h-24 w-24 rounded-full object-cover"
+              />
+              <div className="text-lg font-semibold">{meta?.name || 'Anonymous'}</div>
+            </div>
+            <div className="flex flex-wrap gap-3 pt-2">
+              <button className="btn-secondary" onClick={() => router.push('/onboarding/profile')}>
+                Edit
               </button>
-            )}
-          </div>
-        </Card>
-      </main>
-    </>
+              {state.method === 'local' && (
+                <button className="btn-secondary" onClick={exportKey}>
+                  Export key
+                </button>
+              )}
+            </div>
+          </Card>
+        </div>
+      }
+      right={<></>}
+    />
   );
 }
 

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import AppShell from '@/components/layout/AppShell';
 import MainNav from '@/components/layout/MainNav';
 import { Accordion } from '../components/ui/Accordion';
 import { KeysCard } from '../components/settings/KeysCard';
@@ -23,60 +24,65 @@ export default function Settings() {
     }
   }, []);
 
+  const nav = <MainNav showSearch={false} showProfile={false} />;
+
   return (
-    <>
-      <MainNav showSearch={false} showProfile={false} />
-      <main className="max-w-3xl mx-auto px-4 py-10 space-y-6 lg:ml-48">
-        <Accordion
-          initialOpenIndex={initialOpenIndex}
-          items={[
-            {
-              title: 'Profile',
-              content: (
-                <div id="profile">
-                  <ProfileCard />
-                </div>
-              ),
-            },
-            {
-              title: 'Account & Keys',
-              content: (
-                <div className="space-y-6">
-                  <KeysCard />
-                  <AccountCard />
-                </div>
-              ),
-            },
-            {
-              title: 'Wallet Management',
-              content: <LightningCard />,
-            },
-            {
-              title: 'Network',
-              content: <NetworkCard />,
-            },
-            {
-              title: 'Appearance & Language',
-              content: (
-                <div className="space-y-6">
-                  <AppearanceCard />
-                  <LanguageCard />
-                </div>
-              ),
-            },
-            {
-              title: 'Data, Storage & Privacy',
-              content: (
-                <div className="space-y-6">
-                  <StorageCard />
-                  <DataCard />
-                  <PrivacyCard />
-                </div>
-              ),
-            },
-          ]}
-        />
-      </main>
-    </>
+    <AppShell
+      left={nav}
+      center={
+        <div className="max-w-3xl mx-auto px-4 py-10 space-y-6">
+          <Accordion
+            initialOpenIndex={initialOpenIndex}
+            items={[
+              {
+                title: 'Profile',
+                content: (
+                  <div id="profile">
+                    <ProfileCard />
+                  </div>
+                ),
+              },
+              {
+                title: 'Account & Keys',
+                content: (
+                  <div className="space-y-6">
+                    <KeysCard />
+                    <AccountCard />
+                  </div>
+                ),
+              },
+              {
+                title: 'Wallet Management',
+                content: <LightningCard />,
+              },
+              {
+                title: 'Network',
+                content: <NetworkCard />,
+              },
+              {
+                title: 'Appearance & Language',
+                content: (
+                  <div className="space-y-6">
+                    <AppearanceCard />
+                    <LanguageCard />
+                  </div>
+                ),
+              },
+              {
+                title: 'Data, Storage & Privacy',
+                content: (
+                  <div className="space-y-6">
+                    <StorageCard />
+                    <DataCard />
+                    <PrivacyCard />
+                  </div>
+                ),
+              },
+            ]}
+          />
+        </div>
+      }
+      right={<></>}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- add shared nav item definitions
- implement mobile BottomNav and render in AppShell
- wrap profile/settings pages with AppShell for consistent navigation

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68968f6f99248331bedec40b2f66d253