### PR TITLE
feat: paginate feed and load older videos

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -8,9 +8,10 @@ import Link from 'next/link';
 interface FeedProps {
   items: VideoCardProps[];
   loading?: boolean;
+  loadMore?: () => void;
 }
 
-export const Feed: React.FC<FeedProps> = ({ items, loading }) => {
+export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   const [index, setIndex] = useState(0);
   const [{ y }, api] = useSpring(() => ({ y: 0 }));
 
@@ -52,6 +53,12 @@ export const Feed: React.FC<FeedProps> = ({ items, loading }) => {
   useEffect(() => {
     api.start({ y: -index * 100 });
   }, [index, api]);
+
+  useEffect(() => {
+    if (index >= items.length - 2) {
+      loadMore?.();
+    }
+  }, [index, items.length, loadMore]);
 
   if (loading) {
     return (

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -29,9 +29,13 @@ export async function saveEvent(event: any): Promise<void> {
   if (!db) return;
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_EVENTS, 'readwrite');
-    tx.objectStore(STORE_EVENTS).put({ id: event.id, pubkey: event.pubkey, event });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
+    const store = tx.objectStore(STORE_EVENTS);
+    const req = store.add({ id: event.id, pubkey: event.pubkey, event });
+    req.onsuccess = () => resolve();
+    req.onerror = () => {
+      if ((req.error as any)?.name === 'ConstraintError') resolve();
+      else reject(req.error);
+    };
   });
 }
 

--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -13,7 +13,9 @@ import { CurrentVideoProvider } from '@/hooks/useCurrentVideo';
 
 export default function FeedPage() {
   const { filterAuthor, setFilterAuthor, selectedVideoAuthor } = useFeedSelection();
-  const { items: videos } = useFeed(filterAuthor ? { author: filterAuthor } : 'all');
+  const { items: videos, loadMore } = useFeed(
+    filterAuthor ? { author: filterAuthor } : 'all',
+  );
 
   const { state: auth } = useAuth();
   const { following } = useFollowing(
@@ -63,7 +65,7 @@ export default function FeedPage() {
             {videos.length === 0 ? (
               <PlaceholderVideo className="aspect-[9/16] w-full max-w-[420px] mx-auto text-primary" />
             ) : (
-              <Feed items={videos} />
+              <Feed items={videos} loadMore={loadMore} />
             )}
           </div>
         }


### PR DESCRIPTION
## Summary
- paginate feed hook with configurable cursor and default limit 20
- track oldest/newest timestamps and add loadMore for fetching older videos
- wire loadMore into Feed component
- store cached events without overwriting existing entries

## Testing
- `pnpm test` *(fails: CreateVideoForm profiles subscribes once and populates lna)**

------
https://chatgpt.com/codex/tasks/task_e_6896e166accc83318dd05a7bba3a38b2