### PR TITLE
Disable default touch actions for Feed container

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -87,7 +87,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   }
 
   return (
-    <div {...bind()} className="relative h-full w-full overflow-hidden">
+    <div {...bind()} className="relative h-full w-full overflow-hidden touch-none">
       <animated.div
         style={{ transform: y.to((py) => `translateY(${py}%)`) }}
         className="h-full w-full"


### PR DESCRIPTION
## Summary
- disable default browser touch handling on Feed outer div using `touch-none`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6896e80462f08331b0b7dad50d86a07d