### PR TITLE
fix: support default ffmpeg export

### DIFF
--- a/apps/web/utils/trimVideoFfmpeg.ts
+++ b/apps/web/utils/trimVideoFfmpeg.ts
@@ -14,7 +14,8 @@ let loading: Promise<void> | null = null;
 
 async function loadFfmpeg() {
   if (!ffmpeg) {
-    const { createFFmpeg } = await import('@ffmpeg/ffmpeg');
+    const ffmpegModule = await import('@ffmpeg/ffmpeg');
+    const createFFmpeg = ffmpegModule.createFFmpeg ?? ffmpegModule.default;
     // load core from CDN to avoid bundling large assets
     ffmpeg = createFFmpeg({
       log: false,


### PR DESCRIPTION
## Summary
- handle default export for @ffmpeg/ffmpeg

## Testing
- `pnpm lint`
- `pnpm test` (fails: Error: Worker terminated due to reaching memory limit: JS heap out of memory)

------
https://chatgpt.com/codex/tasks/task_e_6896d0b7e4ec8331beeb322bf08b3dee