### PR TITLE
fix: load workbox script relatively

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,5 +1,7 @@
 try {
-  importScripts('/workbox-sw.js');
+  // Use a relative path so the service worker can locate the bundled
+  // Workbox script regardless of the deployment base path.
+  importScripts('./workbox-sw.js');
 } catch (err) {
   importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.3.0/workbox-sw.js');
 }


### PR DESCRIPTION
## Summary
- load local Workbox script using a relative path so service worker initializes correctly when deployed under a subpath

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test` *(fails: DataCloneError/ERR_WORKER_OUT_OF_MEMORY)*

------
https://chatgpt.com/codex/tasks/task_e_68973754a52c8331b7c11596b03ad36d