### PR TITLE
feat: add subtle crypto fallback

### DIFF
--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -29,6 +29,10 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
     const pass = await promptPassphrase('Set a passphrase to encrypt your key');
     if (!pass) return;
     try {
+      if (!globalThis.crypto?.subtle) {
+        alert('Your browser does not support the Web Crypto API');
+        return;
+      }
       const encPriv = await cryptoVault.encryptPrivkeyHex(priv, pass);
       const pubkey = getPublicKey(priv);
       keyStore.save({ method, pubkey, encPriv });


### PR DESCRIPTION
## Summary
- add `getSubtle` helper with Node fallback
- guard WebCrypto usage in key setup and lightning wallet components

## Testing
- `pnpm -F @paiduan/web lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896bc0b507c8331b5ae2aa495b8fcc3