### PR TITLE
Use accent variables for button styles

### DIFF
--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -1,14 +1,14 @@
-"use client"
+'use client';
 
-import { useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation';
 
 export default function Hero() {
-  const router = useRouter()
+  const router = useRouter();
 
   const handleClick = () => {
-    const privKey = localStorage.privkey
-    router.push(privKey ? '/feed' : '/onboarding/key')
-  }
+    const privKey = localStorage.privkey;
+    router.push(privKey ? '/feed' : '/onboarding/key');
+  };
 
   return (
     <section className="py-16 px-4 grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
@@ -21,7 +21,7 @@ export default function Hero() {
           Lightning-fast short video, powered by Nostr and Lightning.
         </p>
         <div className="mt-8 flex justify-center md:justify-start">
-          <button className="btn-primary" onClick={handleClick}>
+          <button className="btn btn-primary" onClick={handleClick}>
             Get Started
           </button>
         </div>
@@ -29,5 +29,5 @@ export default function Hero() {
       {/* right: preview grid */}
       <div></div>
     </section>
-  )
+  );
 }

--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -85,7 +85,7 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
   return (
     <div className="flex flex-col gap-3 w-full max-w-xs">
       <Button
-        className="btn-primary w-full"
+        className="btn btn-primary w-full"
         onClick={connectExtension}
         disabled={!(globalThis as any).nostr}
       >

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -61,30 +61,25 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
     const size = Math.min(croppedArea.width, croppedArea.height);
     canvas.width = size;
     canvas.height = size;
-    ctx.drawImage(
-      image,
-      croppedArea.x,
-      croppedArea.y,
-      size,
-      size,
-      0,
-      0,
-      size,
-      size
-    );
+    ctx.drawImage(image, croppedArea.x, croppedArea.y, size, size, 0, 0, size, size);
     const dataUrl = canvas.toDataURL('image/png');
     setPicture(dataUrl);
     setRawImage('');
   }, [rawImage, croppedArea]);
 
-  async function setMetadata(data: { name?: string; about?: string; picture?: string; lud16?: string }) {
+  async function setMetadata(data: {
+    name?: string;
+    about?: string;
+    picture?: string;
+    lud16?: string;
+  }) {
     if (state.status !== 'ready') throw new Error('Not signed in');
     const content = JSON.stringify(data);
     const tmpl: EventTemplate = {
       kind: 0,
       created_at: Math.floor(Date.now() / 1000),
       tags: [],
-      content
+      content,
     };
     const signed = await state.signer.signEvent({ ...tmpl });
     const pool = getPool();
@@ -167,7 +162,7 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
         <Button
           onClick={saveProfile}
           disabled={loading}
-          className="btn-primary disabled:opacity-50"
+          className="btn btn-primary disabled:opacity-50"
         >
           {loading ? 'Saving…' : 'Save'}
         </Button>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -55,14 +55,14 @@ body {
     @apply px-4 py-2.5 rounded-xl font-medium focus-visible:outline-none focus-visible:ring-2 ring-offset-2;
   }
   .btn-primary {
-    background: hsl(var(--accent-primary));
+    background-color: hsl(var(--accent-primary));
     color: white;
   }
   .btn-primary:hover {
-    background: hsl(var(--accent-hover));
+    background-color: hsl(var(--accent-hover));
   }
   .btn-primary:active {
-    background: hsl(var(--accent-active));
+    background-color: hsl(var(--accent-active));
   }
   .btn-secondary {
     @apply border border-current text-current bg-transparent;


### PR DESCRIPTION
## Summary
- use accent CSS variables for `.btn-primary` with hover and active states
- apply base `btn` class alongside `btn-primary` in onboarding and landing buttons

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ERR_WORKER_OUT_OF_MEMORY)*

------
https://chatgpt.com/codex/tasks/task_e_6896a9ec96d88331a1f6f7abc24685e2