### PR TITLE
feat: add spring config for feed

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -6,6 +6,8 @@ import { SkeletonVideoCard } from './ui/SkeletonVideoCard';
 import Link from 'next/link';
 import { useFeedSelection } from '@/store/feedSelection';
 
+export const FEED_SPRING_CONFIG = { tension: 170, friction: 26 };
+
 const useMediaQuery = (query: string) => {
   const [matches, setMatches] = useState(false);
 
@@ -24,11 +26,17 @@ interface FeedProps {
   items: VideoCardProps[];
   loading?: boolean;
   loadMore?: () => void;
+  springConfig?: typeof FEED_SPRING_CONFIG;
 }
 
-export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
+export const Feed: React.FC<FeedProps> = ({
+  items,
+  loading,
+  loadMore,
+  springConfig = FEED_SPRING_CONFIG,
+}) => {
   const [index, setIndex] = useState(0);
-  const [{ y }, api] = useSpring(() => ({ y: 0 }));
+  const [{ y }, api] = useSpring(() => ({ y: 0, config: springConfig }));
 
   const wheelOffset = useRef(0);
   const setSelectedVideo = useFeedSelection((s) => s.setSelectedVideo);
@@ -91,8 +99,8 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   }, [next, prev]);
 
   useEffect(() => {
-    api.start({ y: -index * 100 });
-  }, [index, api]);
+    api.start({ y: -index * 100, config: springConfig });
+  }, [index, api, springConfig]);
 
   useEffect(() => {
     if (index >= items.length - 2) {


### PR DESCRIPTION
## Summary
- add default spring config for Feed animations and expose optional override
- ensure api.start uses same spring config for consistent index transitions

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896efab8aa88331baa34a9e89964eb2