### PR TITLE
feat: support nip-71 video events

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ the browser is not supported—prepare clips ahead of time:
 
 1. Select a short clip (MP4/WebM, ≤3 min)
 2. Trim the clip and capture a poster frame
-3. Add a caption, upload the assets, and publish a NIP‑23 note
+3. Add a caption, upload the assets, and publish a NIP‑71 event (kind 21 for normal videos, kind 22 for short clips)
 
-Publishing now includes `['zap', <lnaddr>, <pct>]` tags for the creator and any collaborators when Lightning addresses are provided.
+Publishing now includes `['zap', <lnaddr>, <pct>]` tags for the creator and any collaborators when Lightning addresses are provided. Video events are encoded using NIP‑71, which relies on `imeta` tags from NIP‑92 to describe the video and poster URLs.
 
 For manual testing of the upload endpoint you can use cURL:
 
@@ -80,7 +80,18 @@ For manual testing of the upload endpoint you can use cURL:
 curl -F "file=@video.mp4" -F "poster=@poster.jpg" https://nostr.media/api/upload
 ```
 
-The response returns `video` and `poster` URLs that can be used in a kind 30023 event.
+The response returns `video`, `poster` and `manifest` URLs that can be referenced from an `imeta` tag when constructing a kind 21/22 event.
+
+### NIP‑71 video events
+
+PaiDuan uses [NIP‑71](https://github.com/nostr-protocol/nips/blob/master/71.md) for publishing video posts. Clients should:
+
+1. Upload media to obtain a primary video URL, an optional adaptive `manifest` URL and a poster image.
+2. Decide whether the clip is a **normal** (landscape) or **short** (portrait) video. Publish kind 21 for normal videos or kind 22 for shorts.
+3. Include at least one `imeta` tag per media variant. Each tag lists `dim`, `url`, `m` (MIME type) and one or more `image` fields for previews.
+4. Add optional metadata such as `title`, `published_at`, hashtag `t` tags and `zap` split tags.
+
+Consumers subscribe to kinds 21 and 22, parse the `imeta` tags to find playable URLs and preview images, and display the `title` or event `content` as the caption. Topic `t` tags can be aggregated to build hashtag feeds.
 
 ## Revenue share
 

--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -5,6 +5,33 @@ import type { Filter } from 'nostr-tools/filter';
 import { VideoCardProps } from '../components/VideoCard';
 import { getRelays } from '@/lib/nostr';
 
+function parseImeta(tags: string[][]) {
+  let videoUrl: string | undefined;
+  let manifestUrl: string | undefined;
+  let posterUrl: string | undefined;
+
+  tags
+    .filter((t) => t[0] === 'imeta')
+    .forEach((t) => {
+      const kv: Record<string, string[]> = {};
+      t.slice(1).forEach((entry) => {
+        const [key, ...rest] = entry.split(' ');
+        const value = rest.join(' ');
+        (kv[key] ||= []).push(value);
+      });
+      if (!posterUrl && kv.image?.[0]) posterUrl = kv.image[0];
+      const url = kv.url?.[0];
+      const m = kv.m?.[0];
+      if (m === 'application/x-mpegURL') {
+        if (!manifestUrl && url) manifestUrl = url;
+      } else {
+        if (!videoUrl && url) videoUrl = url;
+      }
+    });
+
+  return { videoUrl, manifestUrl, posterUrl };
+}
+
 export interface CreatorResult {
   pubkey: string;
   name: string;
@@ -45,7 +72,7 @@ export function useSearch(query: string): SearchResults {
       filters.push({ kinds: [0], search: q, limit: 20 } as Filter);
     } else {
       // search videos and creators
-      const videoFilter: Filter = { kinds: [30023], search: q, limit: 50 };
+      const videoFilter: Filter = { kinds: [21, 22], search: q, limit: 50 };
       if (query.startsWith('#')) {
         (videoFilter as any)['#t'] = [q];
       }
@@ -59,19 +86,18 @@ export function useSearch(query: string): SearchResults {
     debounceRef.current = setTimeout(() => {
       const sub = pool.subscribeMany(relays, filters, {
         onevent: (ev: NostrEvent) => {
-          if (ev.kind === 30023) {
-            const videoTag = ev.tags.find((t) => t[0] === 'v');
-            if (!videoTag) return;
-            const posterTag = ev.tags.find((t) => t[0] === 'image');
-            const manifestTag = ev.tags.find((t) => t[0] === 'vman');
+          if (ev.kind === 21 || ev.kind === 22) {
+            const { videoUrl, manifestUrl, posterUrl } = parseImeta(ev.tags);
+            if (!videoUrl && !manifestUrl) return;
             const zapTags = ev.tags.filter((t) => t[0] === 'zap');
             const tTags = ev.tags.filter((t) => t[0] === 't').map((t) => t[1]);
+            const titleTag = ev.tags.find((t) => t[0] === 'title');
             nextVideos.push({
-              videoUrl: videoTag[1],
-              posterUrl: posterTag ? posterTag[1] : undefined,
-              manifestUrl: manifestTag ? manifestTag[1] : undefined,
+              videoUrl: videoUrl || manifestUrl || '',
+              posterUrl,
+              manifestUrl,
               author: ev.pubkey.slice(0, 8),
-              caption: tTags.join(' '),
+              caption: titleTag ? titleTag[1] : ev.content,
               eventId: ev.id,
               lightningAddress: zapTags.length ? zapTags[0][1] : '',
               pubkey: ev.pubkey,


### PR DESCRIPTION
## Summary
- parse NIP-92 `imeta` tags and subscribe to video kinds 21/22 in feed and search hooks
- publish uploads as NIP-71 events using `imeta` metadata and normal vs short video kinds
- document NIP-71 workflow for publishing and consuming video events

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896d2f8c0f48331a9ba675df6bc5df2