### PR TITLE
Automate fetching ffmpeg core assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ out
 dist
 .env
 .DS_Store
-apps/web/public/ffmpeg/
+apps/web/public/ffmpeg

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "build:pwa": "next build && next-pwa"
   },
   "dependencies": {
+    "@ffmpeg/core-mt": "^0.12.6",
     "@ffmpeg/ffmpeg": "^0.12.6",
     "@ffmpeg/util": "^0.12.2",
     "@headlessui/react": "^2.2.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "format": "prettier --write .",
     "test": "vitest run",
     "test:analytics": "vitest run scripts/aggregate-creator-stats.test.ts apps/web/pages/api/creator-stats.test.ts",
-    "cron:summary": "node scripts/cron-summary.js"
+    "cron:summary": "node scripts/cron-summary.js",
+    "postinstall": "node scripts/install-ffmpeg-core.js"
   },
   "packageManager": "pnpm@10.5.2",
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@ffmpeg/core-mt':
+        specifier: ^0.12.6
+        version: 0.12.10
       '@ffmpeg/ffmpeg':
         specifier: ^0.12.6
         version: 0.12.6
@@ -924,6 +927,10 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@ffmpeg/core-mt@0.12.10':
+    resolution: {integrity: sha512-atyRTOpa58bLCIgd6GXBZAXWyWD3AUoQyzxqjvGhp9MuSzdILtOTI62ffLswBsCnLq15lQ8IETHUpm1oe4V9FQ==}
+    engines: {node: '>=16.x'}
 
   '@ffmpeg/ffmpeg@0.12.6':
     resolution: {integrity: sha512-4CuXDaqrCga5qBwVtiDDR45y65OGPYZd7VzwGCGz3QLdrQH7xaLYEjU19XL4DTCL0WnTSH8752b8Atyb1SiiLw==}
@@ -5891,6 +5898,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@ffmpeg/core-mt@0.12.10': {}
 
   '@ffmpeg/ffmpeg@0.12.6':
     dependencies:

--- a/scripts/install-ffmpeg-core.js
+++ b/scripts/install-ffmpeg-core.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.resolve(__dirname, '..', 'apps', 'web', 'node_modules', '@ffmpeg', 'core-mt', 'dist', 'umd');
+const destDir = path.resolve(__dirname, '..', 'apps', 'web', 'public', 'ffmpeg');
+
+const files = ['ffmpeg-core.js', 'ffmpeg-core.wasm', 'ffmpeg-core.worker.js'];
+
+function copyFiles() {
+  if (!fs.existsSync(distDir)) {
+    console.error('Source directory not found:', distDir);
+    process.exit(1);
+  }
+
+  fs.mkdirSync(destDir, { recursive: true });
+  for (const file of files) {
+    const src = path.join(distDir, file);
+    const dest = path.join(destDir, file);
+    fs.copyFileSync(src, dest);
+  }
+}
+
+copyFiles();


### PR DESCRIPTION
## Summary
- ignore ffmpeg public assets
- add @ffmpeg/core-mt dependency and postinstall copy script

## Testing
- `pnpm install`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897075f85048331aff593f89698f6c4