### PR TITLE
Optimize comment drawer subscriptions

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -289,12 +289,14 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           {seekPreview.toFixed(1)}s
         </div>
       </animated.div>
-      <CommentDrawer
-        videoId={eventId}
-        open={commentsOpen}
-        onClose={() => setCommentsOpen(false)}
-        onCountChange={setCommentCount}
-      />
+      {commentsOpen && (
+        <CommentDrawer
+          videoId={eventId}
+          open={commentsOpen}
+          onClose={() => setCommentsOpen(false)}
+          onCountChange={setCommentCount}
+        />
+      )}
       <ReportModal
         targetId={eventId}
         targetKind="video"


### PR DESCRIPTION
## Summary
- Only mount CommentDrawer when comments are open
- Share a Nostr pool across drawers and subscribe only while open
- Close subscriptions on drawer close

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test apps/web/components/NavBar.test.tsx`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6896faaa9ca0833183faa059a7570e0f