### PR TITLE
refactor: make create layout responsive

### DIFF
--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -254,7 +254,7 @@ export default function CreateVideoForm() {
           Cancel
         </button>
       </div>
-      <div className="lg:grid lg:grid-cols-2 lg:gap-4 lg:space-y-0 space-y-4">
+      <div className="flex flex-1 flex-wrap gap-4 items-start">
         <div className="space-y-4">
           <input
             type="file"
@@ -263,7 +263,7 @@ export default function CreateVideoForm() {
             className="block w-full text-sm rounded-md border border-border bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
           />
             {preview ? (
-              <div className="relative aspect-[9/16] w-full max-w-sm max-h-[calc(100vh-9rem)] overflow-hidden rounded-xl bg-black">
+              <div className="relative aspect-[9/16] h-[70vh] max-w-sm overflow-hidden rounded-xl">
                 <video
                   controls
                   src={preview}
@@ -277,7 +277,7 @@ export default function CreateVideoForm() {
                 )}
               </div>
             ) : (
-              <div className="relative aspect-[9/16] w-full max-w-sm max-h-[calc(100vh-9rem)] overflow-hidden rounded-xl bg-black">
+              <div className="relative aspect-[9/16] h-[70vh] max-w-sm overflow-hidden rounded-xl">
                 <PlaceholderVideo className="absolute inset-0 h-full w-full object-cover" />
               </div>
             )}

--- a/apps/web/components/create/CreatorWizard.tsx
+++ b/apps/web/components/create/CreatorWizard.tsx
@@ -3,7 +3,7 @@ import CreateVideoForm from './CreateVideoForm';
 
 export default function CreatorWizard() {
   return (
-    <div className="mx-auto py-12 px-4 space-y-6 lg:py-4">
+    <div className="flex flex-col min-h-[calc(100vh-5rem)] px-4 gap-6 lg:flex-row">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">Create Video</h1>
       </div>

--- a/apps/web/pages/create.tsx
+++ b/apps/web/pages/create.tsx
@@ -6,17 +6,19 @@ const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'),
 
 export default function CreatePage() {
   return (
-    <main className="mx-auto max-w-[1400px] px-4">
-      <div className="grid gap-6 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[280px_minmax(0,1fr)_340px]">
-        <aside className="hidden lg:block self-start sticky top-20 space-y-4">
-          <SearchBar />
-          <MiniProfileCard />
-        </aside>
+    <div className="box-border min-h-screen h-screen">
+      <main className="mx-auto max-w-[1400px] px-4 h-full">
+        <div className="grid h-full gap-6 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[280px_minmax(0,1fr)_340px]">
+          <aside className="hidden lg:block self-start sticky top-20 space-y-4">
+            <SearchBar />
+            <MiniProfileCard />
+          </aside>
 
-        <section className="xl:col-span-2">
-          <CreatorWizard />
-        </section>
-      </div>
-    </main>
+          <section className="xl:col-span-2">
+            <CreatorWizard />
+          </section>
+        </div>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- restructure CreatorWizard with flex layout and viewport-aware height
- switch CreateVideoForm to flex, responsive video preview
- wrap create page with full-height container

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_68969ef8674c8331bb42363578b1b2d7