### PR TITLE
fix: prevent stale online state

### DIFF
--- a/apps/web/utils/useOffline.ts
+++ b/apps/web/utils/useOffline.ts
@@ -7,7 +7,7 @@ export default function useOffline() {
   useEffect(() => {
     const update = () => {
       const status = navigator.onLine
-      if (!status && online) {
+      if (!status) {
         toast.info('You are offline')
       }
       setOnline(status)
@@ -19,7 +19,7 @@ export default function useOffline() {
       window.removeEventListener('online', update)
       window.removeEventListener('offline', update)
     }
-  }, [online])
+  }, [])
 
   return online
 }


### PR DESCRIPTION
## Summary
- avoid stale online state in useOffline hook by relying on navigator.onLine
- register offline/online listeners once

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web lint`

------
https://chatgpt.com/codex/tasks/task_e_6896efdbbad88331a77c442a29724844