### PR TITLE
feat(web): add aria label for mute button

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -212,6 +212,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           className="hover:text-accent-primary"
           onClick={() => setMuted((m) => !m)}
           title={muted ? 'Unmute' : 'Mute'}
+          aria-label={muted ? 'Unmute' : 'Mute'}
         >
           {muted ? <VolumeX /> : <Volume2 />}
         </button>


### PR DESCRIPTION
## Summary
- ensure volume toggle button in VideoCard has matching `aria-label`

## Testing
- `pnpm lint` *(fails: Parsing error in apps/web/components/Feed.tsx)*
- `pnpm test apps/web/components/VideoCard.tsx` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6896f50da1088331ac7f5be8536bab60