### PR TITLE
feat(web): add cross-origin isolation headers

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -15,3 +15,7 @@ A thin progress bar appears at the bottom of the video preview while conversion 
 ### Publish button validation
 
 The **Publish** button remains disabled until a converted video is available and required metadata are supplied—at least one topic and a Lightning address. Validation logic lives in `CreateVideoForm.tsx` and is exposed through the `formValid` flag.
+
+## Cross-origin headers
+
+The application sends `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on all routes. These headers enable cross-origin isolation, which is required for future multi-threaded FFmpeg builds in the browser.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -14,6 +14,13 @@ const baseConfig = {
   async headers() {
     return [
       {
+        source: '/:path*',
+        headers: [
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
+        ],
+      },
+      {
         source: '/(.*)\\.(png|jpg|jpeg|gif|svg|webp|webm)',
         headers: [
           {


### PR DESCRIPTION
## Summary
- send COOP/COEP headers on all routes for cross-origin isolation
- document need for these headers for future multi-threaded FFmpeg builds

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689707a9701883318079645f822144d8