### PR TITLE
Fix duplicate locale static paths

### DIFF
--- a/apps/web/pages/[locale]/create.tsx
+++ b/apps/web/pages/[locale]/create.tsx
@@ -1,9 +1,9 @@
-import { locales } from '../../utils/locales';
+import { otherLocales } from '../../utils/locales';
 export { default } from '../create';
 
 export function getStaticPaths() {
   return {
-    paths: locales.map((locale) => ({ params: { locale } })),
+    paths: otherLocales.map((locale) => ({ params: { locale } })),
     fallback: false,
   };
 }

--- a/apps/web/pages/[locale]/feed.tsx
+++ b/apps/web/pages/[locale]/feed.tsx
@@ -1,9 +1,9 @@
-import { locales } from '../../utils/locales';
+import { otherLocales } from '../../utils/locales';
 export { default } from '../feed';
 
 export function getStaticPaths() {
   return {
-    paths: locales.map((locale) => ({ params: { locale } })),
+    paths: otherLocales.map((locale) => ({ params: { locale } })),
     fallback: false,
   };
 }

--- a/apps/web/pages/[locale]/index.tsx
+++ b/apps/web/pages/[locale]/index.tsx
@@ -1,9 +1,9 @@
-import { locales } from '../../utils/locales';
+import { otherLocales } from '../../utils/locales';
 export { default } from '../index';
 
 export function getStaticPaths() {
   return {
-    paths: locales.map((locale) => ({ params: { locale } })),
+    paths: otherLocales.map((locale) => ({ params: { locale } })),
     fallback: false,
   };
 }

--- a/apps/web/pages/[locale]/offline.tsx
+++ b/apps/web/pages/[locale]/offline.tsx
@@ -1,9 +1,9 @@
-import { locales } from '../../utils/locales';
+import { otherLocales } from '../../utils/locales';
 export { default } from '../offline';
 
 export function getStaticPaths() {
   return {
-    paths: locales.map((locale) => ({ params: { locale } })),
+    paths: otherLocales.map((locale) => ({ params: { locale } })),
     fallback: false,
   };
 }

--- a/apps/web/pages/[locale]/profile.tsx
+++ b/apps/web/pages/[locale]/profile.tsx
@@ -1,9 +1,9 @@
-import { locales } from '../../utils/locales';
+import { otherLocales } from '../../utils/locales';
 export { default } from '../profile';
 
 export function getStaticPaths() {
   return {
-    paths: locales.map((locale) => ({ params: { locale } })),
+    paths: otherLocales.map((locale) => ({ params: { locale } })),
     fallback: false,
   };
 }

--- a/apps/web/pages/[locale]/settings.tsx
+++ b/apps/web/pages/[locale]/settings.tsx
@@ -1,9 +1,9 @@
-import { locales } from '../../utils/locales';
+import { otherLocales } from '../../utils/locales';
 export { default } from '../settings';
 
 export function getStaticPaths() {
   return {
-    paths: locales.map((locale) => ({ params: { locale } })),
+    paths: otherLocales.map((locale) => ({ params: { locale } })),
     fallback: false,
   };
 }

--- a/apps/web/utils/locales.ts
+++ b/apps/web/utils/locales.ts
@@ -1,2 +1,3 @@
 export const locales = ['en', 'zh', 'ar'] as const;
 export type Locale = typeof locales[number];
+export const otherLocales = locales.filter((locale) => locale !== 'en');


### PR DESCRIPTION
## Summary
- exclude English from locale list used for `[locale]` static paths
- update localized pages to use the filtered list

## Testing
- `pnpm --filter @paiduan/web run build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689713caa86c83319387a487929db9fa