### PR TITLE
Limit uploads to MP4/WebM and enforce 9:16 aspect

### DIFF
--- a/apps/web/components/create/UploadField.test.tsx
+++ b/apps/web/components/create/UploadField.test.tsx
@@ -31,9 +31,9 @@ describe('UploadField', () => {
     });
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
     expect(fileInput).toBeTruthy();
+    expect(fileInput.accept).toContain('video/mp4');
     expect(fileInput.accept).toContain('.mp4');
+    expect(fileInput.accept).toContain('video/webm');
     expect(fileInput.accept).toContain('.webm');
-    expect(fileInput.accept).toContain('.mov');
-    expect(fileInput.accept).toContain('.ogg');
   });
 });


### PR DESCRIPTION
## Summary
- restrict video uploads to MP4 or WebM and ensure 9:16 aspect
- trim videos with WebCodecs up to 300s while preserving original MIME type
- adjust tests for updated upload accept list

## Testing
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx apps/web/components/create/CreateVideoForm.profiles.test.tsx` *(no test files found)*
- `pnpm test apps/web/components/create/UploadField.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6897c5cfdbb0833183a7a35d16aad56d