### PR TITLE
Make AppShell right panel optional

### DIFF
--- a/apps/web/components/SettingsLayout.tsx
+++ b/apps/web/components/SettingsLayout.tsx
@@ -6,7 +6,6 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
     <AppShell
       left={<MainNav showSearch={false} showProfile={false} />}
       center={<div className="space-y-8">{children}</div>}
-      right={<></>}
     />
   );
 }

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -9,11 +9,18 @@ export default function AppShell({
 }: {
   left: React.ReactNode;
   center: React.ReactNode;
-  right: React.ReactNode;
+  right?: React.ReactNode;
 }) {
+  const hasRight = !!right;
   return (
     <div className="min-h-screen bg-background-primary text-primary">
-      <div className="mx-auto w-full max-w-[1400px] bg-surface grid grid-cols-1 lg:grid-cols-[300px_1fr_400px] gap-0">
+      <div
+        className={`mx-auto w-full max-w-[1400px] bg-surface grid grid-cols-1 ${
+          hasRight
+            ? 'lg:grid-cols-[300px_1fr_400px]'
+            : 'lg:grid-cols-[300px_1fr]'
+        } gap-0`}
+      >
         {/* Left column: menu/search/profile summary (sticky on desktop) */}
         <aside className="hidden lg:block border-r divider sticky top-0 h-screen overflow-y-auto">
           <div className="p-4">{left}</div>
@@ -25,9 +32,11 @@ export default function AppShell({
         </main>
 
         {/* Right column: author info & comments (sticky on desktop) */}
-        <aside className="hidden lg:block border-l divider sticky top-0 h-screen overflow-y-auto">
-          <div className="p-4">{right}</div>
-        </aside>
+        {hasRight && (
+          <aside className="hidden lg:block border-l divider sticky top-0 h-screen overflow-y-auto">
+            <div className="p-4">{right}</div>
+          </aside>
+        )}
       </div>
       <BottomNav />
     </div>

--- a/apps/web/pages/profile.tsx
+++ b/apps/web/pages/profile.tsx
@@ -34,7 +34,6 @@ export default function Profile() {
             </Card>
           </div>
         }
-        right={<></>}
       />
     );
   }
@@ -66,7 +65,6 @@ export default function Profile() {
           </Card>
         </div>
       }
-      right={<></>}
     />
   );
 }

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -88,7 +88,6 @@ export default function Settings() {
           />
         </div>
       }
-      right={<></>}
     />
   );
 }


### PR DESCRIPTION
## Summary
- allow AppShell to omit right column and adjust grid accordingly
- stop passing empty right components on pages without side content

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b65f47f08331a8423df32a7ccf56