### PR TITLE
feat: use theme tokens for card

### DIFF
--- a/apps/web/components/ui/Card.tsx
+++ b/apps/web/components/ui/Card.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 export const cardStyle =
-  'bg-[#1e1e1e] rounded-[10px] shadow-[0_2px_8px_rgba(0,0,0,0.3)]';
+  'bg-[var(--background-secondary)] rounded-[10px] border border-border-primary shadow-card';
 
 export function Card({
   title,


### PR DESCRIPTION
## Summary
- reference theme variables for Card background, border, and shadow

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896a91660c88331a3633ddf2aad5a97