### PR TITLE
feat: request push permission on user action

### DIFF
--- a/apps/web/components/NotificationBell.tsx
+++ b/apps/web/components/NotificationBell.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Bell } from 'lucide-react';
-import { useNotifications } from '../hooks/useNotifications';
+import { useNotifications, requestNotificationPermission } from '../hooks/useNotifications';
 
 const NotificationBell: React.FC = () => {
   const { unreadCount, setOpen } = useNotifications();
@@ -12,9 +12,14 @@ const NotificationBell: React.FC = () => {
 
   const count = mounted ? unreadCount : 0;
 
+  const handleClick = () => {
+    requestNotificationPermission();
+    setOpen(true);
+  };
+
   return (
     <button
-      onClick={() => setOpen(true)}
+      onClick={handleClick}
       className="relative text-primary hover:text-accent-primary"
       aria-label="Notifications"
     >


### PR DESCRIPTION
## Summary
- add `requestNotificationPermission` helper for push setup
- trigger permission request when user clicks notification bell

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c0fe84688331a1ad464482479ea5