### PR TITLE
fix: remove stray useEffect in feed component

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -112,8 +112,6 @@ export const Feed: React.FC<FeedProps> = ({
   }, [next, prev]);
 
   useEffect(() => {
-
-  useEffect(() => {
     if (index >= items.length - 2) {
       loadMore?.();
     }


### PR DESCRIPTION
## Summary
- remove stray useEffect hook from Feed component

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896f6657c9083319a871bdab2ff226c