### PR TITLE
feat(web): prefetch navigation links

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -65,7 +65,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading }) => {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center text-white">
         <EmptyState />
-        <Link href="/create" className="btn btn-primary mt-4">
+        <Link href="/create" className="btn btn-primary mt-4" prefetch>
           Upload your first video
         </Link>
       </div>

--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -31,6 +31,7 @@ export default function MiniProfileCard({
       <Link
         href="/settings#profile"
         className="text-xs text-[var(--accent-primary)]"
+        prefetch
       >
         Manage profile
       </Link>

--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -4,7 +4,8 @@ import { useRouter } from 'next/router';
 import { motion } from 'framer-motion';
 
 export default function NavBar() {
-  const { asPath, query } = useRouter();
+  const router = useRouter();
+  const { asPath, query } = router;
   const locale = (query.locale as string) || 'en';
   const links = [
     { href: `/${locale}/feed`, icon: <Home />, label: 'Home' },
@@ -29,6 +30,8 @@ export default function NavBar() {
                 : 'text-muted hover:bg-accent-primary/20 hover:text-accent-primary'
             }`}
             aria-current={active ? 'page' : undefined}
+            prefetch={false}
+            onMouseEnter={() => router.prefetch(href)}
           >
             <motion.div
               animate={{ scale: active ? 1.2 : 1 }}

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -8,6 +8,7 @@ import CommentDrawer from './CommentDrawer';
 import ReportModal from './ReportModal';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { Skeleton } from './ui/Skeleton';
 import { SimplePool } from 'nostr-tools/pool';
 import useFollowing from '../hooks/useFollowing';
@@ -50,6 +51,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   zapTotal,
   onLike,
 }) => {
+  const router = useRouter();
   const playerRef = useRef<ReactPlayer>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [playing, setPlaying] = useState(true);
@@ -238,7 +240,12 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       </div>
 
       <div className="absolute bottom-0 left-0 w-full p-4">
-        <Link href={`/p/${pubkey}`} className="flex items-center space-x-3">
+        <Link
+          href={`/p/${pubkey}`}
+          className="flex items-center space-x-3"
+          prefetch={false}
+          onMouseEnter={() => router.prefetch(`/p/${pubkey}`)}
+        >
           {avatar ? (
             <Image
               src={avatar}

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import Thread from '@/components/comments/Thread';
 import { useFeedSelection } from '@/store/feedSelection';
 import { cardStyle } from '@/components/ui/Card';
@@ -14,6 +15,7 @@ export default function RightPanel({
   onFilterByAuthor: (pubkey: string) => void;
 }) {
   const { selectedVideoId, selectedVideoAuthor } = useFeedSelection();
+  const router = useRouter();
   return (
     <div className="p-[1.2rem] space-y-4">
       {author && (
@@ -33,7 +35,12 @@ export default function RightPanel({
                 {author.followers.toLocaleString()} followers
               </div>
               <div className="mt-3 flex gap-2">
-                <Link href={`/p/${author.pubkey}`} className="btn btn-secondary">
+                <Link
+                  href={`/p/${author.pubkey}`}
+                  className="btn btn-secondary"
+                  prefetch={false}
+                  onMouseEnter={() => router.prefetch(`/p/${author.pubkey}`)}
+                >
                   View profile
                 </Link>
                 <button className="btn btn-primary" onClick={() => onFilterByAuthor(author.pubkey)}>

--- a/apps/web/components/layout/BottomNav.tsx
+++ b/apps/web/components/layout/BottomNav.tsx
@@ -5,7 +5,8 @@ import { useRouter } from 'next/router';
 import { navItems } from './nav';
 
 export default function BottomNav() {
-  const { asPath } = useRouter();
+  const router = useRouter();
+  const { asPath } = router;
 
   return (
     <nav className="fixed bottom-0 inset-x-0 flex justify-around border-t bg-surface lg:hidden">
@@ -20,6 +21,8 @@ export default function BottomNav() {
             }`}
             aria-label={label}
             aria-current={active ? 'page' : undefined}
+            prefetch={false}
+            onMouseEnter={() => router.prefetch(href)}
           >
             <Icon size={24} />
             <span className="sr-only">{label}</span>

--- a/apps/web/components/layout/MainNav.tsx
+++ b/apps/web/components/layout/MainNav.tsx
@@ -27,11 +27,12 @@ export default function MainNav({
   showProfile = true,
 }: MainNavProps) {
   const { mode, toggleMode } = useTheme();
-  const { asPath, locale } = useRouter();
+  const router = useRouter();
+  const { asPath, locale } = router;
 
   return (
     <div className="p-[1.2rem] space-y-4">
-      <Link href="/" className="block pl-5">
+      <Link href="/" className="block pl-5" prefetch>
         <Logo width={160} height={34} />
       </Link>
 
@@ -64,6 +65,8 @@ export default function MainNav({
                       : 'text-muted hover:bg-accent-primary/20 hover:text-accent-primary'
                   }`}
                   aria-current={active ? 'page' : undefined}
+                  prefetch={false}
+                  onMouseEnter={() => router.prefetch(href)}
                 >
                   <Icon size={20} /> {label}
                 </Link>

--- a/apps/web/pages/en/index.tsx
+++ b/apps/web/pages/en/index.tsx
@@ -18,10 +18,10 @@ export default function LandingPage() {
           Built on Nostr. Own your keys, your audience, your revenue.
         </p>
         <div className="mt-8 flex justify-center gap-3">
-          <Link href="/onboarding/key" className="btn btn-primary">
+          <Link href="/onboarding/key" className="btn btn-primary" prefetch>
             Get Started
           </Link>
-          <Link href="/en/feed" className="btn btn-secondary">
+          <Link href="/en/feed" className="btn btn-secondary" prefetch>
             Explore Feed
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- prefetch profile link in sidebar and video card on hover
- add prefetch to landing and feed links
- eagerly prefetch routes from nav components on hover

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*
- `pnpm --filter @paiduan/web build` *(fails: Conflicting paths returned from getStaticPaths)*
- `pnpm --filter @paiduan/web dev`

------
https://chatgpt.com/codex/tasks/task_e_6896db9b73d0833182da67bc1ae55850