### PR TITLE
fix modqueue service read encoding

### DIFF
--- a/apps/web/lib/modqueue-service.ts
+++ b/apps/web/lib/modqueue-service.ts
@@ -16,8 +16,8 @@ export class ModQueueService {
 
   async read(): Promise<Report[]> {
     try {
-      const raw = await fs.readFile(this.filePath, 'utf8');
-      return JSON.parse(raw) as Report[];
+      const raw = await fs.readFile(this.filePath);
+      return JSON.parse(raw.toString('utf8')) as Report[];
     } catch {
       return [];
     }


### PR DESCRIPTION
## Summary
- use Buffer and explicit UTF-8 conversion when reading modqueue file

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6897cc3192ec8331afdbb0556ae1f97f