### PR TITLE
Sync following list with Nostr relays

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -19,6 +19,7 @@ import { useInView } from 'react-intersection-observer';
 import { useCurrentVideo } from '../hooks/useCurrentVideo';
 import { useFeedSelection } from '@/store/feedSelection';
 import { getRelays } from '@/lib/nostr';
+import { useAuth } from '@/hooks/useAuth';
 
 const MoreVertical = dynamic(() => import('lucide-react').then((mod) => mod.MoreVertical), {
   ssr: false,
@@ -59,7 +60,10 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const [commentCount, setCommentCount] = useState(0);
   const holdTimer = useRef<number>();
   const [{ opacity }, api] = useSpring(() => ({ opacity: 0 }));
-  const { following, follow } = useFollowing();
+  const { state: auth } = useAuth();
+  const { following, follow } = useFollowing(
+    auth.status === 'ready' ? auth.pubkey : undefined,
+  );
   const [avatar, setAvatar] = useState('');
   const [displayName, setDisplayName] = useState(author);
   const isFollowing = following.includes(pubkey);

--- a/apps/web/components/VideoInfoPane.tsx
+++ b/apps/web/components/VideoInfoPane.tsx
@@ -5,10 +5,14 @@ import { useCurrentVideo } from '../hooks/useCurrentVideo';
 import { useFollowing } from '../hooks/useFollowing';
 import ZapButton from './ZapButton';
 import { getRelays } from '@/lib/nostr';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function VideoInfoPane() {
   const { current } = useCurrentVideo();
-  const { following, follow, unfollow } = useFollowing();
+  const { state: auth } = useAuth();
+  const { following, follow, unfollow } = useFollowing(
+    auth.status === 'ready' ? auth.pubkey : undefined,
+  );
   const [meta, setMeta] = useState<any>(null);
   const [comments, setComments] = useState<Event[]>([]);
 

--- a/apps/web/hooks/useFollowing.test.tsx
+++ b/apps/web/hooks/useFollowing.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import useFollowing from './useFollowing';
+import { useFollowingStore } from '@/store/following';
+
+vi.mock('@/lib/nostr', () => ({
+  getPool: () => ({
+    subscribeMany: (_relays: any, _filters: any, opts: any) => {
+      setTimeout(() => {
+        opts.onevent({ tags: [['p', 'pk1'], ['p', 'pk2']] });
+      }, 0);
+      return { close: vi.fn() };
+    },
+  }),
+  getRelays: () => ['wss://example.com'],
+}));
+
+vi.mock('./useAuth', () => ({
+  useAuth: () => ({ state: { status: 'ready', pubkey: 'me' } }),
+}));
+
+// setup jsdom
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).navigator = dom.window.navigator;
+
+function TestComponent() {
+  useFollowing();
+  return null;
+}
+
+describe('useFollowing', () => {
+  beforeEach(() => {
+    useFollowingStore.setState({ following: [] });
+  });
+
+  it('syncs contacts from relays', async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useFollowingStore.getState().following).toEqual(['pk1', 'pk2']);
+    expect(useFollowingStore.getState().following.length).toBe(2);
+  });
+});

--- a/apps/web/hooks/useFollowing.ts
+++ b/apps/web/hooks/useFollowing.ts
@@ -1,7 +1,35 @@
-import { useFollowingStore } from '@/store/following';
+'use client';
+import { useEffect } from 'react';
+import * as nostrKinds from 'nostr-tools/kinds';
+import type { Filter } from 'nostr-tools/filter';
+import { getPool, getRelays } from '@/lib/nostr';
+import { useFollowingStore, setFollowing } from '@/store/following';
+import { useAuth } from './useAuth';
 
-export function useFollowing() {
-  return useFollowingStore();
+export function useFollowing(pubkey?: string) {
+  const { state } = useAuth();
+  const actualPubkey = pubkey ?? (state.status === 'ready' ? state.pubkey : undefined);
+  const store = useFollowingStore();
+
+  useEffect(() => {
+    if (!actualPubkey) return;
+    const pool = getPool();
+    const sub = pool.subscribeMany(
+      getRelays(),
+      [{ kinds: [nostrKinds.Contacts], authors: [actualPubkey] } as Filter],
+      {
+        onevent: (ev: any) => {
+          const contacts = ev.tags
+            .filter((t: any) => t[0] === 'p' && typeof t[1] === 'string')
+            .map((t: any) => t[1]);
+          setFollowing(Array.from(new Set(contacts)));
+        },
+      },
+    );
+    return () => sub.close();
+  }, [actualPubkey]);
+
+  return store;
 }
 
 export default useFollowing;

--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -14,7 +14,9 @@ export default function FeedPage() {
   const { items: videos } = useFeed(filterAuthor ? { author: filterAuthor } : 'all');
 
   const { state: auth } = useAuth();
-  const { following } = useFollowing();
+  const { following } = useFollowing(
+    auth.status === 'ready' ? auth.pubkey : undefined,
+  );
   const myFollowers = useFollowers(auth.status === 'ready' ? auth.pubkey : undefined);
   const authorFollowers = useFollowers(selectedVideoAuthor);
   const meProfile = useProfile(auth.status === 'ready' ? auth.pubkey : undefined);

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -24,7 +24,9 @@ export default function ProfilePage() {
   const [myPubkey, setMyPubkey] = useState('');
   const [videos, setVideos] = useState<VideoCardProps[]>([]);
   const [selected, setSelected] = useState<VideoCardProps | null>(null);
-  const { following, follow, unfollow } = useFollowing();
+  const { following, follow, unfollow } = useFollowing(
+    state.status === 'ready' ? state.pubkey : undefined,
+  );
   const followers = useFollowers(pubkey);
 
   const isFollowing = pubkey ? following.includes(pubkey) : false;

--- a/apps/web/store/following.ts
+++ b/apps/web/store/following.ts
@@ -5,6 +5,7 @@ export type FollowingState = {
   following: string[];
   follow: (pubkey: string) => void;
   unfollow: (pubkey: string) => void;
+  setFollowing: (pubkeys: string[]) => void;
 };
 
 export const useFollowingStore = create<FollowingState>()(
@@ -21,6 +22,7 @@ export const useFollowingStore = create<FollowingState>()(
         set((state) => ({
           following: state.following.filter((p) => p !== pubkey),
         })),
+      setFollowing: (pubkeys: string[]) => set({ following: pubkeys }),
     }),
     {
       name: 'following',
@@ -32,4 +34,6 @@ export const follow = (pubkey: string) =>
   useFollowingStore.getState().follow(pubkey);
 export const unfollow = (pubkey: string) =>
   useFollowingStore.getState().unfollow(pubkey);
+export const setFollowing = (pubkeys: string[]) =>
+  useFollowingStore.getState().setFollowing(pubkeys);
 export const following = () => useFollowingStore.getState().following;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -7,14 +7,27 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "ui/*": ["../../packages/ui/src/*"],
-      "@/*": ["./*"]
-    }
+      "ui/*": [
+        "../../packages/ui/src/*"
+      ],
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
   },
   "include": [
     "next-env.d.ts",
     "**/*",
-    "../../packages/ui/src/**/*"
+    "../../packages/ui/src/**/*",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- subscribe to Nostr contacts events to derive following list
- sync Zustand store with relay contact updates and use auth pubkey
- update components to consume relay-backed following data
- add test verifying following list matches contacts from relays

## Testing
- `pnpm lint`
- `pnpm test apps/web/hooks/useFollowing.test.tsx apps/web/hooks/useLightning.test.ts -c apps/web/vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68968f96d1fc8331bcfb10c7ba32d7e8