### PR TITLE
Constrain video cards to viewport height

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -166,7 +166,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="relative h-full w-full overflow-hidden rounded-2xl bg-card text-white shadow-card"
+      className="relative w-full max-h-screen overflow-hidden rounded-2xl bg-card text-white shadow-card"
       onDoubleClick={onLike}
       onClick={() => setSelectedVideo(eventId, pubkey)}
       onPointerDown={handlePointerDown}

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -16,8 +16,8 @@ export default function AppShell({
         </aside>
 
         {/* Middle column: main feed */}
-        <main className="min-h-screen">
-          <div className="max-w-2xl mx-auto px-4 py-6">{center}</div>
+        <main className="h-screen overflow-y-auto">
+          <div className="max-w-2xl mx-auto px-4 py-4">{center}</div>
         </main>
 
         {/* Right column: author info & comments (sticky on desktop) */}

--- a/apps/web/components/ui/SkeletonVideoCard.tsx
+++ b/apps/web/components/ui/SkeletonVideoCard.tsx
@@ -3,7 +3,7 @@ import Skeleton from './Skeleton';
 
 export function SkeletonVideoCard() {
   return (
-    <div className="relative h-full w-full overflow-hidden rounded-2xl bg-foreground/10">
+    <div className="relative w-full max-h-screen overflow-hidden rounded-2xl bg-foreground/10">
       <Skeleton className="h-full w-full" />
       <div className="absolute bottom-0 left-0 w-full p-4">
         <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- align main feed with the viewport and reduce center padding
- limit video cards and skeletons to the screen height to prevent overflow

## Testing
- `pnpm test` *(fails: Failed to load url @/store/following; Analytics POST network errors)*

------
https://chatgpt.com/codex/tasks/task_e_689694bd838c8331a68ffb947e522030