### PR TITLE
Hydration-safe relay initialization in NetworkCard

### DIFF
--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Card } from '../ui/Card';
-import { getRelays } from '@/lib/nostr';
+import { getRelays, parseRelays } from '@/lib/nostr';
+import relaysConfig from '@/relays.json';
 
 export function NetworkCard() {
-  const [relays, setRelays] = useState<string[]>(getRelays);
+  const [relays, setRelays] = useState<string[]>(() => parseRelays(relaysConfig) ?? []);
   const [input, setInput] = useState('');
 
   // persist relays to localStorage whenever they change
@@ -16,6 +17,10 @@ export function NetworkCard() {
       /* ignore */
     }
   }, [relays]);
+
+  useEffect(() => {
+    setRelays(getRelays());
+  }, []);
 
   const addRelay = () => {
     const url = input.trim();

--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -41,7 +41,7 @@ export function getMyPubkey(): string | undefined {
 /** Relays you want to hit – tweak as needed */
 const DEFAULT_RELAYS = ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.snort.social'];
 
-function parseRelays(input: unknown): string[] | undefined {
+export function parseRelays(input: unknown): string[] | undefined {
   if (Array.isArray(input)) {
     return input.filter((r): r is string => typeof r === 'string' && r.length > 0);
   }


### PR DESCRIPTION
## Summary
- initialize NetworkCard relays from static config to avoid hydration mismatches
- refresh relay list after hydration via getRelays
- export parseRelays for reuse

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896c107897883318767b7366c21f61e