### PR TITLE
feat: offload ffmpeg trimming to worker threads

### DIFF
--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -12,6 +12,7 @@ import { queryClient } from '../../lib/queryClient';
 const mockTrim = vi.fn();
 vi.mock('../../utils/trimVideoFfmpeg', () => ({
   trimVideoFfmpeg: (...args: any[]) => mockTrim(...(args as any)),
+  terminateFfmpegPool: vi.fn(),
 }));
 vi.mock('../../utils/trimVideoWebCodecs', () => ({
   trimVideoWebCodecs: vi.fn(() => null),

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -4,7 +4,7 @@ import { useDropzone } from 'react-dropzone';
 import { useRouter } from 'next/navigation';
 import PlaceholderVideo from '../PlaceholderVideo';
 import { trimVideoWebCodecs } from '../../utils/trimVideoWebCodecs';
-import { trimVideoFfmpeg } from '../../utils/trimVideoFfmpeg';
+import { trimVideoFfmpeg, terminateFfmpegPool } from '../../utils/trimVideoFfmpeg';
 import { sniffCodec } from '../../utils/codec';
 import { canDecode } from '../../utils/canDecode';
 import { useAuth } from '../../hooks/useAuth';
@@ -143,6 +143,12 @@ export default function CreateVideoForm() {
       if (preview) URL.revokeObjectURL(preview);
     };
   }, [preview]);
+
+  useEffect(() => {
+    return () => {
+      terminateFfmpegPool();
+    };
+  }, []);
 
   async function onPick(f: File | null) {
     setFile(f);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
     "react-use-gesture": "^9.1.3",
     "recharts": "^2.8.0",
     "tailwindcss-plugin-rtl": "^1.2.0",
+    "threads": "^1.7.0",
     "video.js": "^8.23.4",
     "web-push": "^3.6.0",
     "zod": "^4.0.16",

--- a/apps/web/utils/ffmpegWorker.ts
+++ b/apps/web/utils/ffmpegWorker.ts
@@ -1,0 +1,76 @@
+import { expose } from 'threads/worker';
+import { getFFmpeg } from './ffmpegLoader';
+import type { TrimFfmpegOptions } from './trimVideoFfmpeg';
+
+function uniqueId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+async function trim(blob: Blob, opts: TrimFfmpegOptions): Promise<Blob> {
+  const ffmpeg = await getFFmpeg({
+    onProgress: (ratio) => {
+      opts.onProgress?.(ratio);
+    },
+  });
+  const { fetchFile } = await import('@ffmpeg/util');
+
+  const inFile = `in-${uniqueId()}`;
+  const outFile = `out-${uniqueId()}.webm`;
+
+  let data: Uint8Array;
+
+  try {
+    ffmpeg.FS('writeFile', inFile, await fetchFile(blob));
+
+    const args = ['-i', inFile, '-ss', `${opts.start}`];
+    if (opts.end != null) args.push('-to', `${opts.end}`);
+
+    const filters: string[] = [];
+    if (opts.crop) {
+      const { x, y, width, height } = opts.crop;
+      filters.push(`crop=${width}:${height}:${x}:${y}`);
+    }
+    if (opts.width || opts.height) {
+      const w = opts.width ?? -1;
+      const h = opts.height ?? -1;
+      filters.push(`scale=${w}:${h}`);
+    }
+    if (filters.length) {
+      args.push('-vf', filters.join(','));
+    }
+    args.push(
+      '-c:v',
+      'libvpx-vp9',
+      '-b:v',
+      '0',
+      '-crf',
+      '30',
+      '-c:a',
+      'libopus',
+      '-f',
+      'webm',
+      outFile,
+    );
+
+    await ffmpeg.run(...args);
+    opts.onProgress?.(1);
+    data = ffmpeg.FS('readFile', outFile);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`FFmpeg trim failed: ${message}`);
+  } finally {
+    try {
+      ffmpeg.FS('unlink', inFile);
+    } catch {}
+    try {
+      ffmpeg.FS('unlink', outFile);
+    } catch {}
+  }
+
+  return new Blob([data.buffer], { type: 'video/webm' });
+}
+
+expose({ trim });

--- a/apps/web/utils/trimVideoFfmpeg.ts
+++ b/apps/web/utils/trimVideoFfmpeg.ts
@@ -1,4 +1,4 @@
-import { getFFmpeg } from './ffmpegLoader';
+import { Pool, spawn, Worker, ModuleThread } from 'threads';
 
 export interface TrimFfmpegOptions {
   start: number;
@@ -9,76 +9,35 @@ export interface TrimFfmpegOptions {
   onProgress?: (progress: number) => void; // progress 0-1
 }
 
-function uniqueId() {
-  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
-    return crypto.randomUUID();
+type FfmpegWorker = typeof import('./ffmpegWorker');
+
+let pool: any;
+
+function getPool() {
+  if (!pool) {
+    pool = Pool<ModuleThread<FfmpegWorker>>(() =>
+      spawn(new Worker(new URL('./ffmpegWorker.ts', import.meta.url))),
+    ) as any;
+    pool.run = (name: keyof FfmpegWorker, ...args: any[]) =>
+      pool.queue((worker: any) => worker[name](...args));
   }
-  return Math.random().toString(36).slice(2);
+  return pool;
 }
 
-export async function trimVideoFfmpeg(blob: Blob, opts: TrimFfmpegOptions): Promise<Blob> {
+export async function trimVideoFfmpeg(
+  blob: Blob,
+  opts: TrimFfmpegOptions,
+): Promise<Blob> {
   if (typeof window === 'undefined') {
     throw new Error('trimVideoFfmpeg can only run in the browser');
   }
-  const ffmpeg = await getFFmpeg({
-    onProgress: (ratio) => {
-      opts.onProgress?.(ratio);
-    },
-  });
-  const { fetchFile } = await import('@ffmpeg/util');
+  return getPool().run('trim', blob, opts);
+}
 
-  const inFile = `in-${uniqueId()}`;
-  const outFile = `out-${uniqueId()}.webm`;
-
-  let data: Uint8Array;
-
-  try {
-    ffmpeg.FS('writeFile', inFile, await fetchFile(blob));
-
-    const args = ['-i', inFile, '-ss', `${opts.start}`];
-    if (opts.end != null) args.push('-to', `${opts.end}`);
-
-    const filters: string[] = [];
-    if (opts.crop) {
-      const { x, y, width, height } = opts.crop;
-      filters.push(`crop=${width}:${height}:${x}:${y}`);
-    }
-    if (opts.width || opts.height) {
-      const w = opts.width ?? -1;
-      const h = opts.height ?? -1;
-      filters.push(`scale=${w}:${h}`);
-    }
-    if (filters.length) {
-      args.push('-vf', filters.join(','));
-    }
-    args.push(
-      '-c:v',
-      'libvpx-vp9',
-      '-b:v',
-      '0',
-      '-crf',
-      '30',
-      '-c:a',
-      'libopus',
-      '-f',
-      'webm',
-      outFile,
-    );
-
-    await ffmpeg.run(...args);
-    opts.onProgress?.(1);
-    data = ffmpeg.FS('readFile', outFile);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`FFmpeg trim failed: ${message}`);
-  } finally {
-    try {
-      ffmpeg.FS('unlink', inFile);
-    } catch {}
-    try {
-      ffmpeg.FS('unlink', outFile);
-    } catch {}
+export function terminateFfmpegPool() {
+  if (pool) {
+    const p = pool;
+    pool = null;
+    return p.terminate();
   }
-
-  return new Blob([data.buffer], { type: 'video/webm' });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       tailwindcss-plugin-rtl:
         specifier: ^1.2.0
         version: 1.2.0
+      threads:
+        specifier: ^1.7.0
+        version: 1.7.0
       video.js:
         specifier: ^8.23.4
         version: 8.23.4
@@ -3381,6 +3384,10 @@ packages:
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
+
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3876,6 +3883,10 @@ packages:
   is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
+
+  is-observable@2.1.0:
+    resolution: {integrity: sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==}
+    engines: {node: '>=8'}
 
   is-path-cwd@2.2.0:
     resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
@@ -4425,6 +4436,9 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  observable-fns@0.6.1:
+    resolution: {integrity: sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -5293,12 +5307,18 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  threads@1.7.0:
+    resolution: {integrity: sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==}
+
   throttle-debounce@3.0.1:
     resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
     engines: {node: '>=10'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-worker@2.3.0:
+    resolution: {integrity: sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -9384,6 +9404,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm@3.2.25:
+    optional: true
+
   espree@9.6.1:
     dependencies:
       acorn: 8.15.0
@@ -9907,6 +9930,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@1.0.1: {}
+
+  is-observable@2.1.0: {}
 
   is-path-cwd@2.2.0: {}
 
@@ -10481,6 +10506,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  observable-fns@0.6.1: {}
 
   once@1.4.0:
     dependencies:
@@ -11441,9 +11468,25 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  threads@1.7.0:
+    dependencies:
+      callsites: 3.1.0
+      debug: 4.4.1
+      is-observable: 2.1.0
+      observable-fns: 0.6.1
+    optionalDependencies:
+      tiny-worker: 2.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   throttle-debounce@3.0.1: {}
 
   tiny-invariant@1.3.3: {}
+
+  tiny-worker@2.3.0:
+    dependencies:
+      esm: 3.2.25
+    optional: true
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary
- add threads.js to web app
- move ffmpeg trim logic to a worker and use a threads.js pool
- clean up workers when CreateVideoForm unmounts

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897b202b8148331a4c644d855b34fd5