### PR TITLE
Use Feed component on feed page

### DIFF
--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -2,6 +2,7 @@ import AppShell from '@/components/layout/AppShell';
 import MainNav from '@/components/layout/MainNav';
 import RightPanel from '@/components/feed/RightPanel';
 import PlaceholderVideo from '@/components/PlaceholderVideo';
+import Feed from '@/components/Feed';
 import useFeed from '@/hooks/useFeed';
 import { useAuth } from '@/hooks/useAuth';
 import useFollowing from '@/hooks/useFollowing';
@@ -55,12 +56,12 @@ export default function FeedPage() {
     <AppShell
       left={<MainNav me={me} />}
       center={
-        <div className="space-y-6">
+        <div className="h-full">
           {/* tabs bar you already have can stay on top */}
           {videos.length === 0 ? (
             <PlaceholderVideo className="aspect-[9/16] w-full max-w-[420px] mx-auto text-foreground" />
           ) : (
-            videos.map((v) => <div key={v.eventId}>{/* <VideoCard {...v} /> */}</div>)
+            <Feed items={videos} />
           )}
         </div>
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'apps/web'),
+      ui: path.resolve(__dirname, 'packages/ui/src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- render videos using the reusable `Feed` component
- make feed container full height so one video fills the viewport

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test` *(fails: Failed to load url @/store/following)*

------
https://chatgpt.com/codex/tasks/task_e_68969ac7ecb483318072f219915d0504