### PR TITLE
chore: fallback to ffmpeg for unsupported codecs

### DIFF
--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -146,7 +146,19 @@ export default function CreateVideoForm() {
             worker.terminate();
             setProgress(0);
             if (msg.error === 'unsupported-codec') {
-              setErr('Unsupported video codec. Please convert your video and try again.');
+              try {
+                const blob = await trimVideoFfmpeg(f, {
+                  start: 0,
+                  width,
+                  height,
+                  onProgress: (p) => setProgress(Math.round(p * 100)),
+                });
+                setOutBlob(blob);
+                updatePreview(URL.createObjectURL(blob));
+              } catch (err: any) {
+                console.error(err);
+                setErr('Unsupported video codec. Please convert your video and try again.');
+              }
             } else if (msg.error === 'no-keyframe' || msg.error === 'demux-failed') {
               setErr(
                 msg.error === 'no-keyframe'


### PR DESCRIPTION
## Summary
- fallback to ffmpeg when WebCodecs hits an unsupported codec and only show an error if the ffmpeg path fails

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896d403429c8331a7524e3219dd369f