### PR TITLE
feat: add overlay system

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -5,13 +5,17 @@ import { ModqueueProvider } from '@/context/modqueueContext';
 import { GestureProvider } from '@paiduan/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
+import { OverlayHost } from '@/components/ui/Overlay';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <GestureProvider>
         <ModqueueProvider>
-          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+          <QueryClientProvider client={queryClient}>
+            {children}
+            <OverlayHost />
+          </QueryClientProvider>
         </ModqueueProvider>
       </GestureProvider>
     </ThemeProvider>

--- a/apps/web/components/CommentDrawer.stories.tsx
+++ b/apps/web/components/CommentDrawer.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import CommentDrawer from './CommentDrawer';
+import { OverlayHost } from './ui/Overlay';
+import { LayoutContext, LayoutType } from '@/context/LayoutContext';
+
+export default { title: 'Overlays/CommentDrawer' };
+
+const Template = (layout: LayoutType) => () => (
+  <LayoutContext.Provider value={layout}>
+    <OverlayHost />
+    <button onClick={() => CommentDrawer({ videoId: 'video1' })}>Open</button>
+  </LayoutContext.Provider>
+);
+
+export const Desktop = Template('desktop');
+export const Mobile = Template('mobile');

--- a/apps/web/components/CommentDrawer.tsx
+++ b/apps/web/components/CommentDrawer.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import { X, MoreVertical } from 'lucide-react';
 import { toast } from 'react-hot-toast';
@@ -10,27 +9,20 @@ import { useAuth } from '@/hooks/useAuth';
 import { getRelays } from '@/lib/nostr';
 import pool from '@/lib/relayPool';
 import { useModqueue } from '@/context/modqueueContext';
+import Overlay from './ui/Overlay';
 
 interface CommentDrawerProps {
   videoId: string;
-  open: boolean;
-  onClose: () => void;
+  onClose?: () => void;
   onCountChange?: (count: number) => void;
 }
 
-export const CommentDrawer: React.FC<CommentDrawerProps> = ({
-  videoId,
-  open,
-  onClose,
-  onCountChange,
-}) => {
+function CommentDrawerContent({ videoId, onClose, onCountChange }: CommentDrawerProps) {
   const { state } = useAuth();
   const [events, setEvents] = useState<NostrEvent[]>([]);
   const [input, setInput] = useState('');
   const [replyTo, setReplyTo] = useState<NostrEvent | null>(null);
   const [menuFor, setMenuFor] = useState<string | null>(null);
-  const [reportOpen, setReportOpen] = useState(false);
-  const [reportTarget, setReportTarget] = useState<string>('');
   const modqueue = useModqueue();
   const [extraHiddenIds, setExtraHiddenIds] = useState<Set<string>>(new Set());
   const hiddenIds = useMemo(() => {
@@ -50,9 +42,7 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
     return hidden;
   }, [modqueue, extraHiddenIds]);
 
-  // Subscribe to comments
   useEffect(() => {
-    if (!open) return;
     const sub = (pool as any).subscribeMany(getRelays(), [{ kinds: [1], '#e': [videoId] }], {
       onevent: (ev: any) => {
         setEvents((prev) => {
@@ -62,26 +52,19 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
         });
       },
     });
-    return () => {
-      sub.close();
-    };
-  }, [videoId, open]);
+    return () => sub.close();
+  }, [videoId]);
 
-  // fetch reports to hide comments
   useEffect(() => {
-    if (!open) return;
     const sub = (pool as any).subscribeMany(getRelays(), [{ kinds: [9001] }], {
       onevent: (ev: any) => {
         const tag = ev.tags.find((t: string[]) => t[0] === 'e');
         if (tag) setExtraHiddenIds((prev) => new Set(prev).add(tag[1]));
       },
     });
-    return () => {
-      sub.close();
-    };
-  }, [open]);
+    return () => sub.close();
+  }, []);
 
-  // Update count of top level comments
   useEffect(() => {
     const top = events.filter((e) => !e.tags.some((t) => t[0] === 'p'));
     const visible = top.filter((e) => !hiddenIds.has(e.id));
@@ -147,126 +130,119 @@ export const CommentDrawer: React.FC<CommentDrawerProps> = ({
   });
 
   return (
-    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50" />
-        <Dialog.Content className="fixed inset-x-0 bottom-0 z-50 h-1/2 bg-background-primary text-primary focus:outline-none relative">
-          <div className="flex items-center justify-between border-b divider p-2">
-            <span className="font-semibold">Comments</span>
-            <Dialog.Close asChild>
-              <button className="p-1 hover:text-accent-primary" aria-label="Close comments">
-                <X />
-              </button>
-            </Dialog.Close>
-          </div>
-          <div className="h-[calc(50vh-88px)] overflow-y-auto p-4 space-y-4">
-            {visibleTop.map((c) => (
-              <div key={c.id}>
-                <div className="flex items-start space-x-2">
-                  <div className="h-8 w-8 rounded-full bg-text-primary/20" />
-                  <div className="flex-1">
-                    <div className="text-sm font-semibold">@{c.pubkey.slice(0, 8)}</div>
-                    <div className="text-sm">{c.content}</div>
-                    <div className="text-xs text-primary/50">
-                      {new Date(c.created_at * 1000).toLocaleString()}
-                    </div>
-                    <button className="text-xs text-accent-primary mr-2" onClick={() => setReplyTo(c)}>
-                      Reply
-                    </button>
-                  </div>
-                  <div className="relative">
-                    <button
-                      onClick={() => setMenuFor(c.id)}
-                      className="p-1 text-primary/50"
-                      aria-label="Comment options"
-                    >
-                      <MoreVertical size={16} />
-                    </button>
-                    {menuFor === c.id && (
-                      <div className="absolute right-0 mt-1 w-24 rounded bg-background-primary p-1 shadow">
-                        <button
-                          className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
-                          onClick={() => {
-                            setMenuFor(null);
-                            setReportTarget(c.id);
-                            setReportOpen(true);
-                          }}
-                        >
-                          Report
-                        </button>
-                      </div>
-                    )}
-                  </div>
+    <>
+      <div className="flex items-center justify-between border-b divider p-2">
+        <span className="font-semibold">Comments</span>
+        <button
+          className="p-1 hover:text-accent-primary"
+          aria-label="Close comments"
+          onClick={() => {
+            Overlay.close();
+            onClose?.();
+          }}
+        >
+          <X />
+        </button>
+      </div>
+      <div className="h-[calc(50vh-88px)] overflow-y-auto p-4 space-y-4">
+        {visibleTop.map((c) => (
+          <div key={c.id}>
+            <div className="flex items-start space-x-2">
+              <div className="h-8 w-8 rounded-full bg-text-primary/20" />
+              <div className="flex-1">
+                <div className="text-sm font-semibold">@{c.pubkey.slice(0, 8)}</div>
+                <div className="text-sm">{c.content}</div>
+                <div className="text-xs text-primary/50">
+                  {new Date(c.created_at * 1000).toLocaleString()}
                 </div>
-                {visibleMap[c.id]?.map((r) => (
-                  <div key={r.id} className="mt-2 ml-8 flex items-start space-x-2">
-                    <div className="h-6 w-6 rounded-full bg-text-primary/20" />
-                    <div className="flex-1">
-                      <div className="text-sm font-semibold">@{r.pubkey.slice(0, 8)}</div>
-                      <div className="text-sm">{r.content}</div>
-                      <div className="text-xs text-primary/50">
-                        {new Date(r.created_at * 1000).toLocaleString()}
-                      </div>
-                      <button className="text-xs text-accent-primary mr-2" onClick={() => setReplyTo(r)}>
-                        Reply
-                      </button>
-                    </div>
-                    <div className="relative">
-                      <button
-                        onClick={() => setMenuFor(r.id)}
-                        className="p-1 text-primary/50"
-                        aria-label="Comment options"
-                      >
-                        <MoreVertical size={16} />
-                      </button>
-                      {menuFor === r.id && (
-                        <div className="absolute right-0 mt-1 w-24 rounded bg-background-primary p-1 shadow">
-                          <button
-                            className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
-                            onClick={() => {
-                              setMenuFor(null);
-                              setReportTarget(r.id);
-                              setReportOpen(true);
-                            }}
-                          >
-                            Report
-                          </button>
-                        </div>
-                      )}
-                    </div>
+                <button className="text-xs text-accent-primary mr-2" onClick={() => setReplyTo(c)}>
+                  Reply
+                </button>
+              </div>
+              <div className="relative">
+                <button
+                  onClick={() => setMenuFor(c.id)}
+                  className="p-1 text-primary/50"
+                  aria-label="Comment options"
+                >
+                  <MoreVertical size={16} />
+                </button>
+                {menuFor === c.id && (
+                  <div className="absolute right-0 mt-1 w-24 rounded bg-background-primary p-1 shadow">
+                    <button
+                      className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
+                      onClick={() => {
+                        setMenuFor(null);
+                        ReportModal({ targetId: c.id, targetKind: 'comment' });
+                      }}
+                    >
+                      Report
+                    </button>
                   </div>
-                ))}
+                )}
+              </div>
+            </div>
+            {visibleMap[c.id]?.map((r) => (
+              <div key={r.id} className="mt-2 ml-8 flex items-start space-x-2">
+                <div className="h-6 w-6 rounded-full bg-text-primary/20" />
+                <div className="flex-1">
+                  <div className="text-sm font-semibold">@{r.pubkey.slice(0, 8)}</div>
+                  <div className="text-sm">{r.content}</div>
+                  <div className="text-xs text-primary/50">
+                    {new Date(r.created_at * 1000).toLocaleString()}
+                  </div>
+                  <button className="text-xs text-accent-primary mr-2" onClick={() => setReplyTo(r)}>
+                    Reply
+                  </button>
+                </div>
+                <div className="relative">
+                  <button
+                    onClick={() => setMenuFor(r.id)}
+                    className="p-1 text-primary/50"
+                    aria-label="Comment options"
+                  >
+                    <MoreVertical size={16} />
+                  </button>
+                  {menuFor === r.id && (
+                    <div className="absolute right-0 mt-1 w-24 rounded bg-background-primary p-1 shadow">
+                      <button
+                        className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
+                        onClick={() => {
+                          setMenuFor(null);
+                          ReportModal({ targetId: r.id, targetKind: 'comment' });
+                        }}
+                      >
+                        Report
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
             ))}
           </div>
-          <div className="absolute bottom-0 left-0 right-0 border-t divider p-2">
-            {replyTo && (
-              <div className="mb-1 text-xs text-primary/50">
-                Replying to @{replyTo.pubkey.slice(0, 8)}{' '}
-                <button onClick={() => setReplyTo(null)} className="underline hover:text-accent-primary">
-                  cancel
-                </button>
-              </div>
-            )}
-            <input
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Add a comment"
-              className="w-full rounded bg-text-primary/10 p-2 text-sm outline-none"
-              disabled={!open}
-            />
+        ))}
+      </div>
+      <div className="absolute bottom-0 left-0 right-0 border-t divider p-2">
+        {replyTo && (
+          <div className="mb-1 text-xs text-primary/50">
+            Replying to @{replyTo.pubkey.slice(0, 8)}{' '}
+            <button onClick={() => setReplyTo(null)} className="underline hover:text-accent-primary">
+              cancel
+            </button>
           </div>
-          <ReportModal
-            targetId={reportTarget}
-            targetKind="comment"
-            open={reportOpen}
-            onClose={() => setReportOpen(false)}
-          />
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        )}
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Add a comment"
+          className="w-full rounded bg-text-primary/10 p-2 text-sm outline-none"
+        />
+      </div>
+    </>
   );
-};
+}
 
-export default CommentDrawer;
+export default function CommentDrawer(props: CommentDrawerProps) {
+  Overlay.open('drawer', { content: <CommentDrawerContent {...props} />, onClose: props.onClose });
+}

--- a/apps/web/components/ReportModal.stories.tsx
+++ b/apps/web/components/ReportModal.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReportModal from './ReportModal';
+import { OverlayHost } from './ui/Overlay';
+import { LayoutContext, LayoutType } from '@/context/LayoutContext';
+
+export default { title: 'Overlays/ReportModal' };
+
+const Template = (layout: LayoutType) => () => (
+  <LayoutContext.Provider value={layout}>
+    <OverlayHost />
+    <button onClick={() => ReportModal({ targetId: '123', targetKind: 'video' })}>Open</button>
+  </LayoutContext.Provider>
+);
+
+export const Desktop = Template('desktop');
+export const Mobile = Template('mobile');

--- a/apps/web/components/ReportModal.tsx
+++ b/apps/web/components/ReportModal.tsx
@@ -1,18 +1,17 @@
 import React, { useState } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
 import pool from '@/lib/relayPool';
 import toast from 'react-hot-toast';
 import { useAuth } from '@/hooks/useAuth';
 import { getRelays } from '@/lib/nostr';
+import Overlay from './ui/Overlay';
 
 interface Props {
   targetId: string;
   targetKind: 'video' | 'comment';
-  open: boolean;
-  onClose: () => void;
+  onClose?: () => void;
 }
 
-const ReportModal: React.FC<Props> = ({ targetId, targetKind, open, onClose }) => {
+function ReportModalContent({ targetId, targetKind, onClose }: Props) {
   const [reason, setReason] = useState('spam');
   const [details, setDetails] = useState('');
   const { state } = useAuth();
@@ -26,15 +25,15 @@ const ReportModal: React.FC<Props> = ({ targetId, targetKind, open, onClose }) =
       const reporterPubKey = state.pubkey;
       const ts = Math.floor(Date.now() / 1000);
       const report = { targetId, targetKind, reason, reporterPubKey, ts, details };
-        const event = { kind: 30041, created_at: ts, content: JSON.stringify(report), pubkey: reporterPubKey };
-        const signed = await state.signer.signEvent(event);
-        const relays = getRelays();
-        try {
-          await pool.publish(relays, signed);
-        } catch (err) {
-          console.error('Failed to publish report', err);
-          throw err;
-        }
+      const event = { kind: 30041, created_at: ts, content: JSON.stringify(report), pubkey: reporterPubKey } as any;
+      const signed = await state.signer.signEvent(event);
+      const relays = getRelays();
+      try {
+        await pool.publish(relays, signed);
+      } catch (err) {
+        console.error('Failed to publish report', err);
+        throw err;
+      }
       await fetch('/api/modqueue', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -42,51 +41,45 @@ const ReportModal: React.FC<Props> = ({ targetId, targetKind, open, onClose }) =
       });
       window.dispatchEvent(new Event('modqueue'));
       toast.success('Reported');
-      onClose();
+      Overlay.close();
+      onClose?.();
     } catch (err) {
       console.error(err);
       toast.error('Failed to report');
     }
   };
 
-  if (!open) return null;
-
   return (
-    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-80 -translate-x-1/2 -translate-y-1/2 rounded bg-background-primary p-4 text-primary focus:outline-none">
-          <Dialog.Title className="mb-2 font-semibold">Report</Dialog.Title>
-          <select
-            value={reason}
-            onChange={(e) => setReason(e.target.value)}
-            className="mb-2 w-full rounded border p-2 text-sm"
-          >
-            <option value="spam">Spam</option>
-            <option value="nudity">Nudity</option>
-            <option value="harassment">Harassment</option>
-            <option value="other">Other</option>
-          </select>
-          <textarea
-            value={details}
-            onChange={(e) => setDetails(e.target.value)}
-            className="mb-2 w-full rounded border p-2 text-sm"
-            placeholder="Details (optional)"
-          />
-          <div className="flex justify-end space-x-2">
-            <Dialog.Close asChild>
-              <button className="px-3 py-1" onClick={onClose}>
-                Cancel
-              </button>
-            </Dialog.Close>
-            <button className="rounded bg-accent-primary px-3 py-1 text-white" onClick={submit}>
-              Submit
-            </button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    <div className="w-80 p-4 text-primary">
+      <h2 className="mb-2 font-semibold">Report</h2>
+      <select
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        className="mb-2 w-full rounded border p-2 text-sm"
+      >
+        <option value="spam">Spam</option>
+        <option value="nudity">Nudity</option>
+        <option value="harassment">Harassment</option>
+        <option value="other">Other</option>
+      </select>
+      <textarea
+        value={details}
+        onChange={(e) => setDetails(e.target.value)}
+        className="mb-2 w-full rounded border p-2 text-sm"
+        placeholder="Details (optional)"
+      />
+      <div className="flex justify-end space-x-2">
+        <button className="px-3 py-1" onClick={() => { Overlay.close(); onClose?.(); }}>
+          Cancel
+        </button>
+        <button className="rounded bg-accent-primary px-3 py-1 text-white" onClick={submit}>
+          Submit
+        </button>
+      </div>
+    </div>
   );
-};
+}
 
-export default ReportModal;
+export default function ReportModal(props: Props) {
+  Overlay.open('modal', { content: <ReportModalContent {...props} />, onClose: props.onClose });
+}

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -62,7 +62,6 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const [speedMode, setSpeedMode] = useState(false);
   const [seekPreview, setSeekPreview] = useState(0);
   const adaptiveUrl = useAdaptiveSource(manifestUrl, playerRef);
-  const [commentsOpen, setCommentsOpen] = useState(false);
   const [commentCount, setCommentCount] = useState(0);
   const [reposted, setReposted] = useState(false);
   const holdTimer = useRef<number>();
@@ -75,7 +74,6 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const isFollowing = following.includes(pubkey);
   const { online } = useNetworkState();
   const [menuOpen, setMenuOpen] = useState(false);
-  const [reportOpen, setReportOpen] = useState(false);
   const [videoError, setVideoError] = useState(false);
   const { setCurrent } = useCurrentVideo();
   const { ref, inView } = useInView({ threshold: 0.7 });
@@ -231,7 +229,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
                 className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
                 onClick={() => {
                   setMenuOpen(false);
-                  setReportOpen(true);
+                  ReportModal({ targetId: eventId, targetKind: 'video' });
                 }}
               >
                 Report
@@ -258,7 +256,13 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         </button>
         <button
           className="relative hover:text-accent-primary disabled:opacity-50 lg:hidden"
-          onClick={() => online && setCommentsOpen(true)}
+          onClick={() =>
+            online &&
+            CommentDrawer({
+              videoId: eventId,
+              onCountChange: setCommentCount,
+            })
+          }
           disabled={!online}
           title={!online ? 'Offline – reconnect to interact.' : undefined}
         >
@@ -334,20 +338,6 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           {seekPreview.toFixed(1)}s
         </div>
       </animated.div>
-      {commentsOpen && (
-        <CommentDrawer
-          videoId={eventId}
-          open={commentsOpen}
-          onClose={() => setCommentsOpen(false)}
-          onCountChange={setCommentCount}
-        />
-      )}
-      <ReportModal
-        targetId={eventId}
-        targetKind="video"
-        open={reportOpen}
-        onClose={() => setReportOpen(false)}
-      />
     </motion.div>
   );
 };

--- a/apps/web/components/ZapButton.tsx
+++ b/apps/web/components/ZapButton.tsx
@@ -20,34 +20,27 @@ export const ZapButton: React.FC<ZapButtonProps> = ({
   disabled,
   title,
 }) => {
-  const [open, setOpen] = useState(false);
   const [count, setCount] = useState(total);
 
   return (
-    <>
-      <button
-        onClick={() => {
-          if (disabled) return;
-          analytics.trackEvent('zap_click');
-          setOpen(true);
-        }}
-        className="flex flex-col items-center text-primary hover:text-accent-primary disabled:opacity-50"
-        disabled={disabled}
-        title={title}
-      >
-        <Zap />
-        <span className="text-xs">{count}</span>
-      </button>
-      {open && (
-        <ZapModal
-          lightningAddress={lightningAddress}
-          eventId={eventId}
-          pubkey={pubkey}
-          onClose={() => setOpen(false)}
-          onSuccess={(amt) => setCount((c) => c + amt)}
-        />
-      )}
-    </>
+    <button
+      onClick={() => {
+        if (disabled) return;
+        analytics.trackEvent('zap_click');
+        ZapModal({
+          lightningAddress,
+          eventId,
+          pubkey,
+          onSuccess: (amt) => setCount((c) => c + amt),
+        });
+      }}
+      className="flex flex-col items-center text-primary hover:text-accent-primary disabled:opacity-50"
+      disabled={disabled}
+      title={title}
+    >
+      <Zap />
+      <span className="text-xs">{count}</span>
+    </button>
   );
 };
 

--- a/apps/web/components/ZapModal.stories.tsx
+++ b/apps/web/components/ZapModal.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ZapModal from './ZapModal';
+import { OverlayHost } from './ui/Overlay';
+import { LayoutContext, LayoutType } from '@/context/LayoutContext';
+
+export default { title: 'Overlays/ZapModal' };
+
+const Template = (layout: LayoutType) => () => (
+  <LayoutContext.Provider value={layout}>
+    <OverlayHost />
+    <button
+      onClick={() =>
+        ZapModal({
+          lightningAddress: 'test@ln.tld',
+          pubkey: 'pubkey',
+          onSuccess: () => {},
+        })
+      }
+    >
+      Open
+    </button>
+  </LayoutContext.Provider>
+);
+
+export const Desktop = Template('desktop');
+export const Mobile = Template('mobile');

--- a/apps/web/components/ZapModal.tsx
+++ b/apps/web/components/ZapModal.tsx
@@ -1,19 +1,18 @@
 import React, { useState } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
 import useLightning from '../hooks/useLightning';
 import { toast } from 'react-hot-toast';
+import Overlay from './ui/Overlay';
 
 interface ZapModalProps {
   lightningAddress: string;
   eventId?: string;
   pubkey: string;
-  onClose: () => void;
   onSuccess: (amount: number) => void;
 }
 
 const preset = [100, 500, 1000];
 
-export const ZapModal: React.FC<ZapModalProps> = ({ lightningAddress, eventId, pubkey, onClose, onSuccess }) => {
+function ZapModalContent({ lightningAddress, eventId, pubkey, onSuccess }: ZapModalProps) {
   const { createZap } = useLightning();
   const [custom, setCustom] = useState('');
 
@@ -25,50 +24,45 @@ export const ZapModal: React.FC<ZapModalProps> = ({ lightningAddress, eventId, p
       console.error(err);
       toast.error('Split payout failed – zap cancelled');
     }
-    onClose();
+    Overlay.close();
   };
 
   return (
-    <Dialog.Root open onOpenChange={(o) => !o && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/70" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 w-64 -translate-x-1/2 -translate-y-1/2 rounded bg-background-primary p-4 text-primary focus:outline-none">
-          <Dialog.Title className="mb-2 text-lg font-semibold">Send sats</Dialog.Title>
-          <div className="mb-2 flex space-x-2">
-            {preset.map((p) => (
-              <button
-                key={p}
-                onClick={() => send(p)}
-                className="flex-1 rounded border px-2 py-1 hover:bg-accent-primary hover:text-white"
-              >
-                {p}
-              </button>
-            ))}
-          </div>
-          <div className="flex space-x-2">
-            <input
-              type="number"
-              value={custom}
-              onChange={(e) => setCustom(e.target.value)}
-              className="flex-1 rounded border px-2 py-1 bg-background-primary"
-              placeholder="Custom"
-            />
-            <button
-              onClick={() => custom && send(Number(custom))}
-              className="rounded border px-2 py-1 hover:bg-accent-primary hover:text-white"
-            >
-              Zap
-            </button>
-          </div>
-          <Dialog.Close asChild>
-            <button onClick={onClose} className="mt-3 text-sm underline hover:text-accent-primary">
-              Cancel
-            </button>
-          </Dialog.Close>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    <div className="w-64 p-4 text-primary">
+      <h2 className="mb-2 text-lg font-semibold">Send sats</h2>
+      <div className="mb-2 flex space-x-2">
+        {preset.map((p) => (
+          <button
+            key={p}
+            onClick={() => send(p)}
+            className="flex-1 rounded border px-2 py-1 hover:bg-accent-primary hover:text-white"
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          type="number"
+          value={custom}
+          onChange={(e) => setCustom(e.target.value)}
+          className="flex-1 rounded border px-2 py-1 bg-background-primary"
+          placeholder="Custom"
+        />
+        <button
+          onClick={() => custom && send(Number(custom))}
+          className="rounded border px-2 py-1 hover:bg-accent-primary hover:text-white"
+        >
+          Zap
+        </button>
+      </div>
+      <button onClick={() => Overlay.close()} className="mt-3 text-sm underline hover:text-accent-primary">
+        Cancel
+      </button>
+    </div>
   );
-};
+}
 
-export default ZapModal;
+export default function ZapModal(props: ZapModalProps) {
+  Overlay.open('modal', { content: <ZapModalContent {...props} /> });
+}

--- a/apps/web/components/ui/Overlay.tsx
+++ b/apps/web/components/ui/Overlay.tsx
@@ -1,0 +1,60 @@
+import React, { useState, ReactNode } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { useLayout } from '@/context/LayoutContext';
+
+export type OverlayKind = 'modal' | 'drawer';
+
+interface OverlayProps {
+  content: ReactNode;
+  onClose?: () => void;
+}
+
+interface OverlayState {
+  type: OverlayKind;
+  props: OverlayProps;
+}
+
+let openHandler: (type: OverlayKind, props: OverlayProps) => void = () => {};
+let closeHandler: () => void = () => {};
+
+export function OverlayHost() {
+  const layout = useLayout();
+  const [state, setState] = useState<OverlayState | null>(null);
+
+  openHandler = (type: OverlayKind, props: OverlayProps) => {
+    setState({ type, props });
+  };
+
+  closeHandler = () => {
+    if (state?.props.onClose) state.props.onClose();
+    setState(null);
+  };
+
+  if (!state) return null;
+
+  const isDrawer = state.type === 'drawer' && layout !== 'desktop';
+
+  const contentClass = isDrawer
+    ? 'fixed inset-x-0 bottom-0 z-50 h-1/2 bg-background-primary text-primary focus:outline-none'
+    : 'fixed left-1/2 top-1/2 z-50 w-80 -translate-x-1/2 -translate-y-1/2 rounded bg-background-primary p-4 text-primary focus:outline-none';
+
+  return (
+    <Dialog.Root open onOpenChange={(o) => !o && closeHandler()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50" />
+        <Dialog.Content className={contentClass}>{state.props.content}</Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+const Overlay = {
+  open(type: OverlayKind, props: OverlayProps) {
+    openHandler(type, props);
+  },
+  close() {
+    closeHandler();
+  },
+};
+
+export default Overlay;

--- a/apps/web/context/LayoutContext.tsx
+++ b/apps/web/context/LayoutContext.tsx
@@ -10,7 +10,7 @@ function getLayout(width: number): LayoutType {
   return 'mobile';
 }
 
-const LayoutContext = createContext<LayoutType>('desktop');
+export const LayoutContext = createContext<LayoutType>('desktop');
 
 export function LayoutProvider({ children }: { children: React.ReactNode }) {
   const [layout, setLayout] = useState<LayoutType>(() => {


### PR DESCRIPTION
## Summary
- add Overlay utility with modal and drawer support
- refactor comment, report, and zap overlays to use Overlay
- add Storybook stories for overlays

## Testing
- `pnpm test` *(fails: useColorModeValue is not a function; worker out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6897c130413c833182716ca7a06008d5