### PR TITLE
Support event-level zap splits

### DIFF
--- a/apps/web/hooks/useLightning.test.ts
+++ b/apps/web/hooks/useLightning.test.ts
@@ -1,16 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import useLightning from './useLightning';
 
 vi.mock('./useAuth', () => ({
   useAuth: () => ({ state: { status: 'ready', pubkey: 'pk', signer: { signEvent: vi.fn(async (e: any) => ({ ...e, id: 'id', sig: 'sig', pubkey: 'pk' })) } } }),
 }));
 
+const poolGetMock = vi.fn();
+
 vi.mock('nostr-tools/pool', () => ({
   SimplePool: class {
-    get() {
-      return Promise.resolve({
-        content: JSON.stringify({ zapSplits: [{ lnaddr: 'col@example.com', pct: 10 }] }),
-      });
+    get(...args: any[]) {
+      return poolGetMock(...args);
     }
     publish() {
       return {} as any;
@@ -18,12 +17,21 @@ vi.mock('nostr-tools/pool', () => ({
   },
 }));
 
+import useLightning from './useLightning';
+
 describe('useLightning', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it('splits zap between recipients', async () => {
+  it('splits zap using event zap tags', async () => {
+    poolGetMock.mockResolvedValueOnce({
+      tags: [
+        ['zap', 'user@example.com', '85'],
+        ['zap', 'col@example.com', '10'],
+      ],
+    });
+
     process.env.NEXT_PUBLIC_TREASURY_LNADDR = 'treasury@example.com';
     const fetchMock = vi
       .fn()
@@ -50,6 +58,46 @@ describe('useLightning', () => {
       pubkey: 'pk',
     });
 
+    expect(poolGetMock).toHaveBeenCalledTimes(1);
+    expect(invoices.length).toBe(3);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(sendPaymentMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to metadata splits when event has none', async () => {
+    poolGetMock
+      .mockResolvedValueOnce({ tags: [] })
+      .mockResolvedValueOnce({
+        content: JSON.stringify({ zapSplits: [{ lnaddr: 'col@example.com', pct: 10 }] }),
+      });
+
+    process.env.NEXT_PUBLIC_TREASURY_LNADDR = 'treasury@example.com';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ callback: 'https://cb1' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ pr: 'inv1' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ callback: 'https://cb2' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ pr: 'inv2' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ callback: 'https://cb3' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ pr: 'inv3' }) });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const sendPaymentMock = vi.fn();
+    // @ts-ignore
+    global.window = {
+      webln: { sendPayment: sendPaymentMock },
+      open: vi.fn(),
+    };
+
+    const { createZap } = useLightning();
+    const { invoices } = await createZap({
+      lightningAddress: 'user@example.com',
+      amount: 100,
+      eventId: 'note',
+      pubkey: 'pk',
+    });
+
+    expect(poolGetMock).toHaveBeenCalledTimes(2);
     expect(invoices.length).toBe(3);
     expect(fetchMock).toHaveBeenCalledTimes(6);
     expect(sendPaymentMock).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
## Summary
- parse zap recipients from `zap` tags on video events
- fall back to author metadata when event has no zap tags
- cover event-level splits and fallback in lightning hook tests

## Testing
- `pnpm test apps/web/hooks/useLightning.test.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b3e4d4508331ac416546e017c88e