### PR TITLE
fix: use dynamic viewport height for main feed

### DIFF
--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -27,7 +27,7 @@ export default function AppShell({
         </aside>
 
         {/* Middle column: main feed */}
-        <main className="h-screen overflow-y-auto">
+        <main className="h-[100dvh] overflow-hidden">
           <div className="max-w-2xl mx-auto h-full px-4">{center}</div>
         </main>
 


### PR DESCRIPTION
## Summary
- use dynamic viewport height for main feed
- prevent native page scrolling in main feed

## Testing
- `pnpm lint`
- `pnpm test` *(fails: worker out-of-memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896d965b33c8331aaa4bbac0e9dd81c