### PR TITLE
feat: cache profile metadata across components

### DIFF
--- a/apps/web/components/create/CreateVideoForm.profiles.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.profiles.test.tsx
@@ -1,0 +1,56 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import CreateVideoForm from './CreateVideoForm';
+import { __clearProfileCache } from '../../hooks/useProfiles';
+const following = ['pk1', 'pk2'];
+let onEvent: ((ev: any) => void) | null = null;
+const subscribeMany = vi.fn((relays: any, filters: any, opts: any) => {
+  onEvent = opts.onevent;
+  return { close: vi.fn() };
+});
+(globalThis as any).React = React;
+
+describe('CreateVideoForm profiles', () => {
+
+  vi.mock('../../hooks/useAuth', () => ({
+    useAuth: () => ({ state: { status: 'signedOut' } }),
+  }));
+  vi.mock('../../hooks/useFollowing', () => ({
+    default: () => ({ following }),
+  }));
+  vi.mock('../../lib/nostr', () => ({
+    getPool: () => ({ subscribeMany }),
+    getRelays: () => [],
+  }));
+  vi.mock('next/navigation', () => ({
+    useRouter: () => ({ back: vi.fn() }),
+  }));
+
+  beforeEach(() => {
+    __clearProfileCache();
+    subscribeMany.mockClear();
+    onEvent = null;
+  });
+
+  it('subscribes once and populates lnaddr datalist', async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<CreateVideoForm />);
+    });
+    await Promise.resolve();
+    expect(subscribeMany).toHaveBeenCalledTimes(1);
+    expect(subscribeMany.mock.calls[0][1][0].authors).toEqual(following);
+    act(() => {
+      onEvent?.({ pubkey: 'pk1', content: JSON.stringify({ lud16: 'alice@test' }) });
+      onEvent?.({ pubkey: 'pk2', content: JSON.stringify({ lud16: 'bob@test' }) });
+    });
+    await Promise.resolve();
+    const opts = container.querySelectorAll('#lnaddr-options option');
+    const values = Array.from(opts).map((o) => o.getAttribute('value'));
+    expect(values).toEqual(expect.arrayContaining(['alice@test', 'bob@test']));
+  });
+});

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -6,17 +6,9 @@ import { trimVideoWebCodecs } from '../../utils/trimVideoWebCodecs';
 import { SimplePool } from 'nostr-tools/pool';
 import { useAuth } from '../../hooks/useAuth';
 import { useProfile } from '../../hooks/useProfile';
+import { useProfiles } from '../../hooks/useProfiles';
 import useFollowing from '../../hooks/useFollowing';
 import { getRelays } from '../../lib/nostr';
-
-function LnAddrOption({ pubkey }: { pubkey: string }) {
-  const profile = useProfile(pubkey);
-  const addr = Array.isArray(profile?.wallets)
-    ? profile.wallets.find((w: any) => w?.default)?.lnaddr
-    : profile?.lud16;
-  if (!addr) return null;
-  return <option value={addr}>{addr}</option>;
-}
 
 export default function CreateVideoForm() {
   const router = useRouter();
@@ -47,6 +39,7 @@ export default function CreateVideoForm() {
   const { state } = useAuth();
   const profile = useProfile(state.status === 'ready' ? state.pubkey : undefined);
   const { following } = useFollowing(state.status === 'ready' ? state.pubkey : undefined);
+  const profiles = useProfiles(following);
 
   const walletAddrs = Array.isArray(profile?.wallets)
     ? [
@@ -345,9 +338,17 @@ export default function CreateVideoForm() {
         <div className="text-sm">Total {totalPct}% / 95%</div>
       )}
       <datalist id="lnaddr-options">
-        {following.map((pk) => (
-          <LnAddrOption key={pk} pubkey={pk} />
-        ))}
+        {following.map((pk) => {
+          const p = profiles.get(pk);
+          const addr = Array.isArray(p?.wallets)
+            ? p.wallets.find((w: any) => w?.default)?.lnaddr
+            : p?.lud16;
+          return addr ? (
+            <option key={pk} value={addr}>
+              {addr}
+            </option>
+          ) : null;
+        })}
       </datalist>
       <label className="block text-sm">
         <span className="mb-1 block">License</span>

--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -1,42 +1,7 @@
 'use client';
-import { useEffect, useState } from 'react';
-import * as nostrKinds from 'nostr-tools/kinds';
-import type { Filter } from 'nostr-tools/filter';
-import { getPool, getRelays } from '@/lib/nostr';
+import { useProfiles } from './useProfiles';
 
 export function useProfile(pubkey?: string) {
-  const [meta, setMeta] = useState<any>(null);
-  useEffect(() => {
-    if (!pubkey) return;
-    const pool = getPool();
-    const sub = pool.subscribeMany(
-      getRelays(),
-      [{ kinds: [nostrKinds.Metadata], authors: [pubkey], limit: 1 } as Filter],
-      {
-        onevent: (ev) => {
-          try {
-            const content = JSON.parse(ev.content);
-            if (!Array.isArray(content.wallets)) {
-              if (typeof content.lud16 === 'string' && content.lud16) {
-                content.wallets = [
-                  { label: 'Default', lnaddr: content.lud16, default: true },
-                ];
-              } else {
-                content.wallets = [];
-              }
-            }
-            setMeta(content);
-          } catch {}
-        },
-      },
-    );
-    return () => sub.close();
-  }, [pubkey]);
-  return meta as {
-    name?: string;
-    picture?: string;
-    about?: string;
-    lud16?: string;
-    wallets?: { label: string; lnaddr: string; default?: boolean }[];
-  } | null;
+  const profiles = useProfiles(pubkey ? [pubkey] : []);
+  return pubkey ? profiles.get(pubkey) ?? null : null;
 }

--- a/apps/web/hooks/useProfiles.ts
+++ b/apps/web/hooks/useProfiles.ts
@@ -1,0 +1,58 @@
+'use client';
+import { useEffect, useState } from 'react';
+import * as nostrKinds from 'nostr-tools/kinds';
+import type { Filter } from 'nostr-tools/filter';
+import { getPool, getRelays } from '@/lib/nostr';
+
+export type Profile = {
+  name?: string;
+  picture?: string;
+  about?: string;
+  lud16?: string;
+  wallets?: { label: string; lnaddr: string; default?: boolean }[];
+  zapSplits?: { lnaddr: string; pct: number }[];
+};
+
+const cache = new Map<string, Profile>();
+
+export function useProfiles(pubkeys: string[]) {
+  const [, forceUpdate] = useState(0);
+
+  useEffect(() => {
+    const missing = pubkeys.filter((pk) => !cache.has(pk));
+    if (missing.length === 0) return;
+    const pool = getPool();
+    const sub = pool.subscribeMany(
+      getRelays(),
+      [{ kinds: [nostrKinds.Metadata], authors: missing, limit: 1 } as Filter],
+      {
+        onevent: (ev: any) => {
+          try {
+            const content = JSON.parse(ev.content);
+            if (!Array.isArray(content.wallets)) {
+              if (typeof content.lud16 === 'string' && content.lud16) {
+                content.wallets = [
+                  { label: 'Default', lnaddr: content.lud16, default: true },
+                ];
+              } else {
+                content.wallets = [];
+              }
+            }
+            cache.set(ev.pubkey, content);
+            forceUpdate((x) => x + 1);
+          } catch {}
+        },
+      },
+    );
+    return () => sub.close();
+  }, [pubkeys.join(',')]);
+
+  return cache;
+}
+
+// For testing
+export function __clearProfileCache() {
+  cache.clear();
+}
+
+export { cache as __profileCache };


### PR DESCRIPTION
## Summary
- add `useProfiles` hook using a shared cache and single `subscribeMany` query
- update video form to read cached profiles and populate LN address datalist
- ensure `useProfile` pulls from cache and add tests for shared subscription

## Testing
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx apps/web/components/create/CreateVideoForm.profiles.test.tsx`
- `pnpm test apps/web/components/create/CreateVideoForm.profiles.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6896b9f423708331b55a8509a257a501