### PR TITLE
Enable scrolling in settings page layout

### DIFF
--- a/apps/web/components/SettingsLayout.tsx
+++ b/apps/web/components/SettingsLayout.tsx
@@ -5,7 +5,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
   return (
     <AppShell
       left={<MainNav showSearch={false} showProfile={false} />}
-      center={<div className="space-y-8">{children}</div>}
+      center={<div className="space-y-8 min-h-full">{children}</div>}
     />
   );
 }

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -27,7 +27,7 @@ export default function AppShell({
         </aside>
 
         {/* Middle column: main feed */}
-        <main className="h-screen overflow-hidden">
+        <main className="h-screen overflow-y-auto">
           <div className="max-w-2xl mx-auto h-full px-4">{center}</div>
         </main>
 

--- a/apps/web/pages/settings.tsx
+++ b/apps/web/pages/settings.tsx
@@ -31,7 +31,7 @@ export default function Settings() {
     <AppShell
       left={nav}
       center={
-        <div className="max-w-3xl mx-auto px-4 py-10 space-y-6">
+        <div className="max-w-3xl mx-auto px-4 py-10 space-y-6 min-h-full">
           <Accordion
             initialOpenIndex={initialOpenIndex}
             items={[


### PR DESCRIPTION
## Summary
- Allow AppShell's main column to scroll by using `overflow-y-auto`
- Ensure settings layout fills height so content leverages scrolling

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896c31888588331b949930de40cd37c