### PR TITLE
fix: keep video preview within viewport

### DIFF
--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -223,7 +223,7 @@ export default function CreateVideoForm() {
   );
 
   return (
-    <section className="max-w-4xl mx-auto overflow-auto rounded-2xl border border-border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
+    <section className="max-w-4xl mx-auto rounded-2xl border border-border bg-white/5 dark:bg-neutral-900 p-6 space-y-4">
       <div className="flex items-center justify-end">
         <button className="text-sm text-muted-foreground" onClick={handleCancel}>
           Cancel
@@ -238,7 +238,7 @@ export default function CreateVideoForm() {
             className="block w-full text-sm rounded-md border border-border bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
           />
             {preview ? (
-              <div className="relative aspect-[9/16] w-full max-w-sm max-h-[calc(100vh-8rem)] overflow-hidden rounded-xl bg-black">
+              <div className="relative aspect-[9/16] w-full max-w-sm max-h-[calc(100vh-9rem)] overflow-hidden rounded-xl bg-black">
                 <video
                   controls
                   src={preview}
@@ -252,7 +252,7 @@ export default function CreateVideoForm() {
                 )}
               </div>
             ) : (
-              <div className="relative aspect-[9/16] w-full max-w-sm max-h-[calc(100vh-8rem)] overflow-hidden rounded-xl bg-black">
+              <div className="relative aspect-[9/16] w-full max-w-sm max-h-[calc(100vh-9rem)] overflow-hidden rounded-xl bg-black">
                 <PlaceholderVideo className="absolute inset-0 h-full w-full object-cover" />
               </div>
             )}


### PR DESCRIPTION
## Summary
- prevent video preview from exceeding viewport by lowering max height
- remove overflow auto from container to avoid extra scrollbars

## Testing
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68969b5a03f88331a13f022a9d80bc24