### PR TITLE
Improve feed UI responsiveness and styling

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -161,7 +161,7 @@ export const Feed: React.FC<FeedProps> = ({
               e.stopPropagation();
               prev();
             }}
-            className="btn btn-secondary absolute left-4 top-1/2 -translate-y-1/2"
+            className="btn btn-secondary absolute top-1/2 -translate-y-1/2 left-4"
           >
             Previous
           </button>
@@ -170,7 +170,7 @@ export const Feed: React.FC<FeedProps> = ({
               e.stopPropagation();
               next();
             }}
-            className="btn btn-secondary absolute right-4 top-1/2 -translate-y-1/2"
+            className="btn btn-secondary absolute top-1/2 -translate-y-1/2 right-4"
           >
             Next
           </button>

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -74,6 +74,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const online = useOffline();
   const [menuOpen, setMenuOpen] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
+  const [videoError, setVideoError] = useState(false);
   const { setCurrent } = useCurrentVideo();
   const { ref, inView } = useInView({ threshold: 0.7 });
   const setSelectedVideo = useFeedSelection((s) => s.setSelectedVideo);
@@ -184,12 +185,22 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         height="100%"
         className="pointer-events-none absolute inset-0 h-full w-full object-cover"
         config={{ file: { attributes: { poster: posterUrl } } }}
+        onError={() => setVideoError(true)}
       />
+
+      {videoError && (
+        <img
+          src={posterUrl || '/offline.jpg'}
+          alt="Video unavailable"
+          className="absolute inset-0 h-full w-full object-cover"
+          onError={(e) => (e.currentTarget.src = '/offline.jpg')}
+        />
+      )}
 
       {showMenu && (
         <div className="absolute right-4 top-4">
           <button onClick={() => setMenuOpen((o) => !o)} className="hover:text-accent-primary">
-            <MoreVertical />
+            <MoreVertical className="icon" />
           </button>
           {menuOpen && (
             <div className="absolute right-0 mt-2 w-24 rounded bg-background-primary p-1 shadow">
@@ -214,7 +225,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           title={muted ? 'Unmute' : 'Mute'}
           aria-label={muted ? 'Unmute' : 'Mute'}
         >
-          {muted ? <VolumeX /> : <Volume2 />}
+          {muted ? <VolumeX className="icon" /> : <Volume2 className="icon" />}
         </button>
         <button
           className="relative hover:text-accent-primary disabled:opacity-50 lg:hidden"
@@ -222,7 +233,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           disabled={!online}
           title={!online ? 'Offline – reconnect to interact.' : undefined}
         >
-          <MessageCircle />
+          <MessageCircle className="icon" />
           {commentCount > 0 && (
             <span className="absolute -right-2 -top-2 text-xs text-primary">{commentCount}</span>
           )}
@@ -241,7 +252,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           disabled={!online}
           title={!online ? 'Offline – reconnect to interact.' : undefined}
         >
-          <Repeat2 />
+          <Repeat2 className="icon" />
         </button>
       </div>
 
@@ -263,11 +274,12 @@ export const VideoCard: React.FC<VideoCardProps> = ({
               height={40}
               className="h-10 w-10 rounded-full object-cover"
               unoptimized
+              onError={(e) => (e.currentTarget.src = '/offline.jpg')}
             />
           ) : (
             <Skeleton className="h-10 w-10 rounded-full" />
           )}
-          <div className="font-semibold">@{displayName}</div>
+          <div className="username">@{displayName}</div>
         </Link>
         {!isFollowing && (
           <button
@@ -277,7 +289,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
             Follow
           </button>
         )}
-        <div className="text-sm mt-1">{caption}</div>
+        <div className="meta-info mt-1">{caption}</div>
       </div>
 
       <animated.div

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -17,7 +17,7 @@ export default function RightPanel({
   const { selectedVideoId, selectedVideoAuthor } = useFeedSelection();
   const router = useRouter();
   return (
-    <div className="p-[1.2rem] space-y-4">
+    <div className="space-y-4">
       {author && (
         <div className={`${cardStyle} p-4`}>
           <div className="flex gap-3">
@@ -27,23 +27,28 @@ export default function RightPanel({
               width={48}
               height={48}
               className="w-12 h-12 rounded-full object-cover"
+              onError={(e) => (e.currentTarget.src = '/offline.jpg')}
+              unoptimized
             />
             <div>
               <div className="font-semibold">{author.name}</div>
-              <div className="text-sm text-muted">@{author.username}</div>
-              <div className="text-[0.9rem] font-light text-muted mt-1">
+              <div className="username">@{author.username}</div>
+              <div className="meta-info mt-1">
                 {author.followers.toLocaleString()} followers
               </div>
               <div className="mt-3 flex gap-2">
                 <Link
                   href={`/p/${author.pubkey}`}
-                  className="btn btn-secondary"
+                  className="btn btn-secondary px-3 py-1.5 text-sm"
                   prefetch={false}
                   onMouseEnter={() => router.prefetch(`/p/${author.pubkey}`)}
                 >
                   View profile
                 </Link>
-                <button className="btn btn-primary" onClick={() => onFilterByAuthor(author.pubkey)}>
+                <button
+                  className="btn btn-primary px-3 py-1.5 text-sm"
+                  onClick={() => onFilterByAuthor(author.pubkey)}
+                >
                   Filter by author
                 </button>
               </div>

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -33,8 +33,8 @@ export default function AppShell({
 
         {/* Right column: author info & comments (sticky on desktop) */}
         {hasRight && (
-          <aside className="hidden lg:block border-l divider sticky top-0 h-screen overflow-y-auto">
-            <div className="p-4">{right}</div>
+          <aside className="sidebar-right hidden lg:block border-l divider sticky top-0 h-screen overflow-y-auto">
+            {right}
           </aside>
         )}
       </div>

--- a/apps/web/pages/feed.tsx
+++ b/apps/web/pages/feed.tsx
@@ -60,7 +60,7 @@ export default function FeedPage() {
       <AppShell
         left={<MainNav me={me} />}
         center={
-          <div className="h-full">
+          <div className="feed-container h-full">
             {/* tabs bar you already have can stay on top */}
             {videos.length === 0 ? (
               <PlaceholderVideo className="aspect-[9/16] w-full max-w-[420px] mx-auto text-primary" />

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -52,7 +52,7 @@ body {
 /* Button system — works in light & dark */
 @layer components {
   .btn {
-    @apply px-4 py-2.5 rounded-xl font-medium focus-visible:outline-none focus-visible:ring-2 ring-offset-2;
+    @apply px-4 py-2.5 rounded-xl font-medium focus-visible:outline-none focus-visible:ring-2 ring-offset-2 transition-colors duration-200 ease-in-out;
   }
   .btn-primary {
     background-color: hsl(var(--accent-primary));
@@ -67,13 +67,27 @@ body {
   .btn-secondary {
     @apply border border-current text-current bg-transparent;
   }
+  .btn-ghost {
+    @apply bg-transparent text-primary;
+  }
   .btn-danger {
     background: #ef4444;
     color: white;
   }
-  .btn-ghost {
-    background: transparent;
-    color: hsl(var(--text-primary));
+  .icon {
+    @apply transition-colors duration-200 ease-in-out;
+  }
+  .feed-container {
+    @apply lg:mt-4;
+  }
+  .username {
+    @apply text-lg font-semibold;
+  }
+  .meta-info {
+    @apply text-xs text-muted;
+  }
+  .sidebar-right {
+    @apply p-4;
   }
 }
 


### PR DESCRIPTION
## Summary
- Reduce feed container padding and unify sidebar layout
- Add media fallback handling and icon hover transitions
- Standardize button styles and typography for usernames and meta info

## Testing
- `pnpm test` *(fails: vitest not found, missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_6896fa6eac2083319af9e70a0014a96c