### PR TITLE
Close historical subscriptions after EOSE

### DIFF
--- a/apps/web/hooks/useFollowing.ts
+++ b/apps/web/hooks/useFollowing.ts
@@ -24,6 +24,7 @@ export function useFollowing(pubkey?: string) {
             .map((t: any) => t[1]);
           setFollowing(Array.from(new Set(contacts)));
         },
+        oneose: () => sub.close(),
       },
     );
     return () => sub.close();

--- a/apps/web/hooks/useSearch.ts
+++ b/apps/web/hooks/useSearch.ts
@@ -46,13 +46,11 @@ export interface SearchResults {
 export function useSearch(query: string): SearchResults {
   const [videos, setVideos] = useState<VideoCardProps[]>([]);
   const [creators, setCreators] = useState<CreatorResult[]>([]);
-    const subRef = useRef<{ close: () => void } | null>(null);
-  const timerRef = useRef<NodeJS.Timeout>();
+  const subRef = useRef<{ close: () => void } | null>(null);
   const debounceRef = useRef<NodeJS.Timeout>();
 
   useEffect(() => {
     subRef.current?.close();
-    if (timerRef.current) clearTimeout(timerRef.current);
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     if (!query) {
@@ -115,14 +113,11 @@ export function useSearch(query: string): SearchResults {
           }
         },
       });
-
-      timerRef.current = setTimeout(() => sub.close(), 20000);
       subRef.current = sub;
     }, 300);
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      if (timerRef.current) clearTimeout(timerRef.current);
       subRef.current?.close();
     };
   }, [query]);

--- a/apps/web/hooks/useZapHistory.ts
+++ b/apps/web/hooks/useZapHistory.ts
@@ -49,6 +49,7 @@ export default function useZapHistory(): ZapHistory {
               return next;
             });
           },
+          oneose: () => sub?.close(),
         });
       } catch {
         /* ignore */

--- a/apps/web/pages/p/[pubkey]/index.tsx
+++ b/apps/web/pages/p/[pubkey]/index.tsx
@@ -61,6 +61,7 @@ export default function ProfilePage() {
             /* ignore */
           }
         },
+        oneose: () => metaSub.close(),
       },
     );
 
@@ -89,6 +90,7 @@ export default function ProfilePage() {
           });
           setVideos([...nextVideos]);
         },
+        oneose: () => videoSub.close(),
       },
     );
 


### PR DESCRIPTION
## Summary
- stop polling search results after 20s; rely on relay EOSE to close the subscription
- close transient subscriptions like zap history, following lists, and profiles when EOSE is received
- close profile page's metadata/video subscriptions on EOSE to avoid lingering connections

## Testing
- `pnpm test apps/web/hooks/useFollowing.test.tsx`
- `pnpm test apps/web/components/settings/__tests__/LightningHistory.test.tsx`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68970d818c848331ac902e2de953273c