### PR TITLE
refactor: replace accent token

### DIFF
--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -27,7 +27,7 @@ export default function MiniProfileCard({
       )}
       <Link
         href="/settings#profile"
-        className="text-xs text-[hsl(var(--accent-primary))]"
+        className="text-xs text-[var(--accent-primary)]"
       >
         Manage profile
       </Link>


### PR DESCRIPTION
## Summary
- refactor accent token in MiniProfileCard
- scan repository for deprecated `var(--accent)` token

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896a401583c8331885fc411cef6f13a