### PR TITLE
feat: precache core pages for offline support

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,3 +1,9 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.3.0/workbox-sw.js');
+
+self.addEventListener('install', () => {
+  workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+});
+
 self.addEventListener('push', event => {
   const data = event.data ? event.data.json() : {};
   const title = data.title || 'PaiDuan';

--- a/apps/web/public/workbox-config.js
+++ b/apps/web/public/workbox-config.js
@@ -1,3 +1,10 @@
+const precacheManifest = [
+  { url: 'index.html', revision: null },
+  { url: 'feed.html', revision: null },
+  { url: 'main.js', revision: null },
+  { url: 'main.css', revision: null },
+];
+
 module.exports = {
   globDirectory: 'public/',
   globPatterns: ['**/*.{js,css,html,png,jpg,webm,json,svg}'],
@@ -5,9 +12,7 @@ module.exports = {
     { urlPattern: /^https?.*\.(webm|mp4)$/, handler: 'CacheFirst' },
     { urlPattern: /^https?.*\.(jpg|jpeg|png|gif|svg)$/, handler: 'StaleWhileRevalidate' },
     { urlPattern: /^https?.*nostr\.media.*$/, handler: 'NetworkFirst' },
-    {
-      urlPattern: /^(https|wss):.*(relay|nostr).*$/,
-      handler: 'StaleWhileRevalidate',
-    },
+    { urlPattern: /^(https|wss):.*(relay|nostr).*$/, handler: 'StaleWhileRevalidate' },
   ],
+  precacheManifest,
 };


### PR DESCRIPTION
## Summary
- add explicit precache manifest for index, feed, and main bundles
- use workbox precacheAndRoute during service worker install

## Testing
- `pnpm test` *(fails: apps/web/components/create/CreateVideoForm.profiles.test.tsx)*
- `pnpm --filter @paiduan/web build`
- `npx -p puppeteer@21.8.0 node - <<'NODE' ...` *(attempted offline load, environment produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_6896e05d8d648331a9cb902108cf94e1