### PR TITLE
refactor: improve ffmpeg temp file handling

### DIFF
--- a/apps/web/utils/trimVideoFfmpeg.ts
+++ b/apps/web/utils/trimVideoFfmpeg.ts
@@ -27,6 +27,13 @@ async function loadFfmpeg() {
   return ffmpeg!;
 }
 
+function uniqueId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
 export async function trimVideoFfmpeg(blob: Blob, opts: TrimFfmpegOptions): Promise<Blob> {
   if (typeof window === 'undefined') {
     throw new Error('trimVideoFfmpeg can only run in the browser');
@@ -34,47 +41,62 @@ export async function trimVideoFfmpeg(blob: Blob, opts: TrimFfmpegOptions): Prom
   const ffmpeg = await loadFfmpeg();
   const { fetchFile } = await import('@ffmpeg/util');
 
-  ffmpeg.FS('writeFile', 'in', await fetchFile(blob));
+  const inFile = `in-${uniqueId()}`;
+  const outFile = `out-${uniqueId()}.webm`;
 
-  const args = ['-i', 'in', '-ss', `${opts.start}`];
-  if (opts.end != null) args.push('-to', `${opts.end}`);
+  let data: Uint8Array;
 
-  const filters: string[] = [];
-  if (opts.crop) {
-    const { x, y, width, height } = opts.crop;
-    filters.push(`crop=${width}:${height}:${x}:${y}`);
+  try {
+    ffmpeg.FS('writeFile', inFile, await fetchFile(blob));
+
+    const args = ['-i', inFile, '-ss', `${opts.start}`];
+    if (opts.end != null) args.push('-to', `${opts.end}`);
+
+    const filters: string[] = [];
+    if (opts.crop) {
+      const { x, y, width, height } = opts.crop;
+      filters.push(`crop=${width}:${height}:${x}:${y}`);
+    }
+    if (opts.width || opts.height) {
+      const w = opts.width ?? -1;
+      const h = opts.height ?? -1;
+      filters.push(`scale=${w}:${h}`);
+    }
+    if (filters.length) {
+      args.push('-vf', filters.join(','));
+    }
+    args.push(
+      '-c:v',
+      'libvpx-vp9',
+      '-b:v',
+      '0',
+      '-crf',
+      '30',
+      '-c:a',
+      'libopus',
+      '-f',
+      'webm',
+      outFile,
+    );
+
+    ffmpeg.setProgress(({ ratio }) => {
+      opts.onProgress?.(ratio);
+    });
+
+    await ffmpeg.run(...args);
+    opts.onProgress?.(1);
+    data = ffmpeg.FS('readFile', outFile);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`FFmpeg trim failed: ${message}`);
+  } finally {
+    try {
+      ffmpeg.FS('unlink', inFile);
+    } catch {}
+    try {
+      ffmpeg.FS('unlink', outFile);
+    } catch {}
   }
-  if (opts.width || opts.height) {
-    const w = opts.width ?? -1;
-    const h = opts.height ?? -1;
-    filters.push(`scale=${w}:${h}`);
-  }
-  if (filters.length) {
-    args.push('-vf', filters.join(','));
-  }
-  args.push(
-    '-c:v',
-    'libvpx-vp9',
-    '-b:v',
-    '0',
-    '-crf',
-    '30',
-    '-c:a',
-    'libopus',
-    '-f',
-    'webm',
-    'out.webm',
-  );
-
-  ffmpeg.setProgress(({ ratio }) => {
-    opts.onProgress?.(ratio);
-  });
-
-  await ffmpeg.run(...args);
-  opts.onProgress?.(1);
-  const data = ffmpeg.FS('readFile', 'out.webm');
-  ffmpeg.FS('unlink', 'in');
-  ffmpeg.FS('unlink', 'out.webm');
 
   return new Blob([data.buffer], { type: 'video/webm' });
 }


### PR DESCRIPTION
## Summary
- ensure ffmpeg uses unique tmp filenames and cleans them up
- surface detailed errors when ffmpeg processing fails

## Testing
- `pnpm lint`
- `pnpm test` *(fails: CreateVideoForm.profiles.test.tsx > CreateVideoForm profiles > subscribes once and populates lnaddr datalist)*

------
https://chatgpt.com/codex/tasks/task_e_6896e3949c2483319254fd6a390b9563