### PR TITLE
Add FFmpeg logging, progress, and WebCodecs fallback

### DIFF
--- a/apps/web/utils/ffmpegLoader.ts
+++ b/apps/web/utils/ffmpegLoader.ts
@@ -8,17 +8,14 @@ const createFFmpegFn: any =
   (ffmpegModule as any).default;
 
 if (typeof createFFmpegFn !== 'function') {
-  throw new Error(
-    '@ffmpeg/ffmpeg does not provide a `createFFmpeg` export or default export',
-  );
+  throw new Error('@ffmpeg/ffmpeg does not provide a `createFFmpeg` export or default export');
 }
 
 let ffmpeg: FFmpeg | null = null;
 let loading: Promise<void> | null = null;
 
 export interface GetFFmpegOptions {
-  logger?: Parameters<FFmpeg['setLogger']>[0];
-  progress?: Parameters<FFmpeg['setProgress']>[0];
+  onProgress?: (progress: number) => void;
 }
 
 export async function getFFmpeg(opts: GetFFmpegOptions = {}): Promise<FFmpeg> {
@@ -29,9 +26,8 @@ export async function getFFmpeg(opts: GetFFmpegOptions = {}): Promise<FFmpeg> {
     });
     loading = ffmpeg.load();
   }
-  if (opts.logger) ffmpeg.setLogger(opts.logger);
-  if (opts.progress) ffmpeg.setProgress(opts.progress);
+  ffmpeg.setLogger(({ type, message }) => console.debug('[ffmpeg]', type, message));
+  ffmpeg.setProgress(({ ratio }) => opts.onProgress?.(ratio ?? 0));
   if (loading) await loading;
   return ffmpeg;
 }
-

--- a/apps/web/utils/trimVideoFfmpeg.ts
+++ b/apps/web/utils/trimVideoFfmpeg.ts
@@ -21,7 +21,7 @@ export async function trimVideoFfmpeg(blob: Blob, opts: TrimFfmpegOptions): Prom
     throw new Error('trimVideoFfmpeg can only run in the browser');
   }
   const ffmpeg = await getFFmpeg({
-    progress: ({ ratio }) => {
+    onProgress: (ratio) => {
       opts.onProgress?.(ratio);
     },
   });


### PR DESCRIPTION
## Summary
- add default FFmpeg logger and progress forwarding via `getFFmpeg`
- update video trimming and form logic to wrap FFmpeg in try/catch and fall back to WebCodecs
- adjust tests to mock FFmpeg trimming behavior

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*
- `pnpm test apps/web/pages/api/event.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897095b5df08331ba0f099dea884558