### PR TITLE
feat: reload video preview on change

### DIFF
--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -30,6 +30,9 @@ describe('CreateVideoForm', () => {
     mockTrim.mockReset();
     mockSignEvent.mockReset();
     mockPublish.mockReset();
+    (URL as any).revokeObjectURL = vi.fn();
+    (HTMLMediaElement.prototype as any).load = vi.fn();
+    (HTMLMediaElement.prototype as any).play = vi.fn(() => Promise.resolve());
     (globalThis as any).fetch = undefined;
   });
 


### PR DESCRIPTION
## Summary
- reload preview video when blob changes
- release previous object URLs to prevent memory leaks

## Testing
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6896a92f885083319c528479bb42c038