### PR TITLE
fix: correct Feed component syntax

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -33,7 +33,7 @@ export const Feed: React.FC<FeedProps> = ({
   items,
   loading,
   loadMore,
-  springConfig = FEED_SPRING_CONFIG,
+  springConfig = FEED_SPRING_CONFIG
 }) => {
   const [index, setIndex] = useState(0);
   const [{ y }, api] = useSpring(() => ({ y: 0, config: springConfig }));
@@ -94,7 +94,7 @@ export const Feed: React.FC<FeedProps> = ({
         }
       },
     },
-    { drag: { axis: 'y' }, wheel: { eventOptions: { passive: false } } },
+    { drag: { axis: 'y' }, wheel: { eventOptions: { passive: false } } }
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix Feed component's argument list and gesture config formatting to avoid parse errors

## Testing
- `npx tsc --noEmit apps/web/components/Feed.tsx` *(fails: Module '"@paiduan/ui"' has no exported member 'useSpring', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6896f7ad6fd0833189945e0553b59570