### PR TITLE
fix: restore Chakra UI color mode support

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,19 +1,14 @@
 import '../styles/globals.css';
 import Providers from './providers';
 import { LayoutProvider } from '@/context/LayoutContext';
-import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
-import theme from '../styles/theme';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <ChakraProvider theme={theme}>
-          <ColorModeScript initialColorMode={theme.config.initialColorMode} />
-          <LayoutProvider>
-            <Providers>{children}</Providers>
-          </LayoutProvider>
-        </ChakraProvider>
+        <LayoutProvider>
+          <Providers>{children}</Providers>
+        </LayoutProvider>
       </body>
     </html>
   );

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
+import theme from '../styles/theme';
 import { ThemeProvider } from 'next-themes';
 import { ModqueueProvider } from '@/context/modqueueContext';
 import { GestureProvider } from '@paiduan/ui';
@@ -9,15 +11,18 @@ import { OverlayHost } from '@/components/ui/Overlay';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <GestureProvider>
-        <ModqueueProvider>
-          <QueryClientProvider client={queryClient}>
-            {children}
-            <OverlayHost />
-          </QueryClientProvider>
-        </ModqueueProvider>
-      </GestureProvider>
-    </ThemeProvider>
+    <ChakraProvider theme={theme}>
+      <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <GestureProvider>
+          <ModqueueProvider>
+            <QueryClientProvider client={queryClient}>
+              {children}
+              <OverlayHost />
+            </QueryClientProvider>
+          </ModqueueProvider>
+        </GestureProvider>
+      </ThemeProvider>
+    </ChakraProvider>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "storybook:build": "storybook build -o storybook-static"
   },
   "dependencies": {
-    "@chakra-ui/react": "^3.24.2",
+    "@chakra-ui/react": "^2.10.9",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@headlessui/react": "^2.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
   apps/web:
     dependencies:
       '@chakra-ui/react':
-        specifier: ^3.24.2
-        version: 3.24.2(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: ^2.10.9
+        version: 2.10.9(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.1))(@types/react@19.1.9)(react@19.1.1))(@types/react@19.1.9)(framer-motion@12.23.12(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.1.9)(react@19.1.1)
@@ -314,12 +314,6 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
-
-  '@ark-ui/react@5.18.2':
-    resolution: {integrity: sha512-vM2cuKSIe4mCDfqMc4RggsmiulXbicTjpZLf1IUXSHcUluMVn+z2k1minKI4X+Z7XSoKH0To7asxS0nJ1UPODA==}
-    peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -830,12 +824,40 @@ packages:
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
-  '@chakra-ui/react@3.24.2':
-    resolution: {integrity: sha512-FT+WR7WVZOTA+9m5adRrtxPuVh4Y45EsUIX8JimRut3e1U6j6Ddkas9kdUcvy90tkIMhRvvZXq3smDH9buVGtw==}
+  '@chakra-ui/anatomy@2.3.6':
+    resolution: {integrity: sha512-TjmjyQouIZzha/l8JxdBZN1pKZTj7sLpJ0YkFnQFyqHcbfWggW9jKWzY1E0VBnhtFz/xF3KC6UAVuZVSJx+y0g==}
+
+  '@chakra-ui/hooks@2.4.5':
+    resolution: {integrity: sha512-601fWfHE2i7UjaxK/9lDLlOni6vk/I+04YDbM0BrelJy+eqxdlOmoN8Z6MZ3PzFh7ofERUASor+vL+/HaCaZ7w==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react@2.10.9':
+    resolution: {integrity: sha512-lhdcgoocOiURwBNR3L8OioCNIaGCZqRfuKioLyaQLjOanl4jr0PQclsGb+w0cmito252vEWpsz2xRqF7y+Flrw==}
     peerDependencies:
       '@emotion/react': '>=11'
+      '@emotion/styled': '>=11'
+      framer-motion: '>=4.0.0'
       react: '>=18'
       react-dom: '>=18'
+
+  '@chakra-ui/styled-system@2.12.4':
+    resolution: {integrity: sha512-oa07UG7Lic5hHSQtGRiMEnYjuhIa8lszyuVhZjZqR2Ap3VMF688y1MVPJ1pK+8OwY5uhXBgVd5c0+rI8aBZlwg==}
+
+  '@chakra-ui/theme-tools@2.2.9':
+    resolution: {integrity: sha512-PcbYL19lrVvEc7Oydy//jsy/MO/rZz1DvLyO6AoI+bI/+Kwz9WfOKsspbulEhRg5COayE0R/IZPsskXZ7Mp4bA==}
+    peerDependencies:
+      '@chakra-ui/styled-system': '>=2.0.0'
+
+  '@chakra-ui/theme@3.4.9':
+    resolution: {integrity: sha512-GAom2SjSdRWTcX76/2yJOFJsOWHQeBgaynCUNBsHq62OafzvELrsSHDUw0bBqBb1c2ww0CclIvGilPup8kXBFA==}
+    peerDependencies:
+      '@chakra-ui/styled-system': '>=2.8.0'
+
+  '@chakra-ui/utils@2.2.5':
+    resolution: {integrity: sha512-KTBCK+M5KtXH6p54XS39ImQUMVtAx65BoZDoEms3LuObyTo1+civ1sMm4h3nRT320U6H5H7D35WnABVQjqU/4g==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -1087,9 +1109,6 @@ packages:
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
-  '@floating-ui/dom@1.7.2':
-    resolution: {integrity: sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==}
-
   '@floating-ui/dom@1.7.3':
     resolution: {integrity: sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==}
 
@@ -1272,12 +1291,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@internationalized/date@3.8.2':
-    resolution: {integrity: sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==}
-
-  '@internationalized/number@3.6.3':
-    resolution: {integrity: sha512-p+Zh1sb6EfrfVaS86jlHGQ9HA66fJhV9x5LiE5vCbZtXEHAuhcmUZUdZ4WrFpUBfNalr2OkAJI5AcKEQF+Lebw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1607,12 +1620,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@pandacss/is-valid-prop@0.54.0':
-    resolution: {integrity: sha512-UhRgg1k9VKRCBAHl+XUK3lvN0k9bYifzYGZOqajDid4L1DyU813A1L0ZwN4iV9WX5TX3PfUugqtgG9LnIeFGBQ==}
-
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@prisma/instrumentation@6.13.0':
     resolution: {integrity: sha512-b97b0sBycGh89RQcqobSgjGl3jwPaC5cQIOFod6EX1v0zIxlXPmL3ckSXxoHpy+Js0QV/tgCzFvqicMJCtezBA==}
@@ -2436,6 +2449,12 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/lodash.mergewith@4.6.9':
+    resolution: {integrity: sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==}
+
+  '@types/lodash@4.17.20':
+    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
+
   '@types/minimatch@6.0.0':
     resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
     deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
@@ -2761,218 +2780,14 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
-  '@zag-js/accordion@1.21.0':
-    resolution: {integrity: sha512-YuuQs72AmA52Hn30l3Q8KyFDb75g9glFV7AZkUq8V52vtUsdz2PfJye1FPD06M2dnnhHjEbdTQch6Qwwe5ApBA==}
+  '@zag-js/dom-query@0.31.1':
+    resolution: {integrity: sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg==}
 
-  '@zag-js/anatomy@1.21.0':
-    resolution: {integrity: sha512-wL5mmewTR8FJd91ZbfwiXpoMJbaQr1F1fFDel5BJgQukScNzd53HS5zhYb15eqJIOR6tlk/itPiJkxPp/+HdcQ==}
+  '@zag-js/element-size@0.31.1':
+    resolution: {integrity: sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ==}
 
-  '@zag-js/angle-slider@1.21.0':
-    resolution: {integrity: sha512-1d4VgxYv4LQL8PtjkYqvPlx7DsZpG0CaB1woOhPZSva7jmo0WKvTAUZf2pbk9ajTm+iA4C3xHRbVRM6s2Vy/lg==}
-
-  '@zag-js/aria-hidden@1.21.0':
-    resolution: {integrity: sha512-x78v+v/rNYoCFHeHK343kapdevywctNUEmPGdiH2BT3BI7uXZtv270WkD9OgdEOuEKuu18vbZ9TGYO9FGG8Ijw==}
-
-  '@zag-js/auto-resize@1.21.0':
-    resolution: {integrity: sha512-bQZUC5tP5SFdVcZ8vTA2tQy4B/YphwJaKCkG0Y6lHscpcPcZK7+kgBJaRj4XQuon7aKmgECLlD/da5PNNAdOJg==}
-
-  '@zag-js/avatar@1.21.0':
-    resolution: {integrity: sha512-bRkEaoSbJ8Dae246cc0ShmXLBWDcJIcI1KoncST4ClYwCqyMIj4s/zgr1+XUlyz3imz6n1RhTeT2jKcBqFGC6Q==}
-
-  '@zag-js/carousel@1.21.0':
-    resolution: {integrity: sha512-MpGLu6xVyPGDk5OupyTFywb85xrqCEs8qR0FpOH5eyNp3lvx/iLVNMcI+KTk5YTlZWQmDCyT86wBLMlf6SfTvw==}
-
-  '@zag-js/checkbox@1.21.0':
-    resolution: {integrity: sha512-lY9DYOvz0Cbdi3jxudv/nj9cpaGk784RiookL7QHr1u/Z/sUSNj5gUNpsIkSzZmT054Tu0t0jhtTt8vScq8DmQ==}
-
-  '@zag-js/clipboard@1.21.0':
-    resolution: {integrity: sha512-hJl4o8itwvVW3Wz5Zd/OQjR2OhXKdjHqIUuvPGbKcKEWxk6X9SDISslmCH9FbKVGVDgM6q5UypaYwwJZ1SsONQ==}
-
-  '@zag-js/collapsible@1.21.0':
-    resolution: {integrity: sha512-6vdZyZauYdiedlh6hcsYDF5Q5eC/vWstbP88PzeCFSxV5hKCJKxENOTd6d4OXJuYeWGkUABdgOl5MLIZVHrYCA==}
-
-  '@zag-js/collection@1.21.0':
-    resolution: {integrity: sha512-wJYmazXIFnr4/azWI9yeYrK3rB1d0KoaUMhOkrmGnwfp3c0U6rrUL54RuCMeyZ9WmzIUBhjZ5zc+385nsXwlPA==}
-
-  '@zag-js/color-picker@1.21.0':
-    resolution: {integrity: sha512-vovzxNdINPloc5SCBBwZX1/qQnvpGAs++82GUDBGdrdai/ayBYUMkP6Hd0OiStkEDunECpfDv4Qff3kobUIgpg==}
-
-  '@zag-js/color-utils@1.21.0':
-    resolution: {integrity: sha512-phUCKXeDvgnSUdLtjF6oE7HRmFEqNPkKOH2Nkhlnt9Hi8uxW9xhG3Haix7DaBhCN2DLRZqpsULpCA5eYV+S8IA==}
-
-  '@zag-js/combobox@1.21.0':
-    resolution: {integrity: sha512-aVEbcRk2JilDhGJjAmmO1YI4B8lNOeqgDxsbdWDDcgivHOzo1b5Rt+5kfyodXVOlzQAPkdq04b5/xLR9eurnJw==}
-
-  '@zag-js/core@1.21.0':
-    resolution: {integrity: sha512-ERQklS65W2wZD7Xvm/w/7u1nL5ZcTwK6Ppwat8EfAidBGGUB6YoZLW9Vu3I04g5SPhRmDmuIXhkTqKgIbXUUYg==}
-
-  '@zag-js/date-picker@1.21.0':
-    resolution: {integrity: sha512-pfZXvjuF89NfV6CTc4BayPEAujysJ5vRSVFArsDbz5oKB8j5PCRtvHEHo0WWwgF7Jr40CTmiG68wzuDMCdXq3A==}
-    peerDependencies:
-      '@internationalized/date': '>=3.0.0'
-
-  '@zag-js/date-utils@1.21.0':
-    resolution: {integrity: sha512-4H0Z/zQFfpTL45rUZg3tH4lJQmsV6PDTml/ptj9I8/1Mxel5eOwBdmDfQ7owm47H7MjgUvm7CqvYT9987b0KXA==}
-    peerDependencies:
-      '@internationalized/date': '>=3.0.0'
-
-  '@zag-js/dialog@1.21.0':
-    resolution: {integrity: sha512-nAKoCnpd40UeprYl2JazDZVL3r5uHD1L4dUEeY9GlO4CINYBvt7jntVJn1xLGm1tyc4S+kFUSgI1y1DXlS+8KQ==}
-
-  '@zag-js/dismissable@1.21.0':
-    resolution: {integrity: sha512-+BewcHUJvNCRWZ4lbUqABW6EwJRM2hxf65OPcN9XCMFCAoHbezdqHXYgtU7LRvYUJyxbvLPNeUrww3D6vcyhmA==}
-
-  '@zag-js/dom-query@1.21.0':
-    resolution: {integrity: sha512-P7Aeb1hfd5GtmTO1u0HkyVUrhFYgm94NxJhqufF2W+xByz/XspDcdy0l5pHFGsK9Urvh69S4tCx5YVh0MhZYgQ==}
-
-  '@zag-js/editable@1.21.0':
-    resolution: {integrity: sha512-28QivG0KU8OCgsldxi6rVLuqr36cNiuy1vTEzcoc61Ue6B1D4rCBAQaAJedl5r1ki+Vzrjl3uP1ApoUwV3S/JA==}
-
-  '@zag-js/file-upload@1.21.0':
-    resolution: {integrity: sha512-uH55bwFKcftpUYACyHT/8xB2bJdDqe3NM3JNCEYplxvn4scvDEzr2jpyVEmqUeOfrdNnyTuthNnL2hJjm4e+4A==}
-
-  '@zag-js/file-utils@1.21.0':
-    resolution: {integrity: sha512-gEWmz2ryuJMyAq3kg13TTmh5wR4Ft7d4Lb81ZeHiPpI/IwW67QrpBN0AKw3FBTmAuYBpK/dEc5iyETNPPrPTvg==}
-
-  '@zag-js/floating-panel@1.21.0':
-    resolution: {integrity: sha512-PVszFoJ53Iqmx+JD7WQFydRpp6spZFP1bCuBaHSoI044Z57UJ+rAkSlOGpoRHwpSROO9FPIpeqoTgy/kOCNmOA==}
-
-  '@zag-js/focus-trap@1.21.0':
-    resolution: {integrity: sha512-O00KOYOVPWWv/eATfeZxRTEvUTLv+eHJH6ynqOAvQ7RXmsECst4QlL9UJwStrTKn/r2gxhj+UZMwHMEwTGNeVg==}
-
-  '@zag-js/focus-visible@1.21.0':
-    resolution: {integrity: sha512-FNA7H4hyoQRBKpDkJWlBrFeyJpVphATgjvjhNXatCrrfa4F7VZiGnu3RGhEcnaw4b3bNkFnYLdRd+9XX7JHuoA==}
-
-  '@zag-js/highlight-word@1.21.0':
-    resolution: {integrity: sha512-bJIwPtcAMfEP6c5R/a3ZQG1V5FvYBP9onMVwKranAWPqOUj1/Y6lQ2gV/K4s7sw3VnpoXmy+5VxwfOPU/QWU5Q==}
-
-  '@zag-js/hover-card@1.21.0':
-    resolution: {integrity: sha512-G4+/lnc4ATU7BVHlnQ77fNC1b2k9dcbIeaBPMcdnc+g+CtqNhNTBM+rMb2OpSE9IOuFwqld5EK1v4tW8+6qOwQ==}
-
-  '@zag-js/i18n-utils@1.21.0':
-    resolution: {integrity: sha512-5E+vVsL6zcfaLlSGSnB3olXIEzmZ4C5L53+jSnx8LqmIcuTEc8I8mvBhcpTiDVHKrH6jG3jHE+6BvdyJ9SWQiA==}
-
-  '@zag-js/interact-outside@1.21.0':
-    resolution: {integrity: sha512-Yo4lojJYJZ4fjavOz+VbdpZlcDFAOlrOX+rKss3BNKfaffmhCklx/8Zej7WFStPCAv8AOzZ+fE4EhH/w+uPXEw==}
-
-  '@zag-js/json-tree-utils@1.21.0':
-    resolution: {integrity: sha512-OSyIxdWUVWD44hCvSgR+hP0q9nJOejS1VI9P4dbphQfcLNVvntAfwrb1os0DUR++UKBHyhAYwKVuVdThYbkJYQ==}
-
-  '@zag-js/listbox@1.21.0':
-    resolution: {integrity: sha512-XByByVOj4MA/ELcHgtkiS+jP5b2C2wXHmpCeCUp2jYKx3ZiL8al9y7yYLVBEDHRXsAR44UAQuJPIjDsCgtgkJg==}
-
-  '@zag-js/live-region@1.21.0':
-    resolution: {integrity: sha512-buHwgHkW95c8gYtk53AEmjS8r72AtDFRfD3l3OgMsBE/dnYYgM3bfpiZL3pP0IBK+WPKDJxS8TMj7Q7pBiQebQ==}
-
-  '@zag-js/menu@1.21.0':
-    resolution: {integrity: sha512-usD3MQTobKlzplY3j9IZxiq6cGHUZ/N8qmmi+EKvo0xpsEimhyE+FHr9XHqmFfGsxcH/yvyuFkvEjaUrF3qsqQ==}
-
-  '@zag-js/number-input@1.21.0':
-    resolution: {integrity: sha512-77Z2tTI+PcOCaoxNoteXfLaZA0zxObrOxqAjTgwapM88kn9oGNU4Ln6AYMJqdIDZJtQWdLBGjJwi3R8h8irpNQ==}
-
-  '@zag-js/pagination@1.21.0':
-    resolution: {integrity: sha512-d3zXD17CTSsA3o+5oJB1CujEoYNph58/DHFwVFDRgH5lB5K1vBxgas+JxJ2++uhouI8BH5fz7w7X3Wr6kXEHIw==}
-
-  '@zag-js/password-input@1.21.0':
-    resolution: {integrity: sha512-paiZbGEBlkoas08qwrpQVUuZXG8efgti/u464eZR6x7drv6PVc9igWxfqFJXL378I/cEUjj5MvYdk9yMbLJcHg==}
-
-  '@zag-js/pin-input@1.21.0':
-    resolution: {integrity: sha512-Ut3tZ4rDhjopTTdMcNm3BIpTlAu3NR1Uw1w+WM5NTh5C7Vn+GZAL5dP1dahB/t29yqhTZY4ssMxZfDofBpfMHw==}
-
-  '@zag-js/popover@1.21.0':
-    resolution: {integrity: sha512-crDELtzKZo0hSXA1N8LFrleq/9QlSGRlUNNb0DoUW0/gFFBG3wsrLayn2gWHweeM9HBG60ZnZnBW//pXaS32sg==}
-
-  '@zag-js/popper@1.21.0':
-    resolution: {integrity: sha512-PWLF6kY4f88CBM+nGebPJMB3DsXcj8NDuiLdljrGL4j1x18t1dhNY1IIdNDBueJCF0VL0uJrGwcxMZg6FGReSA==}
-
-  '@zag-js/presence@1.21.0':
-    resolution: {integrity: sha512-Fz7nhaoYbfbV6c8ovCnv75HaCD5yvU7NUxtR20wUYBPPx5nvdOViUsU+4ih/HXUcBHsQUW6teIfkf9Gb7xbCgQ==}
-
-  '@zag-js/progress@1.21.0':
-    resolution: {integrity: sha512-AMZsoURX2jotI2KrODE4jw7e9FPslKIZCO/guh11D6A9gvSM3ECRe2gKdAcLjP+UKxayS8MkNPhD51bAYCfkbQ==}
-
-  '@zag-js/qr-code@1.21.0':
-    resolution: {integrity: sha512-mCe8qp+F9ZKS9Py/CkXmfAGMc9h86UM9NkXOWwU880az885Y0Ld8UaHmyWO3AAJDWPYBkTJKq+tEqNTCKx1dyw==}
-
-  '@zag-js/radio-group@1.21.0':
-    resolution: {integrity: sha512-TCb3RjiNhgFWzwHUns9S+z6rNyXng2kexFPmD1ycyEO1efHAb83J5aZv5ShGX/05YCZpwVMf3WsyGEV8p8c/1g==}
-
-  '@zag-js/rating-group@1.21.0':
-    resolution: {integrity: sha512-TBjSGfHT06Ehj3lBACVB3pOnxmb+jvJQgBQUZtFYFMae+gtuKItwx9qleH24vuyqKT/DI3amQhbvpi+bUK9CVA==}
-
-  '@zag-js/react@1.21.0':
-    resolution: {integrity: sha512-yTqpMJ2c6Sf/KqXmyq3yJg1W/VZhYn1YNBRKWYJYT/kUDnoOpyqIBbmwka0dZi/hnWdhK1pzV0UUa7oV4IWa/A==}
-    peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-
-  '@zag-js/rect-utils@1.21.0':
-    resolution: {integrity: sha512-ulzlyupj7QnM5NdAHSy2uKscVanjApxcC5/FRu+ooUZRaK1A8BMqep6r7lsVB8qTz0l1ssjLqCJPGNzP3PB3ug==}
-
-  '@zag-js/remove-scroll@1.21.0':
-    resolution: {integrity: sha512-wsXEM7rUJnJrTmcCHsahtLfxaas/enHOakAB98n5YZelcoFFbE+iR91brb1yUbccfryvepozOac+EIWuO8/2aw==}
-
-  '@zag-js/scroll-snap@1.21.0':
-    resolution: {integrity: sha512-H/8bQql4DjYFVpBG6j/EyUsdboCxyGjRzOg9SN8bA2aXNDBPh+/oLwnCWCqagd4A1VO6JxmuFmbcM2wW9Khmhw==}
-
-  '@zag-js/select@1.21.0':
-    resolution: {integrity: sha512-wVxPzw9lmtCDWTPP0h6P8r7QL93VsyajwV0EPFKoa8HH4XWzl5QBuShXIzmD8dxbHA5HIdAZNYAC5BQCSW37Xw==}
-
-  '@zag-js/signature-pad@1.21.0':
-    resolution: {integrity: sha512-LUXHsMPXLNSaWBJ4WWY+ZSFpAbbPHfUAGOVh22bOIJWMRchcs4Cch42tFgg/sB8cREfc3G/CS5e2gIBqMigcEQ==}
-
-  '@zag-js/slider@1.21.0':
-    resolution: {integrity: sha512-dmH2j8Iu079UZf36TzfPBOYb2jGbvXHcV8x3zYiRWs4ccJDaSNBZieCWCY0/Nm5wI8l+ue/Buc1kcbpIytuWHQ==}
-
-  '@zag-js/splitter@1.21.0':
-    resolution: {integrity: sha512-blsSe3UrhEYieLF2fuO7UM0t2rQxFTeLYMSjuxFspdYZz47VnEKtVypgQUZnQX5dyttyV49vl1g7+AbBBlk6bA==}
-
-  '@zag-js/steps@1.21.0':
-    resolution: {integrity: sha512-w0nzJBgYe/A04pNZN1mv1hRT44MVwwRf9VvlBFIS1CxVpUOGkDoVrzRb/CX1zpOhMdtF8w7+FfgT6Q3/oVJ4+A==}
-
-  '@zag-js/store@1.21.0':
-    resolution: {integrity: sha512-UCAuYWui3+VYfp8KdECXuM+L8tKzQYyNz+7KrRPHyZ37wgHjz4M+QNj/QP5GgDStLJaF3UgbuLYwbXSQ/3WcWw==}
-
-  '@zag-js/switch@1.21.0':
-    resolution: {integrity: sha512-erQ05qU9UUTOKkq77X+fTBOnng75ZFugcbcx4HWkACs9aUQmh9JoRF/1+HzFvRf8SyfuEdiSP25Q+ozmiOUmXQ==}
-
-  '@zag-js/tabs@1.21.0':
-    resolution: {integrity: sha512-ecRS8F5M6QCAln4ob8waySRmSPozbOZ5dq1GGmaVExBwbrOA4C3ZbrHU3Dhmmx8vUji+rOSRifyhHwCTY0PTqQ==}
-
-  '@zag-js/tags-input@1.21.0':
-    resolution: {integrity: sha512-i/3PvNMhUloVi2DO+CRAEHtosu/Xmjcuj7Q3wY1acTORkoyXJrynmKmUcjF2D5ySHuey+Q07ADztlpa9ZHjr8Q==}
-
-  '@zag-js/time-picker@1.21.0':
-    resolution: {integrity: sha512-GIBgfHfo2pYnl9MD0fVNaJ6UE63dOs+T0DFPhBf3DazNR9r4qhK0QXQLRQyH57KD+kcjKiJNgMGRKsKbX88aEw==}
-    peerDependencies:
-      '@internationalized/date': '>=3.0.0'
-
-  '@zag-js/timer@1.21.0':
-    resolution: {integrity: sha512-vFohY91xnJVV6iSkT6tESLIrFssZsE02LbnXjHEnEVajC0jXLExvIu70t+5CWmP08e2yfp7E+G9WI1cDyzS/SQ==}
-
-  '@zag-js/toast@1.21.0':
-    resolution: {integrity: sha512-DMvdLMQFGGwNxRjnzEsszocBWreQ+4spvQTrolra9pp7PuklodnIIuxRNNQ7bQVd1wH/pQPkEwXTbusb4NMBgw==}
-
-  '@zag-js/toggle-group@1.21.0':
-    resolution: {integrity: sha512-zUxLj0sXCUixI3C7lMEekQc8jQlFd0Y70a3/MO5xC/sem3pucPS30rulcvp7b3d9TLJk8YVofpvAjdRPDyb9XA==}
-
-  '@zag-js/toggle@1.21.0':
-    resolution: {integrity: sha512-+toPS8gviWYDAatyuFOWooHts5LP368UYsubedxZAgyz+qE6Mo8j282k2iGvmzrM22WcplRXVzgZ0JYUFVPtbQ==}
-
-  '@zag-js/tooltip@1.21.0':
-    resolution: {integrity: sha512-X7t93MPvB0T82HT9QRlfh+Ts8QwAeouSDmaCCrF5/tdIsMTuzEzGqWtaPbXTDfMGrsG2umlIiIVSraWDe6aAIQ==}
-
-  '@zag-js/tour@1.21.0':
-    resolution: {integrity: sha512-441Az3byK0vP2zL67p4z5m7s/0B7uHicLdvS0rKjoI+2gZ9Qd8yGuzTSfMJY2lWn+407iswN/koY7Kz5K0srFg==}
-
-  '@zag-js/tree-view@1.21.0':
-    resolution: {integrity: sha512-gMjmy+sdZsLm75pwLH8M5qCOnsXA2KIGt0lKcfL/qAhYqDVaXm6xnx43JhJxSvVvqPqDuP1W8R5vUkBtEXV5Ig==}
-
-  '@zag-js/types@1.21.0':
-    resolution: {integrity: sha512-ozT8aTeqCKsPYQDqIgkjkJnXBEADvV8nj8ZuXUzm7RhIN9EqeqpQyOdA7GdYrrDY5bgmdzyzmJu+e/2PbWg/ng==}
-
-  '@zag-js/utils@1.21.0':
-    resolution: {integrity: sha512-yI/CZizbk387TdkDCy9Uc4l53uaeQuWAIJESrmAwwq6yMNbHZ2dm5+1NHdZr/guES5TgyJa/BYJsNJeCsCfesg==}
+  '@zag-js/focus-visible@0.31.1':
+    resolution: {integrity: sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==}
 
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
@@ -3414,6 +3229,9 @@ packages:
 
   color-string@1.9.1:
     resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color2k@2.0.3:
+    resolution: {integrity: sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==}
 
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
@@ -4025,9 +3843,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-
   fast-shallow-equal@1.0.0:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
 
@@ -4089,6 +3904,10 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  focus-lock@1.3.6:
+    resolution: {integrity: sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==}
+    engines: {node: '>=10'}
+
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
@@ -4136,6 +3955,9 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  framesync@6.1.2:
+    resolution: {integrity: sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -4783,6 +4605,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
@@ -5240,9 +5065,6 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
-  perfect-freehand@1.2.2:
-    resolution: {integrity: sha512-eh31l019WICQ03pkF3FSzHxB8n07ItqIQ++G5UV8JX0zVOXzgTGCqnRR0jJ2h9U8/2uW4W4mtGJELt9kEV0CFQ==}
-
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -5436,14 +5258,8 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  proxy-compare@3.0.1:
-    resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
-
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
-  proxy-memoize@3.0.1:
-    resolution: {integrity: sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -5463,6 +5279,11 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  react-clientside-effect@1.2.8:
+    resolution: {integrity: sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -5489,6 +5310,18 @@ packages:
     peerDependencies:
       react: '>=16.4.0'
       react-dom: '>=16.4.0'
+
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-focus-lock@2.13.6:
+    resolution: {integrity: sha512-ehylFFWyYtBKXjAO9+3v8d0i+cnc1trGS0vlTGhzFW1vbFXVUTmR8s2tt/ZQG8x5hElg6rhENlLG1H3EZK0Llg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-hook-form@7.62.0:
     resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
@@ -6208,6 +6041,9 @@ packages:
   tseep@1.3.1:
     resolution: {integrity: sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ==}
 
+  tslib@2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -6345,9 +6181,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  uqr@0.1.2:
-    resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -6756,70 +6589,6 @@ snapshots:
       json-schema: 0.4.0
       jsonpointer: 5.0.1
       leven: 3.1.0
-
-  '@ark-ui/react@5.18.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@internationalized/date': 3.8.2
-      '@zag-js/accordion': 1.21.0
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/angle-slider': 1.21.0
-      '@zag-js/auto-resize': 1.21.0
-      '@zag-js/avatar': 1.21.0
-      '@zag-js/carousel': 1.21.0
-      '@zag-js/checkbox': 1.21.0
-      '@zag-js/clipboard': 1.21.0
-      '@zag-js/collapsible': 1.21.0
-      '@zag-js/collection': 1.21.0
-      '@zag-js/color-picker': 1.21.0
-      '@zag-js/color-utils': 1.21.0
-      '@zag-js/combobox': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/date-picker': 1.21.0(@internationalized/date@3.8.2)
-      '@zag-js/date-utils': 1.21.0(@internationalized/date@3.8.2)
-      '@zag-js/dialog': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/editable': 1.21.0
-      '@zag-js/file-upload': 1.21.0
-      '@zag-js/file-utils': 1.21.0
-      '@zag-js/floating-panel': 1.21.0
-      '@zag-js/focus-trap': 1.21.0
-      '@zag-js/highlight-word': 1.21.0
-      '@zag-js/hover-card': 1.21.0
-      '@zag-js/i18n-utils': 1.21.0
-      '@zag-js/json-tree-utils': 1.21.0
-      '@zag-js/listbox': 1.21.0
-      '@zag-js/menu': 1.21.0
-      '@zag-js/number-input': 1.21.0
-      '@zag-js/pagination': 1.21.0
-      '@zag-js/password-input': 1.21.0
-      '@zag-js/pin-input': 1.21.0
-      '@zag-js/popover': 1.21.0
-      '@zag-js/presence': 1.21.0
-      '@zag-js/progress': 1.21.0
-      '@zag-js/qr-code': 1.21.0
-      '@zag-js/radio-group': 1.21.0
-      '@zag-js/rating-group': 1.21.0
-      '@zag-js/react': 1.21.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@zag-js/select': 1.21.0
-      '@zag-js/signature-pad': 1.21.0
-      '@zag-js/slider': 1.21.0
-      '@zag-js/splitter': 1.21.0
-      '@zag-js/steps': 1.21.0
-      '@zag-js/switch': 1.21.0
-      '@zag-js/tabs': 1.21.0
-      '@zag-js/tags-input': 1.21.0
-      '@zag-js/time-picker': 1.21.0(@internationalized/date@3.8.2)
-      '@zag-js/timer': 1.21.0
-      '@zag-js/toast': 1.21.0
-      '@zag-js/toggle': 1.21.0
-      '@zag-js/toggle-group': 1.21.0
-      '@zag-js/tooltip': 1.21.0
-      '@zag-js/tour': 1.21.0
-      '@zag-js/tree-view': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -7500,19 +7269,66 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@chakra-ui/react@3.24.2(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@chakra-ui/anatomy@2.3.6': {}
+
+  '@chakra-ui/hooks@2.4.5(react@19.1.1)':
     dependencies:
-      '@ark-ui/react': 5.18.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@emotion/is-prop-valid': 1.3.1
+      '@chakra-ui/utils': 2.2.5(react@19.1.1)
+      '@zag-js/element-size': 0.31.1
+      copy-to-clipboard: 3.3.3
+      framesync: 6.1.2
+      react: 19.1.1
+
+  '@chakra-ui/react@2.10.9(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.1))(@types/react@19.1.9)(react@19.1.1))(@types/react@19.1.9)(framer-motion@12.23.12(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@chakra-ui/hooks': 2.4.5(react@19.1.1)
+      '@chakra-ui/styled-system': 2.12.4(react@19.1.1)
+      '@chakra-ui/theme': 3.4.9(@chakra-ui/styled-system@2.12.4(react@19.1.1))(react@19.1.1)
+      '@chakra-ui/utils': 2.2.5(react@19.1.1)
       '@emotion/react': 11.14.0(@types/react@19.1.9)(react@19.1.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.1)
-      '@emotion/utils': 1.4.2
-      '@pandacss/is-valid-prop': 0.54.0
-      csstype: 3.1.3
-      fast-safe-stringify: 2.1.1
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.9)(react@19.1.1))(@types/react@19.1.9)(react@19.1.1)
+      '@popperjs/core': 2.11.8
+      '@zag-js/focus-visible': 0.31.1
+      aria-hidden: 1.2.6
+      framer-motion: 12.23.12(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.6(@types/react@19.1.9)(react@19.1.1)
+      react-remove-scroll: 2.7.1(@types/react@19.1.9)(react@19.1.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@chakra-ui/styled-system@2.12.4(react@19.1.1)':
+    dependencies:
+      '@chakra-ui/utils': 2.2.5(react@19.1.1)
+      csstype: 3.1.3
+    transitivePeerDependencies:
+      - react
+
+  '@chakra-ui/theme-tools@2.2.9(@chakra-ui/styled-system@2.12.4(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@chakra-ui/anatomy': 2.3.6
+      '@chakra-ui/styled-system': 2.12.4(react@19.1.1)
+      '@chakra-ui/utils': 2.2.5(react@19.1.1)
+      color2k: 2.0.3
+    transitivePeerDependencies:
+      - react
+
+  '@chakra-ui/theme@3.4.9(@chakra-ui/styled-system@2.12.4(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@chakra-ui/anatomy': 2.3.6
+      '@chakra-ui/styled-system': 2.12.4(react@19.1.1)
+      '@chakra-ui/theme-tools': 2.2.9(@chakra-ui/styled-system@2.12.4(react@19.1.1))(react@19.1.1)
+      '@chakra-ui/utils': 2.2.5(react@19.1.1)
+    transitivePeerDependencies:
+      - react
+
+  '@chakra-ui/utils@2.2.5(react@19.1.1)':
+    dependencies:
+      '@types/lodash.mergewith': 4.6.9
+      lodash.mergewith: 4.6.2
+      react: 19.1.1
 
   '@csstools/color-helpers@5.0.2': {}
 
@@ -7729,11 +7545,6 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/dom@1.7.2':
-    dependencies:
-      '@floating-ui/core': 1.7.3
-      '@floating-ui/utils': 0.2.10
-
   '@floating-ui/dom@1.7.3':
     dependencies:
       '@floating-ui/core': 1.7.3
@@ -7897,14 +7708,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.3':
     optional: true
-
-  '@internationalized/date@3.8.2':
-    dependencies:
-      '@swc/helpers': 0.5.15
-
-  '@internationalized/number@3.6.3':
-    dependencies:
-      '@swc/helpers': 0.5.15
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -8279,10 +8082,10 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
 
-  '@pandacss/is-valid-prop@0.54.0': {}
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@popperjs/core@2.11.8': {}
 
   '@prisma/instrumentation@6.13.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -9193,6 +8996,12 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/lodash.mergewith@4.6.9':
+    dependencies:
+      '@types/lodash': 4.17.20
+
+  '@types/lodash@4.17.20': {}
+
   '@types/minimatch@6.0.0':
     dependencies:
       minimatch: 9.0.5
@@ -9571,506 +9380,13 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@zag-js/accordion@1.21.0':
+  '@zag-js/dom-query@0.31.1': {}
+
+  '@zag-js/element-size@0.31.1': {}
+
+  '@zag-js/focus-visible@0.31.1':
     dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/anatomy@1.21.0': {}
-
-  '@zag-js/angle-slider@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/rect-utils': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/aria-hidden@1.21.0': {}
-
-  '@zag-js/auto-resize@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-
-  '@zag-js/avatar@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/carousel@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/scroll-snap': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/checkbox@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/focus-visible': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/clipboard@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/collapsible@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/collection@1.21.0':
-    dependencies:
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/color-picker@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/color-utils': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/color-utils@1.21.0':
-    dependencies:
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/combobox@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/aria-hidden': 1.21.0
-      '@zag-js/collection': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/core@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/date-picker@1.21.0(@internationalized/date@3.8.2)':
-    dependencies:
-      '@internationalized/date': 3.8.2
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/date-utils': 1.21.0(@internationalized/date@3.8.2)
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/live-region': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/date-utils@1.21.0(@internationalized/date@3.8.2)':
-    dependencies:
-      '@internationalized/date': 3.8.2
-
-  '@zag-js/dialog@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/aria-hidden': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/focus-trap': 1.21.0
-      '@zag-js/remove-scroll': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/dismissable@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/interact-outside': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/dom-query@1.21.0':
-    dependencies:
-      '@zag-js/types': 1.21.0
-
-  '@zag-js/editable@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/interact-outside': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/file-upload@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/file-utils': 1.21.0
-      '@zag-js/i18n-utils': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/file-utils@1.21.0':
-    dependencies:
-      '@zag-js/i18n-utils': 1.21.0
-
-  '@zag-js/floating-panel@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/rect-utils': 1.21.0
-      '@zag-js/store': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/focus-trap@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-
-  '@zag-js/focus-visible@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-
-  '@zag-js/highlight-word@1.21.0': {}
-
-  '@zag-js/hover-card@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/i18n-utils@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-
-  '@zag-js/interact-outside@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/json-tree-utils@1.21.0': {}
-
-  '@zag-js/listbox@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/collection': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/focus-visible': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/live-region@1.21.0': {}
-
-  '@zag-js/menu@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/rect-utils': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/number-input@1.21.0':
-    dependencies:
-      '@internationalized/number': 3.6.3
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/pagination@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/password-input@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/pin-input@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/popover@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/aria-hidden': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/focus-trap': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/remove-scroll': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/popper@1.21.0':
-    dependencies:
-      '@floating-ui/dom': 1.7.2
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/presence@1.21.0':
-    dependencies:
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-
-  '@zag-js/progress@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/qr-code@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-      proxy-memoize: 3.0.1
-      uqr: 0.1.2
-
-  '@zag-js/radio-group@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/focus-visible': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/rating-group@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/react@1.21.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@zag-js/core': 1.21.0
-      '@zag-js/store': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-
-  '@zag-js/rect-utils@1.21.0': {}
-
-  '@zag-js/remove-scroll@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-
-  '@zag-js/scroll-snap@1.21.0':
-    dependencies:
-      '@zag-js/dom-query': 1.21.0
-
-  '@zag-js/select@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/collection': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/signature-pad@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-      perfect-freehand: 1.2.2
-
-  '@zag-js/slider@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/splitter@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/steps@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/store@1.21.0':
-    dependencies:
-      proxy-compare: 3.0.1
-
-  '@zag-js/switch@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/focus-visible': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/tabs@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/tags-input@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/auto-resize': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/interact-outside': 1.21.0
-      '@zag-js/live-region': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/time-picker@1.21.0(@internationalized/date@3.8.2)':
-    dependencies:
-      '@internationalized/date': 3.8.2
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/timer@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/toast@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/toggle-group@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/toggle@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/tooltip@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/focus-visible': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/store': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/tour@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dismissable': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/focus-trap': 1.21.0
-      '@zag-js/interact-outside': 1.21.0
-      '@zag-js/popper': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/tree-view@1.21.0':
-    dependencies:
-      '@zag-js/anatomy': 1.21.0
-      '@zag-js/collection': 1.21.0
-      '@zag-js/core': 1.21.0
-      '@zag-js/dom-query': 1.21.0
-      '@zag-js/types': 1.21.0
-      '@zag-js/utils': 1.21.0
-
-  '@zag-js/types@1.21.0':
-    dependencies:
-      csstype: 3.1.3
-
-  '@zag-js/utils@1.21.0': {}
+      '@zag-js/dom-query': 0.31.1
 
   acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
@@ -10576,6 +9892,8 @@ snapshots:
       simple-swizzle: 0.2.2
     optional: true
 
+  color2k@2.0.3: {}
+
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
@@ -11076,8 +10394,8 @@ snapshots:
       '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -11106,7 +10424,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -11117,22 +10435,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11143,7 +10461,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11344,8 +10662,6 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-safe-stringify@2.1.1: {}
-
   fast-shallow-equal@1.0.0: {}
 
   fast-uri@3.0.6: {}
@@ -11408,6 +10724,10 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  focus-lock@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
   follow-redirects@1.15.11: {}
 
   for-each@0.3.5:
@@ -11457,6 +10777,10 @@ snapshots:
       '@emotion/is-prop-valid': 1.3.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
+
+  framesync@6.1.2:
+    dependencies:
+      tslib: 2.4.0
 
   fs-extra@10.1.0:
     dependencies:
@@ -12154,6 +11478,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash.mergewith@4.6.2: {}
+
   lodash.sortby@4.7.0: {}
 
   lodash@4.17.21: {}
@@ -12625,8 +11951,6 @@ snapshots:
 
   pathval@2.0.1: {}
 
-  perfect-freehand@1.2.2: {}
-
   pg-int8@1.0.1: {}
 
   pg-protocol@1.10.3: {}
@@ -12794,13 +12118,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  proxy-compare@3.0.1: {}
-
   proxy-from-env@1.1.0: {}
-
-  proxy-memoize@3.0.1:
-    dependencies:
-      proxy-compare: 3.0.1
 
   punycode@2.3.1: {}
 
@@ -12817,6 +12135,11 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  react-clientside-effect@1.2.8(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.2
+      react: 19.1.1
 
   react-docgen-typescript@2.4.0(typescript@5.9.2):
     dependencies:
@@ -12855,6 +12178,20 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       tslib: 2.8.1
+
+  react-fast-compare@3.2.2: {}
+
+  react-focus-lock@2.13.6(@types/react@19.1.9)(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.2
+      focus-lock: 1.3.6
+      prop-types: 15.8.1
+      react: 19.1.1
+      react-clientside-effect: 1.2.8(react@19.1.1)
+      use-callback-ref: 1.3.3(@types/react@19.1.9)(react@19.1.1)
+      use-sidecar: 1.1.3(@types/react@19.1.9)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.9
 
   react-hook-form@7.62.0(react@19.1.1):
     dependencies:
@@ -13732,6 +13069,8 @@ snapshots:
 
   tseep@1.3.1: {}
 
+  tslib@2.4.0: {}
+
   tslib@2.8.1: {}
 
   turbo-darwin-64@2.5.5:
@@ -13880,8 +13219,6 @@ snapshots:
       browserslist: 4.25.1
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  uqr@0.1.2: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Summary
- use Chakra UI v2 to restore color mode hooks
- move Chakra provider into client-side Providers to avoid server rendering issues

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897ce0c424c833191fd696128367da5