### PR TITLE
Close WebCodecs after trimming video

### DIFF
--- a/apps/web/utils/trimVideoWorker.ts
+++ b/apps/web/utils/trimVideoWorker.ts
@@ -191,6 +191,12 @@ self.onmessage = async (e: MessageEvent) => {
       return;
     }
     await encoder.flush();
+    try {
+      encoder.close?.();
+    } catch {}
+    try {
+      decoder.close?.();
+    } catch {}
 
     const webmBlob = new Blob(outChunks, { type: 'video/webm' });
     self.postMessage({ type: 'done', blob: webmBlob });


### PR DESCRIPTION
## Summary
- close encoder and decoder once flushing completes in trim video worker

## Testing
- `npx vitest run apps/web/utils/trimVideoWorker.test.ts`
- `npm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896f1a87bf483319256261b60941226