### PR TITLE
chore: use bundler module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true
   },


### PR DESCRIPTION
## Summary
- set TypeScript `moduleResolution` to `bundler` for better ESM support

## Testing
- `pnpm build` (in `packages/mod-dashboard`, fails: Cannot find module '../../apps/web/lib/nostr')

------
https://chatgpt.com/codex/tasks/task_e_689707cc5938833194db96a87b7e71a9