### PR TITLE
Load PWA plugin only in production

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -3,18 +3,7 @@ import runtimeCaching from 'next-pwa/cache.js';
 
 const isProd = process.env.NODE_ENV === 'production';
 
-const withPWAConfig = withPWA({
-  dest: 'public',
-  disable: !isProd,
-  runtimeCaching,
-  buildExcludes: [/middleware-manifest\.json$/],
-  fallbacks: {
-    image: '/offline.jpg',
-    document: '/offline.html',
-  },
-});
-
-export default withPWAConfig({
+const baseConfig = {
   experimental: { esmExternals: 'loose' },
   reactStrictMode: true,
   typescript: { ignoreBuildErrors: true },
@@ -28,4 +17,16 @@ export default withPWAConfig({
       },
     ];
   },
+};
+
+const withPWAConfig = withPWA({
+  dest: 'public',
+  runtimeCaching,
+  buildExcludes: [/middleware-manifest\.json$/],
+  fallbacks: {
+    image: '/offline.jpg',
+    document: '/offline.html',
+  },
 });
+
+export default isProd ? withPWAConfig(baseConfig) : baseConfig;


### PR DESCRIPTION
## Summary
- guard Next.js config so `next-pwa` only runs in production

## Testing
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6896df8ba3f48331b94154aeb931163a