### PR TITLE
Move feed navigation controls to bottom in landscape view

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -161,7 +161,7 @@ export const Feed: React.FC<FeedProps> = ({
               e.stopPropagation();
               prev();
             }}
-            className="btn btn-secondary absolute left-4 top-1/2 -translate-y-1/2"
+            className="btn btn-secondary absolute left-4 bottom-4"
           >
             Previous
           </button>
@@ -170,7 +170,7 @@ export const Feed: React.FC<FeedProps> = ({
               e.stopPropagation();
               next();
             }}
-            className="btn btn-secondary absolute right-4 top-1/2 -translate-y-1/2"
+            className="btn btn-secondary absolute right-4 bottom-4"
           >
             Next
           </button>


### PR DESCRIPTION
## Summary
- Position feed navigation controls near the bottom to avoid overlapping content on landscape screens

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6896fa848ea883319a4e6962c39bfcdd