### PR TITLE
Fix mod-dashboard build import resolution

### DIFF
--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -1,6 +1,7 @@
 'use client';
 import { SimplePool } from 'nostr-tools/pool';
 import { getPublicKey } from 'nostr-tools/pure';
+import { hexToBytes } from 'nostr-tools/utils';
 import relaysConfig from '../relays.json';
 
 let _pool: SimplePool | null = null;
@@ -32,7 +33,7 @@ export function getMyPubkey(): string | undefined {
   const sk = getMyPrivkey();
   if (!sk) return undefined;
   try {
-    return getPublicKey(sk);
+    return getPublicKey(hexToBytes(sk));
   } catch {
     return undefined;
   }

--- a/packages/mod-dashboard/next.config.js
+++ b/packages/mod-dashboard/next.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   reactStrictMode: true,
+  experimental: {
+    externalDir: true,
+  },
 };

--- a/packages/mod-dashboard/pages/index.tsx
+++ b/packages/mod-dashboard/pages/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { SimplePool } from 'nostr-tools/pool';
-import { getRelays } from '../../apps/web/lib/nostr';
+import { getRelays } from '../../../apps/web/lib/nostr';
 
 const ADMIN_PUBKEYS = (process.env.ADMIN_PUBKEYS || '').split(',').filter(Boolean);
 

--- a/packages/mod-dashboard/tsconfig.json
+++ b/packages/mod-dashboard/tsconfig.json
@@ -1,5 +1,16 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "incremental": true,
+    "jsx": "preserve"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- adjust mod-dashboard config to resolve external TypeScript modules
- fix nostr helper to convert secret keys to bytes before deriving pubkey
- update mod-dashboard dashboard page to pull relays from shared util

## Testing
- `pnpm --filter @paiduan/mod-dashboard build` *(fails: Failed to patch lockfile, fetch failed ENETUNREACH)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689709d2160c83318ecc55c20ed97e11