### PR TITLE
fix: import mp4box as namespace in web worker

### DIFF
--- a/apps/web/mp4box.d.ts
+++ b/apps/web/mp4box.d.ts
@@ -1,1 +1,5 @@
-declare module 'mp4box';
+declare module 'mp4box' {
+  const MP4Box: any;
+  export = MP4Box;
+}
+

--- a/apps/web/utils/trimVideoWorker.ts
+++ b/apps/web/utils/trimVideoWorker.ts
@@ -1,4 +1,4 @@
-import MP4Box from 'mp4box';
+import * as MP4Box from 'mp4box';
 
 function detectCodec(blobType?: string, trackCodec?: string): string | null {
   const candidates = [trackCodec, blobType];


### PR DESCRIPTION
## Summary
- import mp4box as a namespace to avoid default import errors
- declare mp4box module to support namespace import

## Testing
- `pnpm --filter @paiduan/web build` *(fails: Conflicting paths returned from getStaticPaths, unrelated to mp4box)*

------
https://chatgpt.com/codex/tasks/task_e_6896c8b0ceac8331b1b73504e8fc7cdd