### PR TITLE
feat: validate video codec and restrict file types

### DIFF
--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -16,8 +16,8 @@ vi.mock('../../utils/trimVideoFfmpeg', () => ({
 vi.mock('../../utils/trimVideoWebCodecs', () => ({
   trimVideoWebCodecs: vi.fn(() => null),
 }));
-vi.mock('../../utils/codec', () => ({ sniffCodec: () => Promise.resolve(null) }));
-vi.mock('../../utils/canDecode', () => ({ canDecode: () => Promise.resolve(false) }));
+vi.mock('../../utils/codec', () => ({ sniffCodec: () => Promise.resolve('hvc1') }));
+vi.mock('../../utils/canDecode', () => ({ canDecode: () => Promise.resolve(true) }));
 
 const mockSignEvent = vi.fn(() => Promise.resolve({}));
 vi.mock('../../hooks/useAuth', () => ({

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -131,9 +131,13 @@ export default function CreateVideoForm() {
         video.remove();
 
         const codec = await sniffCodec(f);
-        const supported = codec ? await canDecode(codec) : false;
+        const supported = codec && codec !== 'hvc1' ? await canDecode(codec) : false;
         if (!supported) {
-          setErr('Unsupported codec; converting with FFmpeg.');
+          setErr(
+            codec === 'hvc1'
+              ? 'HEVC/H.265 detected; converting with FFmpeg.'
+              : 'Unsupported codec; converting with FFmpeg.',
+          );
           try {
             const blob = await trimVideoFfmpeg(f, {
               start: 0,
@@ -488,7 +492,7 @@ export default function CreateVideoForm() {
         <div className="space-y-4">
           <input
             type="file"
-            accept="video/*"
+            accept="video/webm,video/mp4,video/mov,video/ogg"
             onChange={onPick}
             className="block w-full text-sm rounded-md border border-border bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
           />


### PR DESCRIPTION
## Summary
- restrict uploaded videos to common formats only
- warn and transcode HEVC/H.265 uploads via FFmpeg

## Testing
- `pnpm test` *(fails: Vitest caught 1 unhandled error during the test run)*

------
https://chatgpt.com/codex/tasks/task_e_6897134ded5883319c187d248ccb8c06