### PR TITLE
Include percentages in zap tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ the browser is not supported—prepare clips ahead of time:
 2. Trim the clip and capture a poster frame
 3. Add a caption, upload the assets, and publish a NIP‑23 note
 
-Publishing now includes an optional `['zap', <lnaddr>]` tag when a Lightning address is available.
+Publishing now includes `['zap', <lnaddr>, <pct>]` tags for the creator and any collaborators when Lightning addresses are provided.
 
 For manual testing of the upload endpoint you can use cURL:
 

--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -145,6 +145,7 @@ describe('CreateVideoForm', () => {
 
     expect(mockFetch).toHaveBeenCalledWith('https://nostr.media/api/upload', expect.any(Object));
     const tags = mockSignEvent.mock.calls[0][0].tags;
+    expect(tags).toContainEqual(['zap', 'addr', '100']);
     expect(tags).toContainEqual(['copyright', 'CC BY']);
   });
 
@@ -216,6 +217,7 @@ describe('CreateVideoForm', () => {
     const body = mockFetch.mock.calls[0][1].body as FormData;
     expect(body.get('zapSplits')).toBe(JSON.stringify([{ lnaddr: 'col@example.com', pct: 10 }]));
     const tags = mockSignEvent.mock.calls[0][0].tags;
+    expect(tags).toContainEqual(['zap', 'addr', '90']);
     expect(tags).toContainEqual(['zap', 'col@example.com', '10']);
   });
 

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -168,7 +168,9 @@ export default function CreateVideoForm() {
         ['vman', manifest],
         ...topicList.map((t) => ['t', t]),
       ];
-      if (lightningAddress) tags.push(['zap', lightningAddress]);
+      const creatorPct = Math.max(0, 100 - totalPct);
+      if (lightningAddress)
+        tags.push(['zap', lightningAddress, creatorPct.toString()]);
       zapSplits.forEach((s) => {
         if (s.lnaddr && s.pct > 0) tags.push(['zap', s.lnaddr, s.pct.toString()]);
       });

--- a/apps/web/hooks/useFeed.ts
+++ b/apps/web/hooks/useFeed.ts
@@ -94,7 +94,7 @@ export function useFeed(mode: FeedMode, authors: string[] = []): FeedResult {
         if (!videoTag) return;
         const posterTag = event.tags.find((t) => t[0] === 'image');
         const manifestTag = event.tags.find((t) => t[0] === 'vman');
-        const zapTag = event.tags.find((t) => t[0] === 'zap');
+        const zapTags = event.tags.filter((t) => t[0] === 'zap');
         const tTags = event.tags.filter((t) => t[0] === 't').map((t) => t[1]);
         tTags.forEach((t) => {
           tagCounts[t] = (tagCounts[t] || 0) + 1;
@@ -106,7 +106,7 @@ export function useFeed(mode: FeedMode, authors: string[] = []): FeedResult {
           author: event.pubkey.slice(0, 8),
           caption: tTags.join(' '),
           eventId: event.id,
-          lightningAddress: zapTag ? zapTag[1] : '',
+          lightningAddress: zapTags.length ? zapTags[0][1] : '',
           pubkey: event.pubkey,
           zapTotal: 0,
           onLike: () => {},

--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -61,7 +61,7 @@ export function useSearch(query: string): SearchResults {
           if (!videoTag) return;
           const posterTag = ev.tags.find((t) => t[0] === 'image');
           const manifestTag = ev.tags.find((t) => t[0] === 'vman');
-          const zapTag = ev.tags.find((t) => t[0] === 'zap');
+          const zapTags = ev.tags.filter((t) => t[0] === 'zap');
           const tTags = ev.tags.filter((t) => t[0] === 't').map((t) => t[1]);
           nextVideos.push({
             videoUrl: videoTag[1],
@@ -70,7 +70,7 @@ export function useSearch(query: string): SearchResults {
             author: ev.pubkey.slice(0, 8),
             caption: tTags.join(' '),
             eventId: ev.id,
-            lightningAddress: zapTag ? zapTag[1] : '',
+            lightningAddress: zapTags.length ? zapTags[0][1] : '',
             pubkey: ev.pubkey,
             zapTotal: 0,
             onLike: () => {},

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -76,7 +76,7 @@ export default function ProfilePage() {
           if (!videoTag) return;
           const posterTag = ev.tags.find((t) => t[0] === 'image');
           const manifestTag = ev.tags.find((t) => t[0] === 'vman');
-          const zapTag = ev.tags.find((t) => t[0] === 'zap');
+          const zapTags = ev.tags.filter((t) => t[0] === 'zap');
           const tTags = ev.tags.filter((t) => t[0] === 't').map((t) => t[1]);
           nextVideos.push({
             videoUrl: videoTag[1],
@@ -85,7 +85,7 @@ export default function ProfilePage() {
             author: ev.pubkey.slice(0, 8),
             caption: tTags.join(' '),
             eventId: ev.id,
-            lightningAddress: zapTag ? zapTag[1] : '',
+            lightningAddress: zapTags.length ? zapTags[0][1] : '',
             pubkey: ev.pubkey,
             zapTotal: 0,
             onLike: () => {},

--- a/apps/web/pages/v/[eventId].tsx
+++ b/apps/web/pages/v/[eventId].tsx
@@ -21,7 +21,7 @@ export default function VideoPage() {
       if (!videoTag) return;
       const posterTag = ev.tags.find((t) => t[0] === 'image');
       const manifestTag = ev.tags.find((t) => t[0] === 'vman');
-      const zapTag = ev.tags.find((t) => t[0] === 'zap');
+      const zapTags = ev.tags.filter((t) => t[0] === 'zap');
       const tTags = ev.tags.filter((t) => t[0] === 't').map((t) => t[1]);
       setVideo({
         videoUrl: videoTag[1],
@@ -30,7 +30,7 @@ export default function VideoPage() {
         author: ev.pubkey.slice(0, 8),
         caption: tTags.join(' '),
         eventId: ev.id,
-        lightningAddress: zapTag ? zapTag[1] : '',
+        lightningAddress: zapTags.length ? zapTags[0][1] : '',
         pubkey: ev.pubkey,
         zapTotal: 0,
         onLike: () => {},


### PR DESCRIPTION
## Summary
- include creator and collaborator shares in `zap` tags
- read primary lightning address from the first `zap` tag
- document new `zap` tag format

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896af4f2a0c833192bddd7d7a6940a4