### PR TITLE
refactor: validate createFFmpeg import

### DIFF
--- a/apps/web/utils/trimVideoFfmpeg.ts
+++ b/apps/web/utils/trimVideoFfmpeg.ts
@@ -14,8 +14,13 @@ let loading: Promise<void> | null = null;
 
 async function loadFfmpeg() {
   if (!ffmpeg) {
-    const ffmpegModule = await import('@ffmpeg/ffmpeg');
-    const createFFmpeg = ffmpegModule.createFFmpeg ?? ffmpegModule.default;
+    const { createFFmpeg } = await import('@ffmpeg/ffmpeg');
+    if (!createFFmpeg) {
+      throw new Error('`createFFmpeg` export not found in @ffmpeg/ffmpeg');
+    }
+    if (typeof createFFmpeg !== 'function') {
+      throw new Error('`createFFmpeg` export from @ffmpeg/ffmpeg is not a function');
+    }
     // load core from CDN to avoid bundling large assets
     ffmpeg = createFFmpeg({
       log: false,


### PR DESCRIPTION
## Summary
- refine ffmpeg loading to explicitly import `createFFmpeg`
- guard against missing or invalid `createFFmpeg` exports

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test apps/web/utils/trimVideoWorker.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6896efc1e01c833184d3527801af7624