### PR TITLE
fix: provide react query client in app router

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -3,12 +3,16 @@
 import { ThemeProvider } from '@/context/themeContext';
 import { ModqueueProvider } from '@/context/modqueueContext';
 import { GestureProvider } from '@paiduan/ui';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@/lib/queryClient';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider>
       <GestureProvider>
-        <ModqueueProvider>{children}</ModqueueProvider>
+        <ModqueueProvider>
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        </ModqueueProvider>
       </GestureProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary
- wrap app router providers with React Query's QueryClientProvider to avoid missing client errors during pre-rendering

## Testing
- `pnpm test apps/web/pages/api/event.test.ts`
- `pnpm --filter @paiduan/web build`


------
https://chatgpt.com/codex/tasks/task_e_689715b166988331a93ab133f9514a7a