### PR TITLE
fix: correct relay pool import

### DIFF
--- a/apps/web/hooks/useNotifications.tsx
+++ b/apps/web/hooks/useNotifications.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
-import pool from './pool';
+import pool from '@/lib/relayPool';
 import { toast } from 'react-hot-toast';
 import { getRelays } from '@/lib/nostr';
 


### PR DESCRIPTION
## Summary
- fix Notifications hook to import shared relay pool correctly

## Testing
- `pnpm --filter @paiduan/web build` *(fails: createFFmpeg missing and conflicting static paths)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68970ea0e2b0833181077332ae6723d7