### PR TITLE
feat: add LNURL utilities and tests

### DIFF
--- a/apps/web/components/settings/LightningCard.tsx
+++ b/apps/web/components/settings/LightningCard.tsx
@@ -3,6 +3,7 @@ import type { EventTemplate } from 'nostr-tools/pure';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { getPool, getRelays } from '@/lib/nostr';
+import { fetchPayData, requestInvoice } from '@/utils/lnurl';
 import { Card } from '../ui/Card';
 
 export function LightningCard() {
@@ -10,15 +11,35 @@ export function LightningCard() {
   const meta = useProfile(state.status === 'ready' ? state.pubkey : undefined);
   const [addr, setAddr] = useState('');
   const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [tested, setTested] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     if (meta?.lud16) setAddr(meta.lud16);
   }, [meta]);
 
+  async function testZap() {
+    try {
+      setTesting(true);
+      setError('');
+      const payData = await fetchPayData(addr);
+      await requestInvoice(payData, 1, 'test');
+      setTested(true);
+    } catch (e: any) {
+      setError(e.message || 'Failed to send zap');
+      setTested(false);
+    } finally {
+      setTesting(false);
+    }
+  }
+
   async function save() {
     if (state.status !== 'ready') return;
     try {
       setSaving(true);
+      setError('');
+      await fetchPayData(addr);
       const content = JSON.stringify({ ...(meta || {}), lud16: addr });
       const tmpl: EventTemplate = {
         kind: 0,
@@ -29,9 +50,9 @@ export function LightningCard() {
       const signed = await state.signer.signEvent({ ...tmpl });
       const pool = getPool();
       await pool.publish(getRelays(), signed as any);
-      setSaving(false);
     } catch (e: any) {
-      alert(e.message || 'Failed to save');
+      setError(e.message || 'Failed to save');
+    } finally {
       setSaving(false);
     }
   }
@@ -42,15 +63,28 @@ export function LightningCard() {
         <input
           type="text"
           value={addr}
-          onChange={(e) => setAddr(e.target.value)}
+          onChange={(e) => {
+            setAddr(e.target.value);
+            setTested(false);
+            setError('');
+          }}
           placeholder="name@example.com"
           className="w-full rounded bg-foreground/10 p-2 text-sm outline-none"
         />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <button
+          type="button"
+          onClick={testZap}
+          className="btn btn-secondary"
+          disabled={testing || !addr}
+        >
+          {testing ? 'Testing…' : 'Send test zap'}
+        </button>
         <button
           type="button"
           onClick={save}
           className="btn btn-secondary"
-          disabled={saving || state.status !== 'ready'}
+          disabled={saving || state.status !== 'ready' || !tested}
         >
           {saving ? 'Saving…' : 'Save'}
         </button>

--- a/apps/web/components/settings/__tests__/LightningCard.test.tsx
+++ b/apps/web/components/settings/__tests__/LightningCard.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import LightningCard from '../LightningCard';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    state: { status: 'ready', pubkey: 'pk', signer: { signEvent: vi.fn(async (e: any) => e) } },
+  }),
+}));
+
+vi.mock('@/hooks/useProfile', () => ({
+  useProfile: () => ({}),
+}));
+
+vi.mock('@/lib/nostr', () => ({
+  getPool: () => ({ publish: vi.fn() }),
+  getRelays: () => [],
+}));
+
+const fetchPayDataMock = vi.fn();
+const requestInvoiceMock = vi.fn();
+
+vi.mock('@/utils/lnurl', () => ({
+  fetchPayData: (...args: any[]) => fetchPayDataMock(...args),
+  requestInvoice: (...args: any[]) => requestInvoiceMock(...args),
+}));
+
+describe('LightningCard', () => {
+  beforeEach(() => {
+    fetchPayDataMock.mockReset();
+    requestInvoiceMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('enables save after successful test zap', async () => {
+    fetchPayDataMock.mockResolvedValue({ callback: 'https://cb' });
+    requestInvoiceMock.mockResolvedValue({ invoice: 'inv', result: {} });
+    render(<LightningCard />);
+    const input = screen.getByPlaceholderText('name@example.com');
+    fireEvent.change(input, { target: { value: 'user@example.com' } });
+    fireEvent.click(screen.getByText('Send test zap'));
+    await waitFor(() => expect(requestInvoiceMock).toHaveBeenCalled());
+    const saveBtn = screen.getByText('Save') as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(false);
+    fireEvent.click(saveBtn);
+    await waitFor(() => expect(fetchPayDataMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows error for invalid address', async () => {
+    fetchPayDataMock.mockRejectedValue(new Error('bad'));
+    render(<LightningCard />);
+    const input = screen.getByPlaceholderText('name@example.com');
+    fireEvent.change(input, { target: { value: 'badaddress' } });
+    fireEvent.click(screen.getByText('Send test zap'));
+    await screen.findByText('bad');
+    expect(requestInvoiceMock).not.toHaveBeenCalled();
+    expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('handles failed LNURL request', async () => {
+    fetchPayDataMock.mockResolvedValue({ callback: 'https://cb' });
+    requestInvoiceMock.mockRejectedValue(new Error('fail'));
+    render(<LightningCard />);
+    fireEvent.change(screen.getByPlaceholderText('name@example.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByText('Send test zap'));
+    await screen.findByText('fail');
+    expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/apps/web/hooks/useLightning.test.ts
+++ b/apps/web/hooks/useLightning.test.ts
@@ -27,12 +27,12 @@ describe('useLightning', () => {
     process.env.NEXT_PUBLIC_TREASURY_LNADDR = 'treasury@example.com';
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({ json: async () => ({ callback: 'https://cb1' }) })
-      .mockResolvedValueOnce({ json: async () => ({ pr: 'inv1' }) })
-      .mockResolvedValueOnce({ json: async () => ({ callback: 'https://cb2' }) })
-      .mockResolvedValueOnce({ json: async () => ({ pr: 'inv2' }) })
-      .mockResolvedValueOnce({ json: async () => ({ callback: 'https://cb3' }) })
-      .mockResolvedValueOnce({ json: async () => ({ pr: 'inv3' }) });
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ callback: 'https://cb1' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ pr: 'inv1' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ callback: 'https://cb2' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ pr: 'inv2' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ callback: 'https://cb3' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ pr: 'inv3' }) });
     // @ts-ignore
     global.fetch = fetchMock;
     // @ts-ignore

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,9 @@
     "@paiduan/ui": "workspace:*",
     "@react-spring/web": "^9.7.2",
     "@sentry/nextjs": "^10.2.0",
+    "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
+    "libavjs-webcodecs-polyfill": "^0.5.5",
     "lucide-react": "^0.344.0",
     "next": "^14.2.3",
     "next-intl": "^4.3.4",
@@ -32,9 +34,8 @@
     "react-use-gesture": "^9.1.3",
     "recharts": "^2.8.0",
     "tailwindcss-plugin-rtl": "^1.2.0",
-    "zustand": "^4.5.2",
-    "libavjs-webcodecs-polyfill": "^0.5.5",
-    "web-push": "^3.6.0"
+    "web-push": "^3.6.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/apps/web/utils/lnurl.ts
+++ b/apps/web/utils/lnurl.ts
@@ -1,0 +1,38 @@
+export interface PayData {
+  callback: string;
+  [key: string]: any;
+}
+
+export async function fetchPayData(address: string): Promise<PayData> {
+  const [name, domain] = address.split('@');
+  if (!name || !domain) {
+    throw new Error('Invalid lightning address');
+  }
+  const res = await fetch(`https://${domain}/.well-known/lnurlp/${name}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch LNURL data');
+  }
+  return (await res.json()) as PayData;
+}
+
+export async function requestInvoice(
+  payData: PayData,
+  sats: number,
+  comment?: string,
+): Promise<{ invoice: string; result: any }>
+{
+  if (!payData.callback) {
+    throw new Error('Missing callback');
+  }
+  const url = `${payData.callback}?amount=${sats * 1000}&comment=${encodeURIComponent(comment ?? '')}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to request invoice');
+  }
+  const invoiceData = await res.json();
+  const invoice: string = invoiceData.pr;
+  if (typeof window !== 'undefined') {
+    window.open(`lightning:${invoice}`);
+  }
+  return { invoice, result: invoiceData };
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "packageManager": "pnpm@10.5.2",
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^20.11.19",
     "@types/react": "^18.2.43",
     "eslint": "^8.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^7.3.0
         version: 7.3.0
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^20.11.19
         version: 20.19.9
@@ -69,6 +72,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.2.0
         version: 10.2.0(@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(next@14.2.31(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.101.0)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       framer-motion:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1669,8 +1675,30 @@ packages:
   '@tanstack/virtual-core@3.13.12':
     resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -2073,6 +2101,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -2459,6 +2490,10 @@ packages:
     resolution: {integrity: sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==}
     engines: {node: '>=6'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -2480,6 +2515,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -3381,6 +3419,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
@@ -3828,6 +3870,10 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3884,6 +3930,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -6495,10 +6544,32 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/connect@3.4.38':
     dependencies:
@@ -6933,6 +7004,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -7342,6 +7417,8 @@ snapshots:
       pify: 4.0.1
       rimraf: 2.7.1
 
+  dequal@2.0.3: {}
+
   didyoumean@1.2.2: {}
 
   diff-sequences@29.6.3: {}
@@ -7359,6 +7436,8 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -8459,6 +8538,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.25.9:
     dependencies:
       sourcemap-codec: 1.4.8
@@ -8873,6 +8954,12 @@ snapshots:
 
   pretty-bytes@5.6.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -8926,6 +9013,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 


### PR DESCRIPTION
## Summary
- extract LNURL-pay helpers into shared utils
- validate lightning addresses and allow test zaps before saving
- cover lightning address validation and LNURL failures with tests

## Testing
- `pnpm vitest run -c apps/web/vitest.config.ts apps/web/components/settings/__tests__/LightningCard.test.tsx apps/web/hooks/useLightning.test.ts`
- `pnpm --filter @paiduan/web lint`


------
https://chatgpt.com/codex/tasks/task_e_6896939fceb88331a93cc7dc3a3b1b74