### PR TITLE
feat: add layout context for responsive rendering

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,11 +1,14 @@
 import '../styles/globals.css';
 import Providers from './providers';
+import { LayoutProvider } from '@/context/LayoutContext';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <Providers>{children}</Providers>
+        <LayoutProvider>
+          <Providers>{children}</Providers>
+        </LayoutProvider>
       </body>
     </html>
   );

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 import BottomNav from './BottomNav';
+import { useLayout } from '@/context/LayoutContext';
 
 export default function AppShell({
   left,
@@ -11,20 +12,24 @@ export default function AppShell({
   center: React.ReactNode;
   right?: React.ReactNode;
 }) {
+  const layout = useLayout();
+  const isDesktop = layout === 'desktop';
   const hasRight = !!right;
+  const gridCols = isDesktop
+    ? hasRight
+      ? 'grid-cols-[300px_1fr_400px]'
+      : 'grid-cols-[300px_1fr]'
+    : 'grid-cols-1';
+
   return (
     <div className="min-h-screen bg-background-primary text-primary">
-      <div
-        className={`mx-auto w-full max-w-[1400px] bg-surface grid grid-cols-1 ${
-          hasRight
-            ? 'lg:grid-cols-[300px_1fr_400px]'
-            : 'lg:grid-cols-[300px_1fr]'
-        } gap-0`}
-      >
+      <div className={`mx-auto w-full max-w-[1400px] bg-surface grid ${gridCols} gap-0`}>
         {/* Left column: menu/search/profile summary (sticky on desktop) */}
-        <aside className="hidden lg:block border-r divider sticky top-0 h-screen overflow-y-auto">
-          <div className="p-4">{left}</div>
-        </aside>
+        {isDesktop && (
+          <aside className="border-r divider sticky top-0 h-screen overflow-y-auto">
+            <div className="p-4">{left}</div>
+          </aside>
+        )}
 
         {/* Middle column: main feed */}
         <main className="h-[100dvh] overflow-hidden">
@@ -32,13 +37,13 @@ export default function AppShell({
         </main>
 
         {/* Right column: author info & comments (sticky on desktop) */}
-        {hasRight && (
-          <aside className="sidebar-right hidden lg:block border-l divider sticky top-0 h-screen overflow-y-auto">
+        {hasRight && isDesktop && (
+          <aside className="sidebar-right border-l divider sticky top-0 h-screen overflow-y-auto">
             {right}
           </aside>
         )}
       </div>
-      <BottomNav />
+      {layout !== 'desktop' && <BottomNav />}
     </div>
   );
 }

--- a/apps/web/components/layout/BottomNav.tsx
+++ b/apps/web/components/layout/BottomNav.tsx
@@ -3,13 +3,16 @@
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import { navItems } from './nav';
+import { useLayout } from '@/context/LayoutContext';
 
 export default function BottomNav() {
   const router = useRouter();
   const pathname = usePathname();
+  const layout = useLayout();
+  if (layout === 'desktop') return null;
 
   return (
-    <nav className="fixed bottom-0 inset-x-0 flex justify-around border-t bg-surface lg:hidden">
+    <nav className="fixed bottom-0 inset-x-0 flex justify-around border-t bg-surface">
       {navItems.map(({ href, label, icon: Icon }) => {
         const active = pathname.startsWith(href);
         return (

--- a/apps/web/components/layout/MainNav.tsx
+++ b/apps/web/components/layout/MainNav.tsx
@@ -9,6 +9,7 @@ import { useRouter, usePathname, useSearchParams, useParams } from 'next/navigat
 import { cardStyle } from '@/components/ui/Card';
 import Logo from '@/components/branding/Logo';
 import { navItems } from './nav';
+import { useLayout } from '@/context/LayoutContext';
 
 interface MainNavProps {
   me?: {
@@ -34,6 +35,7 @@ export default function MainNav({
   const searchParams = useSearchParams();
   const params = useParams();
   const locale = (params?.locale as string) || undefined;
+  const layout = useLayout();
 
   return (
     <div className="p-[1.2rem] space-y-4">
@@ -42,10 +44,10 @@ export default function MainNav({
       </Link>
 
       {/* Search */}
-      {showSearch && <SearchBar showActions={false} />}
+      {showSearch && layout !== 'mobile' && <SearchBar showActions={false} />}
 
       {/* Profile mini card */}
-      {showProfile && <MiniProfileCard stats={me?.stats} />}
+      {showProfile && layout === 'desktop' && <MiniProfileCard stats={me?.stats} />}
 
       {/* Nav */}
       <nav className={`${cardStyle} p-2`}>

--- a/apps/web/context/LayoutContext.tsx
+++ b/apps/web/context/LayoutContext.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+export type LayoutType = 'desktop' | 'tablet' | 'mobile';
+
+function getLayout(width: number): LayoutType {
+  if (width >= 1024) return 'desktop';
+  if (width >= 640) return 'tablet';
+  return 'mobile';
+}
+
+const LayoutContext = createContext<LayoutType>('desktop');
+
+export function LayoutProvider({ children }: { children: React.ReactNode }) {
+  const [layout, setLayout] = useState<LayoutType>(() => {
+    if (typeof window === 'undefined') return 'desktop';
+    return getLayout(window.innerWidth);
+  });
+
+  useEffect(() => {
+    const update = () => setLayout(getLayout(window.innerWidth));
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  return <LayoutContext.Provider value={layout}>{children}</LayoutContext.Provider>;
+}
+
+export function useLayout() {
+  return useContext(LayoutContext);
+}
+


### PR DESCRIPTION
## Summary
- add LayoutProvider and useLayout hook to track desktop/tablet/mobile
- wrap app layout with LayoutProvider and switch components based on layout
- replace Tailwind breakpoints in AppShell, MainNav, and BottomNav with useLayout

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest caught unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897bab6762083319cd6744a2e5e6274