### PR TITLE
Wrap feed page with CurrentVideoProvider

### DIFF
--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -9,6 +9,7 @@ import useFollowing from '@/hooks/useFollowing';
 import useFollowers from '@/hooks/useFollowers';
 import { useProfile } from '@/hooks/useProfile';
 import { useFeedSelection } from '@/store/feedSelection';
+import { CurrentVideoProvider } from '@/hooks/useCurrentVideo';
 
 export default function FeedPage() {
   const { filterAuthor, setFilterAuthor, selectedVideoAuthor } = useFeedSelection();
@@ -53,19 +54,21 @@ export default function FeedPage() {
   }
 
   return (
-    <AppShell
-      left={<MainNav me={me} />}
-      center={
-        <div className="h-full">
-          {/* tabs bar you already have can stay on top */}
-          {videos.length === 0 ? (
-            <PlaceholderVideo className="aspect-[9/16] w-full max-w-[420px] mx-auto text-primary" />
-          ) : (
-            <Feed items={videos} />
-          )}
-        </div>
-      }
-      right={<RightPanel author={author} onFilterByAuthor={filterByAuthor} />}
-    />
+    <CurrentVideoProvider>
+      <AppShell
+        left={<MainNav me={me} />}
+        center={
+          <div className="h-full">
+            {/* tabs bar you already have can stay on top */}
+            {videos.length === 0 ? (
+              <PlaceholderVideo className="aspect-[9/16] w-full max-w-[420px] mx-auto text-primary" />
+            ) : (
+              <Feed items={videos} />
+            )}
+          </div>
+        }
+        right={<RightPanel author={author} onFilterByAuthor={filterByAuthor} />}
+      />
+    </CurrentVideoProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap feed page's AppShell with `CurrentVideoProvider`
- allow Feed and RightPanel descendants to consume `useCurrentVideo`

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896d517767c833195c462f6605a57e6