### PR TITLE
feat: centralize modqueue fetching

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { ThemeProvider } from '@/context/themeContext';
+import { ModqueueProvider } from '@/context/modqueueContext';
 import { GestureProvider } from '@paiduan/ui';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider>
-      <GestureProvider>{children}</GestureProvider>
+      <GestureProvider>
+        <ModqueueProvider>{children}</ModqueueProvider>
+      </GestureProvider>
     </ThemeProvider>
   );
 }

--- a/apps/web/context/modqueueContext.tsx
+++ b/apps/web/context/modqueueContext.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+export interface ModqueueItem {
+  targetKind: string;
+  targetId: string;
+  reporterPubKey: string;
+}
+
+const Ctx = createContext<ModqueueItem[]>([]);
+
+export function ModqueueProvider({ children }: { children: React.ReactNode }) {
+  const [data, setData] = useState<ModqueueItem[]>([]);
+
+  const load = () => {
+    fetch('/api/modqueue')
+      .then((r) => r.json())
+      .then((d: ModqueueItem[]) => setData(d))
+      .catch(() => undefined);
+  };
+
+  useEffect(() => {
+    load();
+    const listener = () => load();
+    window.addEventListener('modqueue', listener);
+    return () => window.removeEventListener('modqueue', listener);
+  }, []);
+
+  return <Ctx.Provider value={data}>{children}</Ctx.Provider>;
+}
+
+export function useModqueue() {
+  return useContext(Ctx);
+}
+


### PR DESCRIPTION
## Summary
- add ModqueueProvider to fetch /api/modqueue once and refresh on modqueue events
- use context in CommentDrawer and useFeed to derive hidden items

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896d82bfc9c833183856b3e3c63c208