### PR TITLE
feat: replace like with repost action

### DIFF
--- a/apps/web/hooks/useFeed.ts
+++ b/apps/web/hooks/useFeed.ts
@@ -88,7 +88,6 @@ async function fetchFeedPage({
           lightningAddress: zapTags.length ? zapTags[0][1] : '',
           pubkey: event.pubkey,
           zapTotal: 0,
-          onLike: () => {},
         };
         items.push({ data: item, created: event.created_at || 0 });
         await saveEvent(event);

--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -102,7 +102,6 @@ export function useSearch(query: string): SearchResults {
               lightningAddress: zapTags.length ? zapTags[0][1] : '',
               pubkey: ev.pubkey,
               zapTotal: 0,
-              onLike: () => {},
             });
             setVideos([...nextVideos]);
           } else if (ev.kind === 0) {

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -88,7 +88,6 @@ export default function ProfilePage() {
             lightningAddress: zapTags.length ? zapTags[0][1] : '',
             pubkey: ev.pubkey,
             zapTotal: 0,
-            onLike: () => {},
           });
           setVideos([...nextVideos]);
         },

--- a/apps/web/pages/v/[eventId].tsx
+++ b/apps/web/pages/v/[eventId].tsx
@@ -33,7 +33,6 @@ export default function VideoPage() {
         lightningAddress: zapTags.length ? zapTags[0][1] : '',
         pubkey: ev.pubkey,
         zapTotal: 0,
-        onLike: () => {},
       });
     });
     return () => {


### PR DESCRIPTION
## Summary
- add Nostr repost support and button to VideoCard
- drop onLike prop and share action
- update feed/search/pages to use new VideoCard interface

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896e99569b8833184672a546fc001c2