### PR TITLE
Add zap history display to settings

### DIFF
--- a/apps/web/components/settings/LightningHistory.tsx
+++ b/apps/web/components/settings/LightningHistory.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Card } from '../ui/Card';
+import useZapHistory from '@/hooks/useZapHistory';
+
+export function LightningHistory() {
+  const { events, totalAmount, totalCount } = useZapHistory();
+
+  return (
+    <Card title="Lightning History" desc="Recent zaps and totals.">
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm" data-testid="totals">
+          <span data-testid="total-amount">{totalAmount} sats</span>
+          <span data-testid="total-count">{totalCount} zaps</span>
+        </div>
+        <ul className="space-y-1">
+          {events.map((e) => (
+            <li key={e.id} className="flex justify-between text-sm">
+              <span>{e.from.slice(0, 8)}</span>
+              <span>{e.amount} sats</span>
+              <span>{new Date(e.created_at * 1000).toLocaleString()}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Card>
+  );
+}
+
+export default LightningHistory;

--- a/apps/web/components/settings/__tests__/LightningHistory.test.tsx
+++ b/apps/web/components/settings/__tests__/LightningHistory.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import LightningHistory from '../LightningHistory';
+
+vi.mock('@/lib/nostr', () => ({
+  getRelays: () => [],
+}));
+
+const subscribeManyMock = vi.hoisted(() => vi.fn());
+let onEvent: any;
+
+vi.mock('@/hooks/pool', () => ({
+  default: {
+    subscribeMany: (...args: any[]) => subscribeManyMock(...args),
+  },
+}));
+
+describe('LightningHistory', () => {
+  beforeEach(() => {
+    subscribeManyMock.mockReset();
+    subscribeManyMock.mockImplementation((_relays: any, _filters: any, opts: any) => {
+      onEvent = opts.onevent;
+      return { close: vi.fn() };
+    });
+    (window as any).nostr = { getPublicKey: async () => 'pk' };
+  });
+
+  it('renders zap events in order and updates totals', async () => {
+    render(<LightningHistory />);
+    await waitFor(() => expect(subscribeManyMock).toHaveBeenCalled());
+
+    act(() => {
+      onEvent({ id: '1', pubkey: 'alice', tags: [['amount', '1000']], created_at: 1 });
+      onEvent({ id: '2', pubkey: 'bob', tags: [['amount', '2000']], created_at: 2 });
+    });
+
+    const items = await screen.findAllByRole('listitem');
+    expect(items[0].textContent).toContain('2 sats');
+    expect(items[1].textContent).toContain('1 sats');
+    expect(screen.getByTestId('total-amount').textContent).toContain('3');
+    expect(screen.getByTestId('total-count').textContent).toContain('2');
+
+    act(() => {
+      onEvent({ id: '3', pubkey: 'carol', tags: [['amount', '3000']], created_at: 3 });
+    });
+
+    const items2 = await screen.findAllByRole('listitem');
+    expect(items2[0].textContent).toContain('3 sats');
+    expect(screen.getByTestId('total-amount').textContent).toContain('6');
+    expect(screen.getByTestId('total-count').textContent).toContain('3');
+  });
+});

--- a/apps/web/hooks/useZapHistory.ts
+++ b/apps/web/hooks/useZapHistory.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+import pool from './pool';
+import { getRelays } from '@/lib/nostr';
+
+export interface ZapEvent {
+  id: string;
+  from: string;
+  amount: number;
+  created_at: number;
+}
+
+interface ZapHistory {
+  events: ZapEvent[];
+  totalAmount: number;
+  totalCount: number;
+}
+
+export default function useZapHistory(): ZapHistory {
+  const [events, setEvents] = useState<ZapEvent[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const nostr = (window as any).nostr;
+    if (!nostr) return;
+    let sub: { close: () => void } | null = null;
+
+    (async () => {
+      try {
+        const pubkey = await nostr.getPublicKey();
+        const relays = getRelays();
+        sub = pool.subscribeMany(relays, [{ kinds: [9735], '#p': [pubkey] }], {
+          onevent: (ev: NostrEvent) => {
+            const amt = ev.tags.find((t) => t[0] === 'amount');
+            const amount = amt ? Math.round(parseInt(amt[1] || '0', 10) / 1000) : 0;
+            setEvents((prev) => {
+              if (prev.find((p) => p.id === ev.id)) return prev;
+              const next = [
+                {
+                  id: ev.id,
+                  from: ev.pubkey,
+                  amount,
+                  created_at: ev.created_at,
+                },
+                ...prev,
+              ]
+                .sort((a, b) => b.created_at - a.created_at)
+                .slice(0, 50);
+              return next;
+            });
+          },
+        });
+      } catch {
+        /* ignore */
+      }
+    })();
+
+    return () => {
+      sub?.close();
+    };
+  }, []);
+
+  const totalAmount = events.reduce((sum, e) => sum + e.amount, 0);
+  const totalCount = events.length;
+
+  return { events, totalAmount, totalCount };
+}
+
+export { useZapHistory };

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -5,6 +5,7 @@ import { Accordion } from '../components/ui/Accordion';
 import { KeysCard } from '../components/settings/KeysCard';
 import { AccountCard } from '@/components/settings/AccountCard';
 import { LightningCard } from '../components/settings/LightningCard';
+import { LightningHistory } from '../components/settings/LightningHistory';
 import { NetworkCard } from '../components/settings/NetworkCard';
 import { AppearanceCard } from '../components/settings/AppearanceCard';
 import { LanguageCard } from '@/components/settings/LanguageCard';
@@ -53,7 +54,12 @@ export default function Settings() {
               },
               {
                 title: 'Wallet Management',
-                content: <LightningCard />,
+                content: (
+                  <div className="space-y-6">
+                    <LightningCard />
+                    <LightningHistory />
+                  </div>
+                ),
               },
               {
                 title: 'Network',


### PR DESCRIPTION
## Summary
- implement `useZapHistory` hook subscribing to zap receipts and aggregating totals
- display zap history and totals with new `LightningHistory` component on settings page
- test zap event ordering and total updates

## Testing
- `pnpm test` *(fails: Failed to resolve import "@/hooks/useAuth" from "apps/web/components/settings/LightningCard.tsx")*
- `pnpm vitest run -c apps/web/vitest.config.ts apps/web/components/settings/__tests__/LightningHistory.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68969a07c84c8331a75b509bcabce780