### PR TITLE
Fetch NIP-11 relay info and enforce rate limits

### DIFF
--- a/apps/web/lib/relayPool.test.ts
+++ b/apps/web/lib/relayPool.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('nostr-tools/pool', () => {
+  class SimplePoolMock {
+    relays = new Map<string, any>();
+    ensureRelay(url: string) {
+      let relay = this.relays.get(url);
+      if (!relay) {
+        relay = {
+          rawSend: vi.fn(async () => {}),
+          send(message: string) {
+            return this.rawSend(message);
+          },
+          prepareSubscription: vi.fn(() => ({
+            fire: () => relay.send('REQ'),
+            close: vi.fn(),
+          })),
+          subscribe(this: any, filters: any[], params?: any) {
+            const sub = this.prepareSubscription(filters, params);
+            sub.fire();
+            return sub;
+          },
+        };
+        this.relays.set(url, relay);
+      }
+      return relay;
+    }
+    close() {}
+    subscribeMany(relays: string[], filters: any[], params?: any) {
+      relays.forEach((url) => {
+        this.ensureRelay(url).then((relay) => {
+          filters.forEach((f) => relay.subscribe([f], params));
+        });
+      });
+      return { close: vi.fn() } as any;
+    }
+  }
+  return { SimplePool: SimplePoolMock };
+});
+
+import { RelayPool } from '@/lib/relayPool';
+
+const info = {
+  supported_nips: [1],
+  limitation: { max_message_rate: 1, max_subscriptions: 1 },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // @ts-ignore
+  global.fetch = vi.fn(async () => ({ ok: true, json: async () => info }));
+});
+
+describe('RelayPool', () => {
+  it('fetches nip11 info only once', async () => {
+    const pool = new RelayPool();
+    await pool.ensureRelay('wss://relay.example');
+    await pool.ensureRelay('wss://relay.example');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces max subscriptions', async () => {
+    const pool = new RelayPool();
+    const relay: any = await pool.ensureRelay('wss://relay.example');
+    const sub1 = relay.prepareSubscription([], {});
+    sub1.fire();
+    await Promise.resolve();
+    const sub2 = relay.prepareSubscription([], {});
+    sub2.fire();
+    await Promise.resolve();
+    expect(relay.rawSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('throttles messages by rate limit', async () => {
+    vi.useFakeTimers();
+    const pool = new RelayPool();
+    const relay: any = await pool.ensureRelay('wss://relay.example');
+    const p1 = relay.send('one');
+    await p1;
+    expect(relay.rawSend).toHaveBeenCalledTimes(1);
+    const p2 = relay.send('two');
+    expect(relay.rawSend).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1000);
+    await p2;
+    expect(relay.rawSend).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/lib/relayPool.ts
+++ b/apps/web/lib/relayPool.ts
@@ -11,8 +11,24 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  * Ensures only one WebSocket per relay URL is created and
  * closed when no longer referenced.
  */
-class RelayPool extends SimplePool {
+export class RelayPool extends SimplePool {
   private refs: Map<string, number> = new Map();
+  private infos: Map<string, any> = new Map();
+  private subCounts: Map<string, number> = new Map();
+  private rateState: Map<string, { count: number; reset: number }> = new Map();
+
+  private async fetchInfo(url: string) {
+    try {
+      const httpUrl = url.replace(/^ws(s)?:\/\//, 'http$1://');
+      const res = await fetch(httpUrl, {
+        headers: { Accept: 'application/nostr+json' },
+      });
+      if (!res.ok) return {};
+      return await res.json();
+    } catch {
+      return {};
+    }
+  }
 
   private async connectWithRetry(url: string, params?: any) {
     let attempt = 0;
@@ -32,9 +48,57 @@ class RelayPool extends SimplePool {
     }
   }
 
+  private async rateLimit(url: string) {
+    const info = this.infos.get(url);
+    const max = info?.limitation?.max_message_rate;
+    if (!max) return;
+    const now = Date.now();
+    let state = this.rateState.get(url);
+    if (!state || now > state.reset) {
+      state = { count: 0, reset: now + 1000 };
+    }
+    if (state.count >= max) {
+      await sleep(state.reset - now);
+      state = { count: 0, reset: Date.now() + 1000 };
+    }
+    state.count += 1;
+    this.rateState.set(url, state);
+  }
+
   async ensureRelay(url: string, params?: any) {
     const norm = normalizeURL(url);
     const relay = await this.connectWithRetry(norm, params);
+
+    if (!this.infos.has(norm)) {
+      const info = await this.fetchInfo(norm);
+      this.infos.set(norm, info);
+      this.subCounts.set(norm, 0);
+
+      const origSend = relay.send.bind(relay);
+      relay.send = async (msg: string) => {
+        await this.rateLimit(norm);
+        return origSend(msg);
+      };
+
+      const origPrepare = relay.prepareSubscription.bind(relay);
+      relay.prepareSubscription = (filters: any, params?: any) => {
+        const maxSubs = this.infos.get(norm)?.limitation?.max_subscriptions;
+        const curr = this.subCounts.get(norm) ?? 0;
+        if (maxSubs !== undefined && curr >= maxSubs) {
+          return { fire: () => {}, close: () => {} } as any;
+        }
+        const sub = origPrepare(filters, params);
+        this.subCounts.set(norm, curr + 1);
+        const origClose = sub.close.bind(sub);
+        sub.close = (reason?: string) => {
+          origClose(reason);
+          const c = this.subCounts.get(norm) ?? 1;
+          this.subCounts.set(norm, Math.max(0, c - 1));
+        };
+        return sub;
+      };
+    }
+
     this.refs.set(norm, (this.refs.get(norm) ?? 0) + 1);
     return relay;
   }


### PR DESCRIPTION
## Summary
- fetch relay NIP-11 metadata on first connect and cache supported nips and limits
- throttle outbound messages and cap subscriptions per relay based on NIP-11
- add unit tests covering relay info caching, subscription limits and rate limiting

## Testing
- `pnpm vitest run apps/web/lib/relayPool.test.ts`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897135cad44833199e80107bac8e56d