### PR TITLE
feat(web): add shared relay pool

### DIFF
--- a/apps/web/components/CommentBox.tsx
+++ b/apps/web/components/CommentBox.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { SimplePool } from 'nostr-tools/pool';
+import pool from '@/lib/relayPool';
 import type { Event } from 'nostr-tools/pure';
 import { useAuth } from '@/hooks/useAuth';
 import { getRelays } from '@/lib/nostr';
@@ -24,8 +24,8 @@ export default function CommentBox({ videoId, onSend }: CommentBoxProps) {
         content: input,
         pubkey: state.pubkey,
       };
-      const signed = await state.signer.signEvent(event);
-      await new SimplePool().publish(getRelays(), signed);
+        const signed = await state.signer.signEvent(event);
+        await pool.publish(getRelays(), signed);
       setInput('');
       onSend?.(signed);
     } catch {

--- a/apps/web/components/ReportModal.tsx
+++ b/apps/web/components/ReportModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { SimplePool } from 'nostr-tools/pool';
+import pool from '@/lib/relayPool';
 import toast from 'react-hot-toast';
 import { useAuth } from '@/hooks/useAuth';
 import { getRelays } from '@/lib/nostr';
@@ -25,18 +25,15 @@ const ReportModal: React.FC<Props> = ({ targetId, targetKind, open, onClose }) =
       const reporterPubKey = state.pubkey;
       const ts = Math.floor(Date.now() / 1000);
       const report = { targetId, targetKind, reason, reporterPubKey, ts, details };
-      const event = { kind: 30041, created_at: ts, content: JSON.stringify(report), pubkey: reporterPubKey };
-      const signed = await state.signer.signEvent(event);
-      const pool: any = new SimplePool();
-      const relays = getRelays();
-      try {
-        await pool.publish(relays, signed);
-      } catch (err) {
-        console.error('Failed to publish report', err);
-        throw err;
-      } finally {
-        pool.close(relays);
-      }
+        const event = { kind: 30041, created_at: ts, content: JSON.stringify(report), pubkey: reporterPubKey };
+        const signed = await state.signer.signEvent(event);
+        const relays = getRelays();
+        try {
+          await pool.publish(relays, signed);
+        } catch (err) {
+          console.error('Failed to publish report', err);
+          throw err;
+        }
       await fetch('/api/modqueue', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -21,7 +21,7 @@ import { useFeedSelection } from '@/store/feedSelection';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { prefetchProfile } from '@/hooks/useProfiles';
-import { SimplePool } from 'nostr-tools/pool';
+import pool from '@/lib/relayPool';
 import { getRelays } from '@/lib/nostr';
 
 const MoreVertical = dynamic(() => import('lucide-react').then((mod) => mod.MoreVertical), {
@@ -91,12 +91,11 @@ export const VideoCard: React.FC<VideoCardProps> = ({
     if (auth.status !== 'ready') return;
     if (!window.confirm('Repost this video?')) return;
     try {
-      const relays = getRelays();
-      const pool = new SimplePool();
+        const relays = getRelays();
       let original: any = null;
       let relayUrl: string | undefined;
-      for (const r of relays) {
-        original = await pool.get([r], { ids: [eventId] });
+        for (const r of relays) {
+          original = await pool.get([r], { ids: [eventId] });
         if (original) {
           relayUrl = r;
           break;

--- a/apps/web/components/VideoInfoPane.tsx
+++ b/apps/web/components/VideoInfoPane.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
-import { SimplePool } from 'nostr-tools/pool';
 import type { Event } from 'nostr-tools/pure';
 import { useCurrentVideo } from '../hooks/useCurrentVideo';
 import { useFollowing } from '../hooks/useFollowing';
 import ZapButton from './ZapButton';
 import { getRelays } from '@/lib/nostr';
+import pool from '@/lib/relayPool';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function VideoInfoPane() {
@@ -20,8 +20,7 @@ export default function VideoInfoPane() {
   useEffect(() => {
     if (!current) return;
     (async () => {
-      const pool = new SimplePool();
-      const relays = getRelays();
+        const relays = getRelays();
       try {
         const [m] = await pool.list(relays, [{ kinds: [0], authors: [current.pubkey], limit: 1 }]);
         setMeta(m ? JSON.parse(m.content) : null);

--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../../hooks/useFollowing', () => ({ default: () => ({ following: [] }) 
 vi.mock('../../lib/nostr', () => ({ getRelays: () => [] }));
 
 const mockPublish = vi.fn();
-vi.mock('nostr-tools/pool', () => ({ SimplePool: vi.fn(() => ({ publish: mockPublish })) }));
+vi.mock('../../lib/relayPool', () => ({ default: { publish: mockPublish } }));
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({ back: vi.fn() }) }));
 

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -4,12 +4,12 @@ import { useRouter } from 'next/navigation';
 import PlaceholderVideo from '../PlaceholderVideo';
 import { trimVideoWebCodecs } from '../../utils/trimVideoWebCodecs';
 import { trimVideoFfmpeg } from '../../utils/trimVideoFfmpeg';
-import { SimplePool } from 'nostr-tools/pool';
 import { useAuth } from '../../hooks/useAuth';
 import { useProfile } from '../../hooks/useProfile';
 import { useProfiles } from '../../hooks/useProfiles';
 import useFollowing from '../../hooks/useFollowing';
 import { getRelays } from '../../lib/nostr';
+import pool from '../../lib/relayPool';
 
 export default function CreateVideoForm() {
   const router = useRouter();
@@ -247,8 +247,7 @@ export default function CreateVideoForm() {
       };
 
       const signed = await state.signer.signEvent(event);
-      const pool = new SimplePool();
-      pool.publish(getRelays(), signed);
+      await pool.publish(getRelays(), signed);
       alert('Posted to Nostr');
     } catch (e: any) {
       alert(e.message || 'Failed to post');

--- a/apps/web/components/settings/__tests__/LightningHistory.test.tsx
+++ b/apps/web/components/settings/__tests__/LightningHistory.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@/lib/nostr', () => ({
 const subscribeManyMock = vi.hoisted(() => vi.fn());
 let onEvent: any;
 
-vi.mock('@/hooks/pool', () => ({
+vi.mock('@/lib/relayPool', () => ({
   default: {
     subscribeMany: (...args: any[]) => subscribeManyMock(...args),
   },

--- a/apps/web/hooks/pool.ts
+++ b/apps/web/hooks/pool.ts
@@ -1,6 +1,0 @@
-import { SimplePool } from 'nostr-tools/pool';
-
-// Shared SimplePool instance for the web app
-const pool = new SimplePool();
-
-export default pool;

--- a/apps/web/hooks/useFeed.ts
+++ b/apps/web/hooks/useFeed.ts
@@ -1,11 +1,11 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { SimplePool } from 'nostr-tools/pool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
 import { getRelays } from '@/lib/nostr';
 import { saveEvent } from '@/lib/db';
 import { VideoCardProps } from '../components/VideoCard';
 import { queryClient } from '@/lib/queryClient';
+import pool from '@/lib/relayPool';
 
 function parseImeta(tags: string[][]) {
   let videoUrl: string | undefined;
@@ -54,9 +54,8 @@ async function fetchFeedPage({
   authors: string[];
   limit: number;
 }) {
-  const pool: any = new SimplePool();
-  const relays = getRelays();
-  const filter: Filter = { kinds: [21, 22], limit };
+    const relays = getRelays();
+    const filter: Filter = { kinds: [21, 22], limit };
   if (pageParam) filter.until = pageParam;
   if (mode === 'following') {
     if (authors.length > 0) filter.authors = authors;

--- a/apps/web/hooks/useLightning.test.ts
+++ b/apps/web/hooks/useLightning.test.ts
@@ -6,14 +6,10 @@ vi.mock('./useAuth', () => ({
 
 const poolGetMock = vi.fn();
 
-vi.mock('nostr-tools/pool', () => ({
-  SimplePool: class {
-    get(...args: any[]) {
-      return poolGetMock(...args);
-    }
-    publish() {
-      return {} as any;
-    }
+vi.mock('@/lib/relayPool', () => ({
+  default: {
+    get: (...args: any[]) => poolGetMock(...args),
+    publish: () => ({} as any),
   },
 }));
 

--- a/apps/web/hooks/useLightning.ts
+++ b/apps/web/hooks/useLightning.ts
@@ -1,4 +1,4 @@
-import { SimplePool } from 'nostr-tools/pool';
+import pool from '@/lib/relayPool';
 import type { Filter } from 'nostr-tools/filter';
 import { useAuth } from './useAuth';
 import { getRelays } from '../lib/nostr';
@@ -18,7 +18,6 @@ interface Split {
 }
 
 export default function useLightning() {
-  const pool = new SimplePool();
   const { state } = useAuth();
 
   const payLn = async (lnaddr: string, sats: number, comment?: string) => {

--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { SimplePool } from 'nostr-tools/pool';
+import pool from '@/lib/relayPool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
 import { VideoCardProps } from '../components/VideoCard';
@@ -47,8 +47,7 @@ export interface SearchResults {
 export function useSearch(query: string): SearchResults {
   const [videos, setVideos] = useState<VideoCardProps[]>([]);
   const [creators, setCreators] = useState<CreatorResult[]>([]);
-  const poolRef = useRef<SimplePool>();
-  const subRef = useRef<{ close: () => void } | null>(null);
+    const subRef = useRef<{ close: () => void } | null>(null);
   const timerRef = useRef<NodeJS.Timeout>();
   const debounceRef = useRef<NodeJS.Timeout>();
 
@@ -63,8 +62,7 @@ export function useSearch(query: string): SearchResults {
       return;
     }
 
-    const pool = (poolRef.current ||= new SimplePool());
-    const relays = getRelays();
+      const relays = getRelays();
     const filters: Filter[] = [];
     const q = query.startsWith('@') || query.startsWith('#') ? query.slice(1) : query;
 

--- a/apps/web/hooks/useZapHistory.ts
+++ b/apps/web/hooks/useZapHistory.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
-import pool from './pool';
+import pool from '@/lib/relayPool';
 import { getRelays } from '@/lib/nostr';
 
 export interface ZapEvent {

--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -1,13 +1,10 @@
 'use client';
-import { SimplePool } from 'nostr-tools/pool';
 import { getPublicKey } from 'nostr-tools/pure';
 import relaysConfig from '../relays.json';
-
-let _pool: SimplePool | null = null;
+import pool from './relayPool';
 
 export function getPool() {
-  if (!_pool) _pool = new SimplePool();
-  return _pool;
+  return pool;
 }
 
 const LS_KEY = 'pd.auth.v1';

--- a/apps/web/lib/relayPool.ts
+++ b/apps/web/lib/relayPool.ts
@@ -1,0 +1,59 @@
+import { SimplePool } from 'nostr-tools/pool';
+import { normalizeURL } from 'nostr-tools/utils';
+
+/**
+ * Shared, reference-counted pool of relay connections.
+ * Ensures only one WebSocket per relay URL is created and
+ * closed when no longer referenced.
+ */
+class RelayPool extends SimplePool {
+  private refs: Map<string, number> = new Map();
+
+  async ensureRelay(url: string, params?: any) {
+    const norm = normalizeURL(url);
+    const relay = await super.ensureRelay(norm, params);
+    this.refs.set(norm, (this.refs.get(norm) ?? 0) + 1);
+    return relay;
+  }
+
+  private release(url: string) {
+    const norm = normalizeURL(url);
+    const count = this.refs.get(norm);
+    if (!count) return;
+    if (count <= 1) {
+      this.refs.delete(norm);
+      super.close([norm]);
+    } else {
+      this.refs.set(norm, count - 1);
+    }
+  }
+
+  async get(relayUrl: string): Promise<WebSocket> {
+    const relay = await this.ensureRelay(relayUrl);
+    // @ts-ignore accessing underlying websocket implementation
+    return (relay as any).ws as WebSocket;
+  }
+
+  async onMessage(relayUrl: string, handler: (ev: MessageEvent) => void) {
+    const ws = await this.get(relayUrl);
+    ws.addEventListener('message', handler);
+    return () => {
+      ws.removeEventListener('message', handler);
+      this.release(relayUrl);
+    };
+  }
+
+  close(relays: string[]) {
+    relays.forEach((url) => this.release(url));
+  }
+}
+
+const pool = new RelayPool();
+
+export const get = (relayUrl: string) => pool.get(relayUrl);
+export const onMessage = (
+  relayUrl: string,
+  handler: (ev: MessageEvent) => void,
+) => pool.onMessage(relayUrl, handler);
+
+export default pool;

--- a/apps/web/lib/signers/nip46.ts
+++ b/apps/web/lib/signers/nip46.ts
@@ -1,9 +1,9 @@
-import { SimplePool } from 'nostr-tools/pool';
 import { generateSecretKey, getPublicKey, type EventTemplate } from 'nostr-tools/pure';
 import * as nip04 from 'nostr-tools/nip04';
 import { Relay } from 'nostr-tools/relay';
 import type { Signer } from './types';
 import { getRelays } from '@/lib/nostr';
+import pool from '@/lib/relayPool';
 
 type Nip46Session = {
   remotePubkey: string;
@@ -14,7 +14,7 @@ type Nip46Session = {
 export class Nip46Signer implements Signer {
   type: Signer['type'] = 'nip46';
   private session: Nip46Session;
-  private pool = new SimplePool();
+    private pool = pool;
 
   constructor(session: Nip46Session) {
     this.session = session;

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
-import { SimplePool } from 'nostr-tools/pool';
+import { useEffect, useState } from 'react';
+import pool from '@/lib/relayPool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
 import { toast } from 'react-hot-toast';
@@ -15,7 +15,6 @@ import { getRelays } from '@/lib/nostr';
 export default function ProfilePage() {
   const router = useRouter();
   const { pubkey } = router.query as { pubkey?: string };
-  const poolRef = useRef<SimplePool>();
   const { state } = useAuth();
   const [name, setName] = useState('');
   const [picture, setPicture] = useState('');
@@ -39,7 +38,6 @@ export default function ProfilePage() {
 
   useEffect(() => {
     if (!pubkey) return;
-    const pool = (poolRef.current ||= new SimplePool());
     const relays = getRelays();
 
     const metaSub = pool.subscribeMany(
@@ -145,7 +143,6 @@ export default function ProfilePage() {
         pubkey: state.pubkey,
       };
       const signed = await state.signer.signEvent(event);
-      const pool = (poolRef.current ||= new SimplePool());
       await pool.publish(getRelays(), signed);
       toast.success('Revenue share updated');
     } catch (err) {

--- a/apps/web/pages/treasury.tsx
+++ b/apps/web/pages/treasury.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
-import { SimplePool } from 'nostr-tools/pool';
+import { useEffect, useState } from 'react';
+import pool from '@/lib/relayPool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
 import { getRelays } from '@/lib/nostr';
@@ -7,7 +7,6 @@ import { getRelays } from '@/lib/nostr';
 export default function TreasuryPage() {
   const [authorised, setAuthorised] = useState(false);
   const [total, setTotal] = useState(0);
-  const poolRef = useRef<SimplePool>();
 
   useEffect(() => {
     let sub: { close: () => void } | undefined;
@@ -20,8 +19,7 @@ export default function TreasuryPage() {
       const pk = await nostr.getPublicKey();
       if (pk !== admin) return;
       setAuthorised(true);
-      const pool = (poolRef.current ||= new SimplePool());
-      const since = Math.floor(new Date().setHours(0, 0, 0, 0) / 1000);
+        const since = Math.floor(new Date().setHours(0, 0, 0, 0) / 1000);
       sub = pool.subscribeMany(getRelays(), [{ kinds: [9736], since } as Filter], {
         onevent: (ev: NostrEvent) => {
           try {

--- a/apps/web/pages/v/[eventId].tsx
+++ b/apps/web/pages/v/[eventId].tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { SimplePool } from 'nostr-tools/pool';
+import pool from '@/lib/relayPool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import VideoCard, { VideoCardProps } from '../../components/VideoCard';
 import { getRelays } from '@/lib/nostr';
@@ -13,9 +13,8 @@ export default function VideoPage() {
   useEffect(() => {
     if (!eventId) return;
     document.body.style.overflow = 'hidden';
-    const pool = new SimplePool();
-    const relays = getRelays();
-    pool.get(relays, { ids: [eventId] }).then((ev: NostrEvent | null) => {
+      const relays = getRelays();
+      pool.get(relays, { ids: [eventId] }).then((ev: NostrEvent | null) => {
       if (!ev) return;
       const videoTag = ev.tags.find((t) => t[0] === 'v');
       if (!videoTag) return;

--- a/packages/mod-dashboard/pages/index.tsx
+++ b/packages/mod-dashboard/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
-import { SimplePool } from 'nostr-tools/pool';
+import pool from '../../apps/web/lib/relayPool';
 import { getRelays } from '../../apps/web/lib/nostr';
 
 const ADMIN_PUBKEYS = (process.env.ADMIN_PUBKEYS || '').split(',').filter(Boolean);
@@ -55,8 +55,7 @@ export default function Dashboard({ allowed }: Props) {
     const hide = { targetId: id, moderator, reason: 'removed', ts };
     const event = { kind: 9001, created_at: ts, content: JSON.stringify(hide) };
     const signed = await nostr.signEvent(event);
-    const pool: any = new SimplePool();
-    const relays = getRelays();
+      const relays = getRelays();
     try {
       await pool.publish(relays, signed);
       await approve(id);


### PR DESCRIPTION
## Summary
- add reference-counted RelayPool to reuse relay connections
- switch SimplePool usages to shared RelayPool

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6897081992508331b0ef040b4237a05e