### PR TITLE
Validate Nostr connect URIs

### DIFF
--- a/apps/web/components/NostrLogin.tsx
+++ b/apps/web/components/NostrLogin.tsx
@@ -38,8 +38,13 @@ export function NostrLogin() {
   };
 
   const connectRemote = async () => {
+    const trimmed = uri.trim();
+    if (!trimmed || !/^nostrconnect:/i.test(trimmed)) {
+      alert('Invalid Nostr Connect URI');
+      return;
+    }
     try {
-      await signInWithNip46(uri);
+      await signInWithNip46(trimmed);
       window.location.href = '/onboarding/profile';
     } catch (e: any) {
       alert(e.message || 'Failed to connect');
@@ -73,7 +78,11 @@ export function NostrLogin() {
           placeholder="nostrconnect:..."
           className="input w-full"
         />
-        <button className="btn btn-secondary w-full" onClick={connectRemote}>
+        <button
+          className="btn btn-secondary w-full"
+          onClick={connectRemote}
+          disabled={!uri.trim()}
+        >
           Connect remote signer
         </button>
       </div>

--- a/apps/web/lib/signers/nip46.test.ts
+++ b/apps/web/lib/signers/nip46.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { Nip46Signer } from './nip46';
+
+describe('parseNostrConnectUri', () => {
+  it('parses valid URI', () => {
+    const uri =
+      'nostrconnect:abcdef?relay=wss://relay1.example&relay=wss://relay2.example&secret=shh';
+    const res = Nip46Signer.parseNostrConnectUri(uri);
+    expect(res.remotePubkey).toBe('abcdef');
+    expect(res.relays).toEqual(['wss://relay1.example', 'wss://relay2.example']);
+    expect(res.secret).toBe('shh');
+  });
+
+  it('throws on invalid URI', () => {
+    expect(() => Nip46Signer.parseNostrConnectUri('nostr:xyz')).toThrow(
+      'Invalid Nostr Connect URI',
+    );
+  });
+});

--- a/apps/web/lib/signers/nip46.ts
+++ b/apps/web/lib/signers/nip46.ts
@@ -25,8 +25,13 @@ export class Nip46Signer implements Signer {
     uri: string,
   ): { remotePubkey: string; relays: string[]; secret?: string } {
     const u = uri.replace('nostrconnect://', 'nostrconnect:');
-    const [, rest] = u.split('nostrconnect:');
-    const [remotePubkey, query = ''] = rest.split('?');
+    const parts = u.split('nostrconnect:');
+    const rest = parts[1];
+    if (!rest) throw new Error('Invalid Nostr Connect URI');
+    const pq = rest.split('?');
+    const remotePubkey = pq[0];
+    const query = pq[1] ?? '';
+    if (!remotePubkey) throw new Error('Invalid Nostr Connect URI');
     const params = new URLSearchParams(query.replace(/&wss/g, '&relay'));
     const relays: string[] = [];
     for (const [k, v] of params.entries()) if (k === 'relay') relays.push(v);


### PR DESCRIPTION
## Summary
- validate nostrconnect URIs before attempting remote signer login
- guard against malformed nostrconnect URLs in nip46 signer
- add unit test for URI parser

## Testing
- `pnpm test apps/web/lib/signers/nip46.test.ts`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896bc740b4c833185f6798ed4548d66