### PR TITLE
Wrap app with NextIntl provider for translations

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,13 +1,36 @@
 import '../styles/globals.css';
 import Providers from './providers';
 import { LayoutProvider } from '@/context/LayoutContext';
+import { NextIntlClientProvider } from 'next-intl';
+import { locales } from '../utils/locales';
+import { notFound } from 'next/navigation';
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export default async function RootLayout({
+  children,
+  params: { locale },
+}: {
+  children: React.ReactNode;
+  params: { locale: string };
+}) {
+  if (!locales.includes(locale as typeof locales[number])) {
+    notFound();
+  }
+
+  const messages = {
+    common: (await import(`../locales/${locale}/common.json`)).default,
+  };
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body>
         <LayoutProvider>
-          <Providers>{children}</Providers>
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <Providers>{children}</Providers>
+          </NextIntlClientProvider>
         </LayoutProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- load locale-specific messages in `app/layout.tsx`
- wrap application with `NextIntlClientProvider` so components can use `useTranslations`

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897d071afcc8331b06092d84ff17cba