### PR TITLE
fix: support default export for ffmpeg loader

### DIFF
--- a/apps/web/utils/trimVideoFfmpeg.ts
+++ b/apps/web/utils/trimVideoFfmpeg.ts
@@ -14,12 +14,17 @@ let loading: Promise<void> | null = null;
 
 async function loadFfmpeg() {
   if (!ffmpeg) {
-    const { createFFmpeg } = await import('@ffmpeg/ffmpeg');
+    const ffmpegModule = await import('@ffmpeg/ffmpeg');
+    const createFFmpeg = ffmpegModule.createFFmpeg ?? ffmpegModule.default;
     if (!createFFmpeg) {
-      throw new Error('`createFFmpeg` export not found in @ffmpeg/ffmpeg');
+      throw new Error(
+        '@ffmpeg/ffmpeg does not provide a `createFFmpeg` export or default export',
+      );
     }
     if (typeof createFFmpeg !== 'function') {
-      throw new Error('`createFFmpeg` export from @ffmpeg/ffmpeg is not a function');
+      throw new Error(
+        'Resolved `createFFmpeg` export from @ffmpeg/ffmpeg is not a function',
+      );
     }
     // load core from CDN to avoid bundling large assets
     ffmpeg = createFFmpeg({


### PR DESCRIPTION
## Summary
- load `@ffmpeg/ffmpeg` using module object and fall back to default export
- improve runtime errors when ffmpeg exports are missing or not functions

## Testing
- `pnpm test -- --maxWorkers=2` (fails: ERR_WORKER_OUT_OF_MEMORY)
- `pnpm --filter @paiduan/web build` (fails: Conflicting paths returned from getStaticPaths)
- `pnpm dlx tsx -e "globalThis.window={};globalThis.crypto=require('node:crypto').webcrypto;(async()=>{const {trimVideoFfmpeg}=await import('./apps/web/utils/trimVideoFfmpeg.ts');try{await trimVideoFfmpeg(new Blob(),{start:0});}catch(e){console.error(e.message);}})()"` (fails: @ffmpeg/ffmpeg does not provide a `createFFmpeg` export or default export)

------
https://chatgpt.com/codex/tasks/task_e_6896ff3ba2b483318c607fa619117586