### PR TITLE
Allow remote images

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -19,6 +19,9 @@ export default withPWAConfig({
   reactStrictMode: true,
   typescript: { ignoreBuildErrors: true },
   transpilePackages: ['@paiduan/ui'],
+  images: {
+    remotePatterns: [{ protocol: 'https', hostname: '**' }],
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary
- allow Next.js to serve remote images from any HTTPS domain

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896dfa410dc83318dbf43e04dc5b904