### PR TITLE
Fix Following nav link and refine active route detection

### DIFF
--- a/apps/web/components/layout/MainNav.tsx
+++ b/apps/web/components/layout/MainNav.tsx
@@ -27,7 +27,7 @@ export default function MainNav({
   showProfile = true,
 }: MainNavProps) {
   const { mode, toggleMode } = useTheme();
-  const { asPath } = useRouter();
+  const { asPath, locale } = useRouter();
 
   return (
     <div className="p-[1.2rem] space-y-4">
@@ -45,7 +45,15 @@ export default function MainNav({
       <nav className={`${cardStyle} p-2`}>
         <ul className="flex flex-col">
           {navItems.map(({ href, label, icon: Icon }) => {
-            const active = asPath.startsWith(href);
+            const currentUrl = new URL(asPath, 'http://localhost');
+            const targetUrl = new URL(href, 'http://localhost');
+            let currentPath = currentUrl.pathname;
+            if (locale) currentPath = currentPath.replace(new RegExp(`^/${locale}`), '');
+            const active =
+              currentPath === targetUrl.pathname &&
+              (targetUrl.search
+                ? currentUrl.search === targetUrl.search
+                : currentUrl.search === '');
             return (
               <li key={href}>
                 <Link

--- a/apps/web/components/layout/nav.ts
+++ b/apps/web/components/layout/nav.ts
@@ -9,7 +9,7 @@ export interface NavItem {
 
 export const navItems: NavItem[] = [
   { href: '/feed', label: 'Home', icon: Home },
-  { href: '/following', label: 'Following', icon: Users },
+  { href: '/feed?tab=following', label: 'Following', icon: Users },
   { href: '/create', label: 'Create', icon: Plus },
   { href: '/settings', label: 'Settings', icon: User },
 ];


### PR DESCRIPTION
## Summary
- point Following navigation item to `/feed?tab=following`
- compare normalized path and query string to set active navigation state

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896a11fe6008331ab9f185071ca9800