### PR TITLE
Handle WebCodecs worker errors with fallback

### DIFF
--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -134,8 +134,20 @@ export default function CreateVideoForm() {
           if (msg?.type === 'progress') {
             setProgress(Math.round((msg.progress || 0) * 100));
           } else if (msg?.type === 'error') {
-            setErr(msg.message || 'Conversion failed.');
             setProgress(0);
+            if (msg.error === 'unsupported-codec') {
+              setErr('Unsupported video codec. Please convert your video and try again.');
+            } else if (msg.error === 'no-keyframe') {
+              setErr('Cannot trim this video because it lacks a key frame. Using the original file.');
+              setOutBlob(f);
+              updatePreview(URL.createObjectURL(f));
+            } else if (msg.error === 'demux-failed') {
+              setErr('Failed to read video file. Using the original file.');
+              setOutBlob(f);
+              updatePreview(URL.createObjectURL(f));
+            } else {
+              setErr(msg.message || 'Conversion failed.');
+            }
             worker.terminate();
           } else if (msg?.type === 'done') {
             const blob: Blob = msg.blob;


### PR DESCRIPTION
## Summary
- add granular decode/encode error handling in trim worker and self-terminate on failure
- display friendly guidance and fallback when WebCodecs trimming fails

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896c0e8d2a883319b8788fe15165ee0