### PR TITLE
feat: add video extensions to upload

### DIFF
--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -280,15 +280,8 @@ export default function CreateVideoForm() {
   }
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    accept: {
-      'video/webm': [],
-      'video/mp4': [],
-      'video/quicktime': [],
-      'video/ogg': [],
-    },
-    onDrop: (accepted) => {
-      onPick(accepted[0] ?? null);
-    },
+    accept: { 'video/*': ['.mp4', '.webm', '.mov', '.ogg'] },
+    onDrop: (accepted) => onPick(accepted[0] ?? null),
   });
 
   const onSubmit = async (values: FormValues) => {

--- a/apps/web/components/create/UploadField.test.tsx
+++ b/apps/web/components/create/UploadField.test.tsx
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '../../lib/queryClient';
+import CreateVideoForm from './CreateVideoForm';
+
+// minimal mocks required by component
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({ state: { status: 'ready' } }),
+}));
+vi.mock('../../hooks/useProfile', () => ({ useProfile: () => ({}) }));
+vi.mock('../../hooks/useFollowing', () => ({ default: () => ({ following: [] }) }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ back: vi.fn() }) }));
+
+;(globalThis as any).React = React;
+
+
+describe('UploadField', () => {
+  it('accepts common video formats', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CreateVideoForm />
+        </QueryClientProvider>,
+      );
+    });
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    expect(fileInput.accept).toContain('.mp4');
+    expect(fileInput.accept).toContain('.webm');
+    expect(fileInput.accept).toContain('.mov');
+    expect(fileInput.accept).toContain('.ogg');
+  });
+});


### PR DESCRIPTION
## Summary
- allow selecting common video extensions in video upload form
- add test verifying upload accepts supported formats

## Testing
- `pnpm --filter @paiduan/web lint`
- `node_modules/.bin/vitest run apps/web/components/create/UploadField.test.tsx --config /tmp/vitest.config.ts`
- `pnpm test` *(fails: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68973293aef083318c2d749925584d60