### PR TITLE
Avoid precache 404 during development

### DIFF
--- a/apps/web/hooks/useNotifications.tsx
+++ b/apps/web/hooks/useNotifications.tsx
@@ -57,6 +57,7 @@ function writeStorage(list: Notification[]) {
 
 export async function requestNotificationPermission() {
   if (typeof window === 'undefined') return;
+  if (process.env.NODE_ENV !== 'production') return;
   if (!('serviceWorker' in navigator)) return;
   try {
     const reg = await navigator.serviceWorker.register('/sw.js');

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -52,7 +52,7 @@ const baseConfig = {
 const withPWAConfig = withPWA({
   dest: 'public',
   runtimeCaching,
-  buildExcludes: [/middleware-manifest\.json$/],
+  buildExcludes: [/middleware-manifest\.json$/, /app-build-manifest\.json$/],
   fallbacks: {
     image: '/offline.jpg',
     document: '/offline.html',


### PR DESCRIPTION
## Summary
- skip service worker registration outside production to avoid missing _next assets
- exclude Next.js app build manifest from PWA precache list

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test` *(failed: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68972648d7ec8331a837666126470c38