### PR TITLE
fix: remove invalid attribute from accordion

### DIFF
--- a/apps/web/components/ui/Accordion.tsx
+++ b/apps/web/components/ui/Accordion.tsx
@@ -26,7 +26,7 @@ export function Accordion({ items, initialOpenIndex = null }: AccordionProps) {
       {items.map((item, index) => (
         <Disclosure key={index}>
           {() => (
-            <>
+            <div>
               <Disclosure.Button
                 onClick={() => setOpenIndex(openIndex === index ? null : index)}
                 className="flex w-full items-center justify-between py-2 text-left"
@@ -44,7 +44,7 @@ export function Accordion({ items, initialOpenIndex = null }: AccordionProps) {
               >
                 {item.content}
               </Disclosure.Panel>
-            </>
+            </div>
           )}
         </Disclosure>
       ))}


### PR DESCRIPTION
## Summary
- replace React Fragment wrapper with div in Accordion to prevent invalid prop warnings

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 4 unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_689730f214ac833186805d4efcdfe0ad