### PR TITLE
fix: update mp4box import in trim video worker

### DIFF
--- a/apps/web/utils/trimVideoWorker.ts
+++ b/apps/web/utils/trimVideoWorker.ts
@@ -1,4 +1,4 @@
-import * as MP4Box from 'mp4box';
+import { createFile } from 'mp4box';
 
 function detectCodec(blobType?: string, trackCodec?: string): string | null {
   const candidates = [trackCodec, blobType];
@@ -36,7 +36,7 @@ self.onmessage = async (e: MessageEvent) => {
     }
 
     const buffer = await (blob as Blob).arrayBuffer();
-    const mp4box = MP4Box.createFile();
+    const mp4box = createFile();
     let track: any;
     let demuxError: any;
     const samples: { data: Uint8Array; timestamp: number; type: 'key' | 'delta' }[] = [];


### PR DESCRIPTION
## Summary
- refactor trim video worker to use named mp4box createFile import

## Testing
- `pnpm -F @paiduan/web dev`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896c9f90a4883318175bf5ebb3296be