### PR TITLE
fix: respect aspect ratio for video preview

### DIFF
--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -422,7 +422,7 @@ export default function CreateVideoForm() {
             className="block w-full text-sm rounded-md border border-border bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
           />
             {preview ? (
-              <div className="relative aspect-[9/16] h-[70vh] w-full sm:max-w-sm overflow-hidden rounded-xl">
+              <div className="relative aspect-[9/16] max-h-[70vh] w-full sm:max-w-sm overflow-hidden rounded-xl">
                 <video
                   ref={videoRef}
                   controls
@@ -437,7 +437,7 @@ export default function CreateVideoForm() {
                 )}
               </div>
             ) : (
-              <div className="relative aspect-[9/16] h-[70vh] w-full sm:max-w-sm overflow-hidden rounded-xl">
+              <div className="relative aspect-[9/16] max-h-[70vh] w-full sm:max-w-sm overflow-hidden rounded-xl">
                 <PlaceholderVideo className="absolute inset-0 h-full w-full object-cover" />
               </div>
             )}


### PR DESCRIPTION
## Summary
- avoid fixed height on video preview containers so 9:16 aspect ratio can control layout

## Testing
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6896c3e8ad688331badf2251a92a9db1