### PR TITLE
fix: correct feed page export path

### DIFF
--- a/apps/web/app/en/feed/page.tsx
+++ b/apps/web/app/en/feed/page.tsx
@@ -1,1 +1,1 @@
-export { default } from '../feed';
+export { default } from '../../feed/page';


### PR DESCRIPTION
## Summary
- point English feed route to actual feed page component

## Testing
- `pnpm lint --filter=@paiduan/web` *(fails: Component definition is missing display name)*
- `pnpm test` *(fails: unhandled errors and worker out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6897c7d239688331971f1d214698377e