### PR TITLE
Ensure feed column shows single video without scrolling

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -61,9 +61,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const holdTimer = useRef<number>();
   const [{ opacity }, api] = useSpring(() => ({ opacity: 0 }));
   const { state: auth } = useAuth();
-  const { following, follow } = useFollowing(
-    auth.status === 'ready' ? auth.pubkey : undefined,
-  );
+  const { following, follow } = useFollowing(auth.status === 'ready' ? auth.pubkey : undefined);
   const [avatar, setAvatar] = useState('');
   const [displayName, setDisplayName] = useState(author);
   const isFollowing = following.includes(pubkey);
@@ -166,7 +164,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="relative w-full max-h-screen overflow-hidden rounded-2xl bg-card text-white shadow-card"
+      className="relative w-full h-full max-h-full overflow-hidden rounded-2xl bg-card text-white shadow-card"
       onDoubleClick={onLike}
       onClick={() => setSelectedVideo(eventId, pubkey)}
       onPointerDown={handlePointerDown}

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -6,7 +6,11 @@ export default function AppShell({
   left,
   center,
   right,
-}: { left: React.ReactNode; center: React.ReactNode; right: React.ReactNode }) {
+}: {
+  left: React.ReactNode;
+  center: React.ReactNode;
+  right: React.ReactNode;
+}) {
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto w-full max-w-[1400px] bg-surface grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
@@ -16,8 +20,8 @@ export default function AppShell({
         </aside>
 
         {/* Middle column: main feed */}
-        <main className="h-screen overflow-y-auto">
-          <div className="max-w-2xl mx-auto px-4 py-4">{center}</div>
+        <main className="h-screen overflow-hidden">
+          <div className="max-w-2xl mx-auto h-full px-4">{center}</div>
         </main>
 
         {/* Right column: author info & comments (sticky on desktop) */}


### PR DESCRIPTION
## Summary
- Prevent feed column from scrolling by switching AppShell's main area to `overflow-hidden` and removing vertical padding.
- Allow video cards to expand fully within their container by replacing `max-h-screen` with `h-full max-h-full`.

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test` *(fails: Failed to resolve imports in tests and network analytics post errors)*

------
https://chatgpt.com/codex/tasks/task_e_689697a454048331824d0347a2d421e6