### PR TITLE
feat: reconnect NDK when relays change

### DIFF
--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -12,6 +12,14 @@ export const ndk = new NDK({ explicitRelayUrls: getRelays() });
 // establish connections eagerly so hooks/components can use it immediately
 ndk.connect();
 
+// update relay connections when the list changes
+if (typeof window !== 'undefined') {
+  window.addEventListener('pd.relays', () => {
+    ndk.explicitRelayUrls = getRelays();
+    ndk.connect();
+  });
+}
+
 const LS_KEY = 'pd.auth.v1';
 
 function loadAuth(): any | undefined {


### PR DESCRIPTION
## Summary
- update NDK relay configuration when `pd.relays` event fires

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689734614a9c8331a7b4d4371f57d3ca