### PR TITLE
Fix video preview to reopen dropzone file dialog

### DIFF
--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -346,4 +346,40 @@ describe('CreateVideoForm', () => {
     const tags = mockSignEvent.mock.calls[0][0].tags;
     expect(tags).toContainEqual(['copyright', 'My License']);
   });
+
+  it('opens file dialog when clicking the preview', async () => {
+    (URL as any).createObjectURL = vi.fn(() => 'blob:mock');
+    mockTrim.mockImplementation((_f: any, opts: any) => {
+      opts.onProgress?.(1);
+      return Promise.resolve(new Blob());
+    });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CreateVideoForm />
+        </QueryClientProvider>,
+      );
+    });
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['x'], 'video.mp4', { type: 'video/mp4' });
+
+    await act(async () => {
+      Object.defineProperty(fileInput, 'files', { value: [file] });
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await Promise.resolve();
+
+    const clickSpy = vi.spyOn(fileInput, 'click');
+    const video = container.querySelector('video') as HTMLVideoElement;
+
+    await act(async () => {
+      video.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
 });

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -547,7 +547,7 @@ export default function CreateVideoForm() {
                 ref={videoRef}
                 controls
                 src={preview}
-                className="absolute inset-0 h-full w-full object-cover"
+                className="absolute inset-0 h-full w-full object-cover pointer-events-none"
               />
             ) : (
               <PlaceholderVideo className="absolute inset-0 h-full w-full object-cover" />


### PR DESCRIPTION
## Summary
- allow clicking the video preview to reopen the file picker by ignoring pointer events
- add a test ensuring the preview triggers the file dialog

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689735115a88833187fbed4d71599557