### PR TITLE
feat(web): add settings link to navbar

### DIFF
--- a/apps/web/components/NavBar.test.tsx
+++ b/apps/web/components/NavBar.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import NavBar from './NavBar';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ asPath: '/en/feed', query: { locale: 'en' } }),
+}));
+
+// Ensure React is available globally for components compiled with the classic JSX runtime
+(globalThis as any).React = React;
+
+describe('NavBar', () => {
+  it('includes link to settings page', () => {
+    const html = renderToStaticMarkup(<NavBar />);
+    expect(html).toContain('/en/settings');
+  });
+});

--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Home, Users, Plus, User } from 'lucide-react';
+import { Home, Users, Plus, Settings } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { motion } from 'framer-motion';
 
@@ -10,7 +10,7 @@ export default function NavBar() {
     { href: `/${locale}/feed`, icon: <Home />, label: 'Home' },
     { href: `/${locale}/feed?tab=following`, icon: <Users />, label: 'Following' },
     { href: `/${locale}/create`, icon: <Plus />, label: 'Create' },
-    { href: `/${locale}/profile`, icon: <User />, label: 'Profile' },
+    { href: `/${locale}/settings`, icon: <Settings />, label: 'Settings' },
   ];
   return (
     <nav


### PR DESCRIPTION
## Summary
- replace profile tab with settings tab in mobile navbar
- update lucide import and add regression test for settings link

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test apps/web/components/NavBar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6896d17d167883319263604d34772ad3