### PR TITLE
fix: guard player play

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -170,7 +170,14 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       api.start({ opacity: 0 });
       setSeekPreview(0);
     }
-    player?.play();
+    if (player && typeof (player as any).play === 'function') {
+      player.play();
+    } else if (player && typeof (player as any).el === 'function') {
+      const videoEl = (player as any).el().querySelector('video');
+      if (videoEl && typeof (videoEl as any).play === 'function') {
+        (videoEl as HTMLVideoElement).play();
+      }
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- avoid `player.play is not a function` by checking for play method and falling back to underlying video element

## Testing
- `pnpm test` *(fails: ERR_WORKER_OUT_OF_MEMORY)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6897295435788331b394a39ceb3c6d57