### PR TITLE
feat: make VideoCard menu optional

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -118,7 +118,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
       >
         {items.map((item, i) => (
           <div key={i} className="h-full w-full">
-            <VideoCard {...item} />
+            <VideoCard {...item} showMenu />
           </div>
         ))}
       </animated.div>

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -38,6 +38,7 @@ export interface VideoCardProps {
   lightningAddress: string;
   pubkey: string;
   zapTotal?: number;
+  showMenu?: boolean;
 }
 
 export const VideoCard: React.FC<VideoCardProps> = ({
@@ -50,6 +51,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   lightningAddress,
   pubkey,
   zapTotal,
+  showMenu = false,
 }) => {
   const router = useRouter();
   const playerRef = useRef<ReactPlayer>(null);
@@ -183,24 +185,26 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         config={{ file: { attributes: { poster: posterUrl } } }}
       />
 
-      <div className="absolute right-4 top-4">
-        <button onClick={() => setMenuOpen((o) => !o)} className="hover:text-accent-primary">
-          <MoreVertical />
-        </button>
-        {menuOpen && (
-          <div className="absolute right-0 mt-2 w-24 rounded bg-background-primary p-1 shadow">
-            <button
-              className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
-              onClick={() => {
-                setMenuOpen(false);
-                setReportOpen(true);
-              }}
-            >
-              Report
-            </button>
-          </div>
-        )}
-      </div>
+      {showMenu && (
+        <div className="absolute right-4 top-4">
+          <button onClick={() => setMenuOpen((o) => !o)} className="hover:text-accent-primary">
+            <MoreVertical />
+          </button>
+          {menuOpen && (
+            <div className="absolute right-0 mt-2 w-24 rounded bg-background-primary p-1 shadow">
+              <button
+                className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
+                onClick={() => {
+                  setMenuOpen(false);
+                  setReportOpen(true);
+                }}
+              >
+                Report
+              </button>
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="absolute right-4 bottom-24 flex flex-col items-center space-y-4">
         <button

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -253,7 +253,7 @@ export default function ProfilePage() {
       {selected && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90">
           <div className="relative h-full w-full">
-            <VideoCard {...selected} />
+            <VideoCard {...selected} showMenu />
             <button
               className="absolute right-4 top-4 text-white"
               onClick={() => setSelected(null)}

--- a/apps/web/pages/v/[eventId].tsx
+++ b/apps/web/pages/v/[eventId].tsx
@@ -41,5 +41,5 @@ export default function VideoPage() {
   }, [eventId]);
 
   if (!video) return <div className="flex min-h-screen items-center justify-center bg-black text-white">Loading...</div>;
-  return <VideoCard {...video} />;
+  return <VideoCard {...video} showMenu />;
 }


### PR DESCRIPTION
## Summary
- allow VideoCard menu to be toggled via new `showMenu` prop
- update Feed and video pages to opt into menu actions

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896ebf044708331b92cf0bd97a6c3f7