### PR TITLE
fix: avoid precache 404 in service worker

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,7 +1,10 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.3.0/workbox-sw.js');
 
 self.addEventListener('install', () => {
-  workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+  const manifest = (self.__WB_MANIFEST || []).filter(
+    (entry) => !/app-build-manifest\.json$/.test(entry.url)
+  );
+  workbox.precaching.precacheAndRoute(manifest);
 });
 
 self.addEventListener('push', event => {


### PR DESCRIPTION
## Summary
- filter out `app-build-manifest.json` from service worker precache manifest

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68972930fc448331a4ddef51d803dfb2