### PR TITLE
fix: improve creator wizard layout

### DIFF
--- a/apps/web/components/create/CreatorWizard.tsx
+++ b/apps/web/components/create/CreatorWizard.tsx
@@ -3,15 +3,17 @@ import CreateVideoForm from './CreateVideoForm';
 
 export default function CreatorWizard() {
   return (
-    <div className="flex flex-col min-h-[calc(100vh-5rem)] px-4 gap-6 lg:flex-row">
-      <div className="flex flex-col items-start gap-2">
+    <div className="flex flex-col min-h-[calc(100vh-5rem)] px-4 gap-6 xl:flex-row">
+      <div className="flex flex-col items-start gap-2 xl:max-w-xs flex-none">
         <h1 className="text-3xl font-bold">Create Video</h1>
         <p className="text-sm text-gray-600 dark:text-gray-400">
           Choose how you want to add a video—upload from your device or import from a URL—and publish
           it to the Nostr network.
         </p>
       </div>
-      <CreateVideoForm />
+      <div className="flex-1 min-w-0">
+        <CreateVideoForm />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- prevent CreatorWizard header from taking excessive width
- keep layout stacked until xl breakpoint
- ensure video form can shrink without overflow

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm vitest run apps/web/components/create/CreateVideoForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6896b68485188331836785de44d7bc72