### PR TITLE
feat: cache public assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ pnpm --filter @paiduan/web build:pwa
 
 Open the app and choose **Install** (or **Add to Home Screen**) to install it.
 
+## CDN configuration
+
+Static assets in `apps/web/public` are served with long-lived caching headers. When deploying:
+
+- **Vercel** respects `Cache-Control` by default, so no extra setup is required.
+- **Cloudflare** should be set to *Respect Existing Headers* or *Origin Cache Control* so the `Cache-Control: public, max-age=31536000, immutable` header is honored.
+
+Verify locally by running `pnpm --filter @paiduan/web dev` and inspecting network responses in your browser's developer tools to confirm the `Cache-Control` value.
+
 ## Tests
 
 ```bash

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -11,6 +11,19 @@ const baseConfig = {
   images: {
     remotePatterns: [{ protocol: 'https', hostname: '**' }],
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)\\.(png|jpg|jpeg|gif|svg|webp|webm)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary
- add headers() to serve public images and WebM with immutable, one-year cache control
- document CDN configuration for Vercel and Cloudflare

## Testing
- `curl -I http://localhost:3000/avatar.svg`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896e829d32c83319621998d423aef9e