### PR TITLE
feat(web): use dexie for event cache

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,7 +43,8 @@
     "recharts": "^2.8.0",
     "tailwindcss-plugin-rtl": "^1.2.0",
     "web-push": "^3.6.0",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "dexie": "^4.0.11"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      dexie:
+        specifier: ^4.0.11
+        version: 4.0.11
       framer-motion:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -2702,6 +2705,9 @@ packages:
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
+
+  dexie@4.0.11:
+    resolution: {integrity: sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -7909,6 +7915,8 @@ snapshots:
 
   detect-libc@2.0.4:
     optional: true
+
+  dexie@4.0.11: {}
 
   didyoumean@1.2.2: {}
 


### PR DESCRIPTION
## Summary
- add dexie to web app dependencies
- replace custom indexedDB logic with Dexie subclass for events
- query and store events via Dexie APIs

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm --filter @paiduan/web test`


------
https://chatgpt.com/codex/tasks/task_e_68971d184d8c8331b1b726d6a15d700d