### PR TITLE
feat: debounce search subscriptions

### DIFF
--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -23,19 +23,20 @@ export function useSearch(query: string): SearchResults {
   const poolRef = useRef<SimplePool>();
   const subRef = useRef<{ close: () => void } | null>(null);
   const timerRef = useRef<NodeJS.Timeout>();
+  const debounceRef = useRef<NodeJS.Timeout>();
 
   useEffect(() => {
+    subRef.current?.close();
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
     if (!query) {
       setVideos([]);
       setCreators([]);
-      subRef.current?.close();
       return;
     }
 
     const pool = (poolRef.current ||= new SimplePool());
-    subRef.current?.close();
-    if (timerRef.current) clearTimeout(timerRef.current);
-
     const relays = getRelays();
     const filters: Filter[] = [];
     const q = query.startsWith('@') || query.startsWith('#') ? query.slice(1) : query;
@@ -54,49 +55,54 @@ export function useSearch(query: string): SearchResults {
 
     const nextVideos: VideoCardProps[] = [];
     const nextCreators: CreatorResult[] = [];
-    const sub = pool.subscribeMany(relays, filters, {
-      onevent: (ev: NostrEvent) => {
-        if (ev.kind === 30023) {
-          const videoTag = ev.tags.find((t) => t[0] === 'v');
-          if (!videoTag) return;
-          const posterTag = ev.tags.find((t) => t[0] === 'image');
-          const manifestTag = ev.tags.find((t) => t[0] === 'vman');
-          const zapTags = ev.tags.filter((t) => t[0] === 'zap');
-          const tTags = ev.tags.filter((t) => t[0] === 't').map((t) => t[1]);
-          nextVideos.push({
-            videoUrl: videoTag[1],
-            posterUrl: posterTag ? posterTag[1] : undefined,
-            manifestUrl: manifestTag ? manifestTag[1] : undefined,
-            author: ev.pubkey.slice(0, 8),
-            caption: tTags.join(' '),
-            eventId: ev.id,
-            lightningAddress: zapTags.length ? zapTags[0][1] : '',
-            pubkey: ev.pubkey,
-            zapTotal: 0,
-            onLike: () => {},
-          });
-          setVideos([...nextVideos]);
-        } else if (ev.kind === 0) {
-          try {
-            const content = JSON.parse(ev.content);
-            nextCreators.push({
-              pubkey: ev.pubkey,
-              name: content.name || ev.pubkey.slice(0, 8),
-              picture: content.picture,
-            });
-            setCreators([...nextCreators]);
-          } catch {
-            /* ignore */
-          }
-        }
-      },
-    });
 
-    timerRef.current = setTimeout(() => sub.close(), 20000);
-    subRef.current = sub;
+    debounceRef.current = setTimeout(() => {
+      const sub = pool.subscribeMany(relays, filters, {
+        onevent: (ev: NostrEvent) => {
+          if (ev.kind === 30023) {
+            const videoTag = ev.tags.find((t) => t[0] === 'v');
+            if (!videoTag) return;
+            const posterTag = ev.tags.find((t) => t[0] === 'image');
+            const manifestTag = ev.tags.find((t) => t[0] === 'vman');
+            const zapTags = ev.tags.filter((t) => t[0] === 'zap');
+            const tTags = ev.tags.filter((t) => t[0] === 't').map((t) => t[1]);
+            nextVideos.push({
+              videoUrl: videoTag[1],
+              posterUrl: posterTag ? posterTag[1] : undefined,
+              manifestUrl: manifestTag ? manifestTag[1] : undefined,
+              author: ev.pubkey.slice(0, 8),
+              caption: tTags.join(' '),
+              eventId: ev.id,
+              lightningAddress: zapTags.length ? zapTags[0][1] : '',
+              pubkey: ev.pubkey,
+              zapTotal: 0,
+              onLike: () => {},
+            });
+            setVideos([...nextVideos]);
+          } else if (ev.kind === 0) {
+            try {
+              const content = JSON.parse(ev.content);
+              nextCreators.push({
+                pubkey: ev.pubkey,
+                name: content.name || ev.pubkey.slice(0, 8),
+                picture: content.picture,
+              });
+              setCreators([...nextCreators]);
+            } catch {
+              /* ignore */
+            }
+          }
+        },
+      });
+
+      timerRef.current = setTimeout(() => sub.close(), 20000);
+      subRef.current = sub;
+    }, 300);
 
     return () => {
-      sub.close();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      subRef.current?.close();
     };
   }, [query]);
 


### PR DESCRIPTION
## Summary
- debounce `pool.subscribeMany` calls in search hook
- clear debounce and cleanup timers on query change or unmount

## Testing
- `pnpm test` *(fails: worker terminated due to out-of-memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896b791b0288331a86f78d90c347b99