### PR TITLE
feat: add subscription registry

### DIFF
--- a/apps/web/hooks/useFollowers.ts
+++ b/apps/web/hooks/useFollowers.ts
@@ -2,16 +2,14 @@
 import { useEffect, useState } from 'react';
 import * as nostrKinds from 'nostr-tools/kinds';
 import type { Filter } from 'nostr-tools/filter';
-import { getPool, getRelays } from '@/lib/nostr';
+import { register } from '@/lib/subRegistry';
 
 export function useFollowers(pubkey?: string) {
   const [followers, setFollowers] = useState<string[]>([]);
   useEffect(() => {
     if (!pubkey) return;
-    const pool = getPool();
     const seen = new Set<string>();
-    const sub = pool.subscribeMany(
-      getRelays(),
+    const sub = register(
       [{ kinds: [nostrKinds.Contacts], '#p': [pubkey] } as Filter],
       {
         onevent: (ev) => {

--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import pool from '@/lib/relayPool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Filter } from 'nostr-tools/filter';
 import { VideoCardProps } from '../components/VideoCard';
-import { getRelays } from '@/lib/nostr';
+import { register } from '@/lib/subRegistry';
 
 function parseImeta(tags: string[][]) {
   let videoUrl: string | undefined;
@@ -62,7 +61,6 @@ export function useSearch(query: string): SearchResults {
       return;
     }
 
-      const relays = getRelays();
     const filters: Filter[] = [];
     const q = query.startsWith('@') || query.startsWith('#') ? query.slice(1) : query;
 
@@ -82,7 +80,7 @@ export function useSearch(query: string): SearchResults {
     const nextCreators: CreatorResult[] = [];
 
     debounceRef.current = setTimeout(() => {
-      const sub = pool.subscribeMany(relays, filters, {
+      const sub = register(filters, {
         onevent: (ev: NostrEvent) => {
           if (ev.kind === 21 || ev.kind === 22) {
             const { videoUrl, manifestUrl, posterUrl } = parseImeta(ev.tags);

--- a/apps/web/lib/subRegistry.ts
+++ b/apps/web/lib/subRegistry.ts
@@ -1,0 +1,101 @@
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+import type { Filter } from 'nostr-tools/filter';
+
+import { getRelays } from './nostr';
+import pool from './relayPool';
+
+type Handler = {
+  onevent?: (ev: NostrEvent) => void;
+  oneose?: () => void;
+};
+
+function normalizeFilter(filter: Filter): Filter {
+  const out: Filter = {};
+
+  Object.entries(filter).forEach(([k, v]) => {
+    if (v === undefined || v === null) return;
+    if (Array.isArray(v)) {
+      // sort arrays for stable key generation
+      (out as any)[k] = [...v].sort();
+    } else {
+      (out as any)[k] = v;
+    }
+  });
+
+  if (out.limit !== undefined) {
+    const l = out.limit;
+    // clamp limit between 1 and 500
+    out.limit = Math.max(1, Math.min(l, 500));
+  }
+
+  if (out.since !== undefined) {
+    const s = out.since;
+    // don't allow negative since values
+    out.since = Math.max(0, s);
+  }
+
+  return out;
+}
+
+function keyFor(filter: Filter, relays: string[]): string {
+  return JSON.stringify({
+    filter,
+    relays: [...relays].sort(),
+  });
+}
+
+class SubRegistry {
+  private subs = new Map<
+    string,
+    { sub: { close: () => void }; handlers: Set<Handler> }
+  >();
+
+  register(filters: Filter[], handler: Handler) {
+    const relays = getRelays();
+    const unsubs: (() => void)[] = [];
+
+    for (const f of filters) {
+      const norm = normalizeFilter(f);
+      const key = keyFor(norm, relays);
+      let entry = this.subs.get(key);
+      if (!entry) {
+        const handlers = new Set<Handler>();
+        const sub = pool.subscribeMany(relays, [norm], {
+          onevent: (ev: NostrEvent) => {
+            handlers.forEach((h) => h.onevent?.(ev));
+          },
+          oneose: () => {
+            handlers.forEach((h) => h.oneose?.());
+            sub.close();
+            this.subs.delete(key);
+          },
+        });
+        entry = { sub, handlers };
+        this.subs.set(key, entry);
+      }
+
+      entry.handlers.add(handler);
+
+      unsubs.push(() => {
+        entry?.handlers.delete(handler);
+        if (entry && entry.handlers.size === 0) {
+          entry.sub.close();
+          this.subs.delete(key);
+        }
+      });
+    }
+
+    return {
+      close: () => unsubs.forEach((fn) => fn()),
+    };
+  }
+}
+
+const registry = new SubRegistry();
+
+export function register(filters: Filter[], handler: Handler) {
+  return registry.register(filters, handler);
+}
+
+export default registry;
+


### PR DESCRIPTION
## Summary
- add registry to normalize nostr filters, clamp bounds, and dedupe subscriptions
- hook up feed, follower, and search hooks to use the shared registry

## Testing
- `pnpm test` *(fails: ERR_WORKER_OUT_OF_MEMORY)*

------
https://chatgpt.com/codex/tasks/task_e_68970b12991c83318f8790a2a21a2d74