### PR TITLE
refactor: use pd auth key in vault gate

### DIFF
--- a/apps/web/hooks/useVaultGate.ts
+++ b/apps/web/hooks/useVaultGate.ts
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 
+const LS_KEY = 'pd.auth.v1';
+
 export function useVaultGate(nextHrefWhenHasKeys = '/en/feed') {
   useEffect(() => {
     try {
-      const vault = localStorage.getItem('nostrVault');
-      if (vault) window.location.replace(nextHrefWhenHasKeys);
+      const auth = localStorage.getItem(LS_KEY);
+      if (auth) window.location.replace(nextHrefWhenHasKeys);
     } catch {}
   }, [nextHrefWhenHasKeys]);
 }


### PR DESCRIPTION
## Summary
- check `pd.auth.v1` in `useVaultGate` hook instead of legacy `nostrVault`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c516b59c8331a2da9fac6580af59