### PR TITLE
Close pools after publish and handle errors

### DIFF
--- a/apps/web/components/ReportModal.tsx
+++ b/apps/web/components/ReportModal.tsx
@@ -28,7 +28,15 @@ const ReportModal: React.FC<Props> = ({ targetId, targetKind, open, onClose }) =
       const event = { kind: 30041, created_at: ts, content: JSON.stringify(report), pubkey: reporterPubKey };
       const signed = await state.signer.signEvent(event);
       const pool: any = new SimplePool();
-      await pool.publish(getRelays(), signed);
+      const relays = getRelays();
+      try {
+        await pool.publish(relays, signed);
+      } catch (err) {
+        console.error('Failed to publish report', err);
+        throw err;
+      } finally {
+        pool.close(relays);
+      }
       await fetch('/api/modqueue', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/packages/mod-dashboard/pages/index.tsx
+++ b/packages/mod-dashboard/pages/index.tsx
@@ -56,8 +56,16 @@ export default function Dashboard({ allowed }: Props) {
     const event = { kind: 9001, created_at: ts, content: JSON.stringify(hide) };
     const signed = await nostr.signEvent(event);
     const pool: any = new SimplePool();
-    await pool.publish(getRelays(), signed);
-    await approve(id);
+    const relays = getRelays();
+    try {
+      await pool.publish(relays, signed);
+      await approve(id);
+    } catch (err) {
+      console.error('Failed to publish removal', err);
+      alert('Failed to publish removal');
+    } finally {
+      pool.close(relays);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure `SimplePool` publishes use explicit relay list and close relays
- log publish failures in dashboard and report modal

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896efe91f14833191fc4f531f529a36