### PR TITLE
refactor: read stats file as buffer

### DIFF
--- a/apps/web/lib/creatorStatsStore.ts
+++ b/apps/web/lib/creatorStatsStore.ts
@@ -33,7 +33,8 @@ export class CreatorStatsStore {
 
   read(): Record<string, AggregatedStats> {
     try {
-      return JSON.parse(fs.readFileSync(this.filePath, 'utf8'));
+      const raw = fs.readFileSync(this.filePath);
+      return JSON.parse(raw.toString('utf8'));
     } catch {
       return {};
     }


### PR DESCRIPTION
## Summary
- read creator stats file as buffer and convert to UTF-8 before JSON parse

## Testing
- `pnpm test` *(fails: Vitest caught 3 unhandled errors during the test run; Error: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897cd5ab2d083318c631eda20050a65