### PR TITLE
feat: add shared onboarding layout with branding

### DIFF
--- a/apps/web/app/onboarding/key/page.tsx
+++ b/apps/web/app/onboarding/key/page.tsx
@@ -2,14 +2,14 @@
 
 import { useRouter } from 'next/navigation';
 import KeySetupStep from '@/components/onboarding/KeySetupStep';
+import OnboardingLayout from '@/components/onboarding/OnboardingLayout';
 
 export default function KeyOnboardingPage() {
   const router = useRouter();
   return (
-    <section className="min-h-screen py-16 px-4 flex flex-col items-center justify-center text-center bg-background">
-      <div className="w-full max-w-md mx-auto flex justify-center">
-        <KeySetupStep onComplete={() => router.push('/onboarding/profile')} />
-      </div>
-    </section>
+    <OnboardingLayout>
+      <KeySetupStep onComplete={() => router.push('/onboarding/profile')} />
+    </OnboardingLayout>
   );
 }
+

--- a/apps/web/app/onboarding/profile/page.tsx
+++ b/apps/web/app/onboarding/profile/page.tsx
@@ -2,15 +2,19 @@
 
 import { useRouter } from 'next/navigation';
 import ProfileSetupStep from '@/components/onboarding/ProfileSetupStep';
+import OnboardingLayout from '@/components/onboarding/OnboardingLayout';
 
 export default function ProfileOnboardingPage() {
   const router = useRouter();
   return (
-    <ProfileSetupStep
-      onComplete={() => {
-        localStorage.setItem('pd.onboarded', '1');
-        router.replace('/feed');
-      }}
-    />
+    <OnboardingLayout>
+      <ProfileSetupStep
+        onComplete={() => {
+          localStorage.setItem('pd.onboarded', '1');
+          router.replace('/feed');
+        }}
+      />
+    </OnboardingLayout>
   );
 }
+

--- a/apps/web/components/onboarding/OnboardingLayout.tsx
+++ b/apps/web/components/onboarding/OnboardingLayout.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import Logo from '@/components/branding/Logo';
+import HeroArt from '@/components/branding/HeroArt';
+import type { ReactNode } from 'react';
+
+export default function OnboardingLayout({ children }: { children: ReactNode }) {
+  return (
+    <section className="min-h-screen grid grid-cols-1 lg:grid-cols-2 bg-background">
+      <div className="flex flex-col items-center justify-center p-8 text-center space-y-6">
+        <Logo width={180} height={40} />
+        <HeroArt className="w-full max-w-xs text-primary" />
+        <p className="text-lg opacity-80 max-w-md">
+          Lightning-fast short video, powered by Nostr and Lightning.
+        </p>
+      </div>
+      <div className="flex items-center justify-center p-8">
+        {children}
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add shared `OnboardingLayout` with logo, hero art, and copy
- switch key and profile onboarding pages to the new layout

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test` *(fails: Failed to resolve import "@/hooks/useAuth" in LightningCard.test.tsx; Failed to load url @/store/following in useFollowing.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689699f537e88331be30bd2f508e1d9f