### PR TITLE
Handle additional H.264 codec labels

### DIFF
--- a/apps/web/utils/trimVideoWorker.test.ts
+++ b/apps/web/utils/trimVideoWorker.test.ts
@@ -1,0 +1,20 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let detectCodec: (blobType?: string, trackCodec?: string) => string | null;
+
+beforeAll(async () => {
+  (globalThis as any).self = {};
+  ({ detectCodec } = await import('./trimVideoWorker'));
+});
+
+describe('detectCodec', () => {
+  it('maps H.264 aliases to avc1', () => {
+    expect(detectCodec(undefined, 'avc3')).toBe('avc1');
+    expect(detectCodec(undefined, 'avc4')).toBe('avc1');
+    expect(detectCodec(undefined, 'x264')).toBe('avc1');
+  });
+
+  it('returns null for unknown codecs', () => {
+    expect(detectCodec(undefined, 'unknown')).toBeNull();
+  });
+});

--- a/apps/web/utils/trimVideoWorker.ts
+++ b/apps/web/utils/trimVideoWorker.ts
@@ -1,11 +1,16 @@
 import { createFile } from 'mp4box';
 
-function detectCodec(blobType?: string, trackCodec?: string): string | null {
+export function detectCodec(blobType?: string, trackCodec?: string): string | null {
   const candidates = [trackCodec, blobType];
   for (const c of candidates) {
     if (!c) continue;
     const codec = c.toLowerCase();
-    if (codec.includes('avc1') || codec.includes('h264')) return 'avc1';
+    if (
+      codec.startsWith('avc') ||
+      codec.includes('h264') ||
+      codec.includes('x264')
+    )
+      return 'avc1';
     if (
       codec.includes('hvc1') ||
       codec.includes('hev1') ||


### PR DESCRIPTION
## Summary
- treat more H.264 codec aliases (avc2/avc3/avc4/x264) as avc1 in `detectCodec`
- add unit test verifying H.264 aliases map to avc1

## Testing
- `pnpm test apps/web/utils/trimVideoWorker.test.ts`
- `pnpm test` *(fails: apps/web/components/create/CreateVideoForm.profiles.test.tsx: subscribes once and populates lnaddr datalist)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6896e7196ab08331969417f4e992aa2f