### PR TITLE
feat: add WebLN support

### DIFF
--- a/apps/web/components/settings/LightningCard.tsx
+++ b/apps/web/components/settings/LightningCard.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { getPool, getRelays } from '@/lib/nostr';
 import { fetchPayData, requestInvoice } from '@/utils/lnurl';
+import useWebLN from '@/hooks/useWebLN';
 import { Card } from '../ui/Card';
 
 export function LightningCard() {
@@ -14,6 +15,7 @@ export function LightningCard() {
   const [testing, setTesting] = useState(false);
   const [tested, setTested] = useState(false);
   const [error, setError] = useState('');
+  const { webln, getInfo } = useWebLN();
 
   useEffect(() => {
     if (meta?.lud16) setAddr(meta.lud16);
@@ -31,6 +33,20 @@ export function LightningCard() {
       setTested(false);
     } finally {
       setTesting(false);
+    }
+  }
+
+  async function connect() {
+    try {
+      const info = await getInfo();
+      const lightningAddress =
+        info?.lightningAddress || info?.node?.alias || info?.node?.lightning_address;
+      if (lightningAddress) {
+        setAddr(lightningAddress);
+        setTested(false);
+      }
+    } catch (e: any) {
+      setError(e.message || 'Failed to connect wallet');
     }
   }
 
@@ -71,6 +87,11 @@ export function LightningCard() {
           placeholder="name@example.com"
           className="w-full rounded bg-foreground/10 p-2 text-sm outline-none"
         />
+        {webln && (
+          <button type="button" onClick={connect} className="btn btn-secondary">
+            Connect wallet
+          </button>
+        )}
         {error && <p className="text-sm text-red-500">{error}</p>}
         <button
           type="button"

--- a/apps/web/components/settings/__tests__/LightningCard.test.tsx
+++ b/apps/web/components/settings/__tests__/LightningCard.test.tsx
@@ -35,6 +35,8 @@ describe('LightningCard', () => {
 
   afterEach(() => {
     cleanup();
+    // @ts-ignore
+    delete window.webln;
   });
 
   it('enables save after successful test zap', async () => {
@@ -72,5 +74,19 @@ describe('LightningCard', () => {
     fireEvent.click(screen.getByText('Send test zap'));
     await screen.findByText('fail');
     expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('connects via WebLN and sets address', async () => {
+    // @ts-ignore
+    window.webln = {
+      getInfo: vi.fn().mockResolvedValue({ lightningAddress: 'user@example.com' }),
+    };
+    render(<LightningCard />);
+    const btn = await screen.findByText('Connect wallet');
+    fireEvent.click(btn);
+    await screen.findByDisplayValue('user@example.com');
+    // cleanup
+    // @ts-ignore
+    delete window.webln;
   });
 });

--- a/apps/web/hooks/useLightning.test.ts
+++ b/apps/web/hooks/useLightning.test.ts
@@ -35,8 +35,10 @@ describe('useLightning', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ pr: 'inv3' }) });
     // @ts-ignore
     global.fetch = fetchMock;
+    const sendPaymentMock = vi.fn();
     // @ts-ignore
     global.window = {
+      webln: { sendPayment: sendPaymentMock },
       open: vi.fn(),
     };
 
@@ -50,6 +52,6 @@ describe('useLightning', () => {
 
     expect(invoices.length).toBe(3);
     expect(fetchMock).toHaveBeenCalledTimes(6);
-    expect((global as any).window.open).toHaveBeenCalledTimes(3);
+    expect(sendPaymentMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/web/hooks/useLightning.ts
+++ b/apps/web/hooks/useLightning.ts
@@ -23,7 +23,19 @@ export default function useLightning() {
 
   const payLn = async (lnaddr: string, sats: number, comment?: string) => {
     const payData = await fetchPayData(lnaddr);
-    return requestInvoice(payData, sats, comment);
+    const res = await requestInvoice(payData, sats, comment);
+    if (typeof window !== 'undefined') {
+      try {
+        if (window.webln) {
+          await window.webln.sendPayment(res.invoice);
+        } else {
+          window.open(`lightning:${res.invoice}`);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    return res;
   };
 
   const createZap = async ({ lightningAddress, amount, comment, eventId, pubkey }: ZapArgs) => {

--- a/apps/web/hooks/useWebLN.ts
+++ b/apps/web/hooks/useWebLN.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+interface WebLNProvider {
+  getInfo: () => Promise<any>;
+  sendPayment: (invoice: string) => Promise<any>;
+}
+
+declare global {
+  interface Window {
+    webln?: WebLNProvider;
+  }
+}
+
+export default function useWebLN() {
+  const [webln, setWebln] = useState<WebLNProvider | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.webln) {
+      setWebln(window.webln);
+    }
+  }, []);
+
+  const getInfo = async () => {
+    if (!webln) throw new Error('WebLN not available');
+    return webln.getInfo();
+  };
+
+  const sendPayment = async (invoice: string) => {
+    if (webln) {
+      return webln.sendPayment(invoice);
+    }
+    if (typeof window !== 'undefined') {
+      window.open(`lightning:${invoice}`);
+    }
+  };
+
+  return { webln, getInfo, sendPayment };
+}
+

--- a/apps/web/utils/lnurl.ts
+++ b/apps/web/utils/lnurl.ts
@@ -31,8 +31,5 @@ export async function requestInvoice(
   }
   const invoiceData = await res.json();
   const invoice: string = invoiceData.pr;
-  if (typeof window !== 'undefined') {
-    window.open(`lightning:${invoice}`);
-  }
   return { invoice, result: invoiceData };
 }


### PR DESCRIPTION
## Summary
- add `useWebLN` hook to detect WebLN provider and send payments
- route LN payments through WebLN when available and expose wallet connect in `LightningCard`
- test WebLN flows via mocked provider

## Testing
- `pnpm test` *(fails: Failed to resolve import "@/hooks/useAuth" etc.)*
- `pnpm vitest run -c apps/web/vitest.config.ts apps/web/hooks/useLightning.test.ts apps/web/components/settings/__tests__/LightningCard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689695b29f348331a7917817705d235f