### PR TITLE
docs: remove passphrase encryption requirement

### DIFF
--- a/project_spec.md
+++ b/project_spec.md
@@ -11,21 +11,20 @@ Replace “Enter Feed” with standard Nostr login flow, support new/imported ke
 | 1   | Replace entry        | Remove “Enter Feed” button. Add Nostr login UI on landing page with 3 options: **Import key**, **Generate new key**, **Remote signer login** (NIP-46/NIP-07). |
 | 2   | Key import           | Support `nsec` and raw hex; decode to 32-byte Uint8Array; validate length; save to localStorage/session.                                                      |
 | 3   | Key generation       | Use `nostr-tools` `generateSecretKey()` (not deprecated `generatePrivateKey()`), derive pubkey; store keys.                                                   |
-| 4   | Security             | Encrypt privkey at rest via WebCrypto + passphrase; prompt passphrase on app start.                                                                           |
-| 5   | Remote signer        | Implement NIP-46 connect flow; persist pubkey, no privkey stored.                                                                                             |
-| 6   | Post-auth onboarding | After successful import/generate/login, route to `/onboarding/profile`.                                                                                       |
-| 7   | Enable notifications | Prompt user to grant browser notification permission and register push subscription.            |
-| 8   | Profile onboarding   | If imported key has existing kind 0 profile, prefill name, picture, about; else show empty form.                                                              |
-| 9   | Profile UI           | Avatar upload (browser file → Blob URL or upload to media API), name, bio; publish kind 0 metadata to relays.                                                 |
-| 10  | Profile page         | `/p/[pubkey]` shows banner, avatar, name, bio, zaps, follow; edit button if own profile.                                                                      |
-| 11  | Export keys          | Settings → “Keys” section to copy/export `nsec` or pubkey; warn about privkey handling.                                                                       |
-| 12  | Testing              | Validate that login state persists, keys work for publishing/zaps, and onboarding flows correctly.                                                            |
+| 4   | Remote signer        | Implement NIP-46 connect flow; persist pubkey, no privkey stored.                                                                                             |
+| 5   | Post-auth onboarding | After successful import/generate/login, route to `/onboarding/profile`.                                                                                       |
+| 6   | Enable notifications | Prompt user to grant browser notification permission and register push subscription.            |
+| 7   | Profile onboarding   | If imported key has existing kind 0 profile, prefill name, picture, about; else show empty form.                                                              |
+| 8   | Profile UI           | Avatar upload (browser file → Blob URL or upload to media API), name, bio; publish kind 0 metadata to relays.                                                 |
+| 9   | Profile page         | `/p/[pubkey]` shows banner, avatar, name, bio, zaps, follow; edit button if own profile.                                                                      |
+| 10  | Export keys          | Settings → “Keys” section to copy/export `nsec` or pubkey; warn about privkey handling.                                                                       |
+| 11  | Testing              | Validate that login state persists, keys work for publishing/zaps, and onboarding flows correctly.                                                            |
 
 ### Acceptance Criteria
 
 - Landing page shows modern styled login buttons (dark/light mode visible).
 - Import accepts both `nsec` and hex, rejects invalid keys.
-- Generate uses new API and stores securely.
+- Generate uses new API and stores keys locally.
 - Remote signer works with NIP-46/NIP-07 providers.
 - Onboarding after auth leads to profile setup or edit.
 - Profile updates publish to relays and reflect in `/p/[pubkey]`.
@@ -44,16 +43,16 @@ Modernise Creator Wizard UI, fix tool loading/trim bugs, and ensure WebM (9:16) 
 
 | #   | Area               | Work required                                                                                                                                                                      |
 | --- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | CreatorWizard UI   | Replace current 3-step flow with wizard that first asks “What do you want to do?” — options: **Upload existing** or **Import from URL**.                           |
-| 2   | Dynamic components | Load relevant step component depending on option (e.g., `UploadStep.tsx`).                                                                                |
-| 3   | Upload             | Existing file input flow; enforce ≤3 minutes; immediately transcode if not WebM.                                                                                |
-| 4   | Transcoding        | Use the WebCodecs API with a polyfill; default to WebM VP9, 9:16 crop. |
-| 5   | Trim tool          | Ensure trim UI loads only after video metadata loaded; fix “pressing Next throws trim error” by validating clip bounds.                                                            |
-| 6   | Poster capture     | Frame capture via `<canvas>`; store as JPEG/WebP; attach to upload payload.                                                                                |
-| 7   | Upload flow        | POST video + poster to `nostr.media/api/upload`; show progress; capture `video`, `poster` & `manifest` URLs and publish kind‑30023 event with `v`, `image`, `vman`, optional `zap` and one `t` tag per topic.                                                            |
-| 8   | Error handling     | Toasts for FFmpeg load failure, file type issues, upload errors.                                                                                |
-| 9   | Responsive design  | Wizard lets steps manage their own widths; metadata step displays preview and fields side-by-side on large (`lg`) screens. |
-| 10  | Event publishing   | CreatorWizard publishes a signed kind-30023 event containing video URL, poster, manifest, zap address, and topic tags. |
+| 12  | CreatorWizard UI   | Replace current 3-step flow with wizard that first asks “What do you want to do?” — options: **Upload existing** or **Import from URL**.                           |
+| 13  | Dynamic components | Load relevant step component depending on option (e.g., `UploadStep.tsx`).                                                                                |
+| 14  | Upload             | Existing file input flow; enforce ≤3 minutes; immediately transcode if not WebM.                                                                                |
+| 15  | Transcoding        | Use the WebCodecs API with a polyfill; default to WebM VP9, 9:16 crop. |
+| 16  | Trim tool          | Ensure trim UI loads only after video metadata loaded; fix “pressing Next throws trim error” by validating clip bounds.                                                            |
+| 17  | Poster capture     | Frame capture via `<canvas>`; store as JPEG/WebP; attach to upload payload.                                                                                |
+| 18  | Upload flow        | POST video + poster to `nostr.media/api/upload`; show progress; capture `video`, `poster` & `manifest` URLs and publish kind‑30023 event with `v`, `image`, `vman`, optional `zap` and one `t` tag per topic.                                                            |
+| 19  | Error handling     | Toasts for FFmpeg load failure, file type issues, upload errors.                                                                                |
+| 20  | Responsive design  | Wizard lets steps manage their own widths; metadata step displays preview and fields side-by-side on large (`lg`) screens. |
+| 21  | Event publishing   | CreatorWizard publishes a signed kind-30023 event containing video URL, poster, manifest, zap address, and topic tags. |
 ### Acceptance Criteria
 
 - CreatorWizard first screen is option chooser.


### PR DESCRIPTION
## Summary
- drop passphrase-based encryption task from sprint spec
- clarify acceptance criteria that key generation stores keys locally

## Testing
- `pnpm test` *(fails: Vitest caught 1 unhandled error; worker out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896c522b3e883319746b4da817fdf6a