### PR TITLE
Hide mobile comment button on desktop

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -208,7 +208,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
 
       <div className="absolute right-4 bottom-24 flex flex-col items-center space-y-4">
         <button
-          className="relative hover:text-accent-primary disabled:opacity-50"
+          className="relative hover:text-accent-primary disabled:opacity-50 lg:hidden"
           onClick={() => online && setCommentsOpen(true)}
           disabled={!online}
           title={!online ? 'Offline – reconnect to interact.' : undefined}


### PR DESCRIPTION
## Summary
- hide comment drawer trigger on large screens so desktop uses the comments panel

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test` *(fails: Worker terminated due to memory limit)*
- `pnpm test apps/web/components/VideoFeed.test.tsx apps/web/components/NavBar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6896ef526e5c8331942c484601cd0488