### PR TITLE
feat(web): make cross-origin isolation configurable

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -18,4 +18,6 @@ The **Publish** button remains disabled until a converted video is available and
 
 ## Cross-origin headers
 
-The application sends `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on all routes. These headers enable cross-origin isolation, which is required for future multi-threaded FFmpeg builds in the browser.
+By default, the application sends `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on all routes. These headers enable cross-origin isolation, which is required for future multi-threaded FFmpeg builds in the browser.
+
+Set `ENABLE_ISOLATION=false` to disable these headers and allow loading third-party resources that do not provide COEP/CORP.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -3,6 +3,8 @@ import runtimeCaching from 'next-pwa/cache.js';
 
 const isProd = process.env.NODE_ENV === 'production';
 
+const enableIsolation = process.env.ENABLE_ISOLATION !== 'false';
+
 const baseConfig = {
   experimental: { esmExternals: 'loose' },
   reactStrictMode: true,
@@ -12,24 +14,29 @@ const baseConfig = {
     remotePatterns: [{ protocol: 'https', hostname: '**' }],
   },
   async headers() {
-    return [
-      {
+    const headers = [];
+
+    if (enableIsolation) {
+      headers.push({
         source: '/:path*',
         headers: [
           { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
           { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
         ],
-      },
-      {
-        source: '/(.*)\\.(png|jpg|jpeg|gif|svg|webp|webm)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
-          },
-        ],
-      },
-    ];
+      });
+    }
+
+    headers.push({
+      source: '/(.*)\\.(png|jpg|jpeg|gif|svg|webp|webm)',
+      headers: [
+        {
+          key: 'Cache-Control',
+          value: 'public, max-age=31536000, immutable',
+        },
+      ],
+    });
+
+    return headers;
   },
   async redirects() {
     return [


### PR DESCRIPTION
## Summary
- gate cross-origin isolation headers behind `ENABLE_ISOLATION`
- document how disabling the flag allows third-party resources without COEP/CORP headers

## Testing
- `pnpm test`
- `ENABLE_ISOLATION=false pnpm --filter web dev` + `curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_689718ac325c8331b1b6399d54487dcc