### PR TITLE
Prefetch above-the-fold avatars

### DIFF
--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -20,6 +20,7 @@ export default function MiniProfileCard({
         alt="Profile avatar"
         width={80}
         height={80}
+        priority
         className="mx-auto mb-2 h-20 w-20 rounded-full"
       />
       <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">@{name}</div>

--- a/apps/web/components/TopNavProfile.tsx
+++ b/apps/web/components/TopNavProfile.tsx
@@ -27,6 +27,7 @@ export default function TopNavProfile() {
         alt="Profile avatar"
         width={80}
         height={80}
+        priority
         className="h-20 w-20 rounded-lg"
       />
     </div>

--- a/apps/web/components/VideoInfoPane.tsx
+++ b/apps/web/components/VideoInfoPane.tsx
@@ -50,6 +50,7 @@ export default function VideoInfoPane() {
           alt={meta?.name || ''}
           width={48}
           height={48}
+          priority
           className="h-12 w-12 rounded-full"
         />
         <div>

--- a/apps/web/pages/profile.tsx
+++ b/apps/web/pages/profile.tsx
@@ -51,6 +51,7 @@ export default function Profile() {
                 alt="avatar"
                 width={96}
                 height={96}
+                priority
                 className="h-24 w-24 rounded-full object-cover"
               />
               <div className="text-lg font-semibold">{meta?.name || 'Anonymous'}</div>


### PR DESCRIPTION
## Summary
- add `priority` to above-the-fold avatar `<Image>` components for faster Largest Contentful Paint

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test` (fails: CreateVideoForm profiles test and worker out of memory)
- `pnpm build --filter=@paiduan/web` (fails: Conflicting paths returned from getStaticPaths)


------
https://chatgpt.com/codex/tasks/task_e_6896e1212b748331911733fdb87868b5