### PR TITLE
fix feed selection update loop

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -17,7 +17,8 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   const [{ y }, api] = useSpring(() => ({ y: 0 }));
 
   const wheelOffset = useRef(0);
-  const { setSelectedVideo } = useFeedSelection();
+  const setSelectedVideo = useFeedSelection((s) => s.setSelectedVideo);
+  const selectedVideoId = useFeedSelection((s) => s.selectedVideoId);
 
   const next = useCallback(() => {
     setIndex((i) => (i < items.length - 1 ? i + 1 : i));
@@ -85,9 +86,10 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   }, [index, items.length, loadMore]);
 
   useEffect(() => {
-    if (!items[index]) return;
-    setSelectedVideo(items[index].eventId, items[index].pubkey);
-  }, [index, items, setSelectedVideo]);
+    if (items[index] && items[index].eventId !== selectedVideoId) {
+      setSelectedVideo(items[index].eventId, items[index].pubkey);
+    }
+  }, [index, items, setSelectedVideo, selectedVideoId]);
 
   if (loading) {
     return (

--- a/apps/web/store/feedSelection.ts
+++ b/apps/web/store/feedSelection.ts
@@ -11,7 +11,12 @@ export const useFeedSelection = create<S>((set) => ({
   selectedVideoId: undefined,
   selectedVideoAuthor: undefined,
   setSelectedVideo: (id, authorPubkey) =>
-    set({ selectedVideoId: id, selectedVideoAuthor: authorPubkey }),
+    set((state) => {
+      if (state.selectedVideoId === id && state.selectedVideoAuthor === authorPubkey) {
+        return state;
+      }
+      return { selectedVideoId: id, selectedVideoAuthor: authorPubkey };
+    }),
   filterAuthor: undefined,
   setFilterAuthor: (pubkey) => set({ filterAuthor: pubkey }),
 }));


### PR DESCRIPTION
## Summary
- use selectors in `Feed` to avoid store-driven re-renders
- skip redundant state updates in `feedSelection` store

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896e9d2aa0483319f2c38e9aa78e85f