### PR TITLE
Document WebCodecs upload limits and expand CreateVideoForm tests

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,20 +4,27 @@
 
 The upload page at `pages/create.tsx` (and locale variants in `[locale]/create.tsx`) renders the `CreateVideoForm` component from `components/create/CreateVideoForm.tsx`. This form keeps file selection, metadata entry and publishing on a single screen.
 
-### Automatic conversion
+### Requirements
 
-Selecting a file triggers `utils/trimVideoWebCodecs.ts`, which trims and re-encodes the clip in the browser. Conversion progress is reported via a callback and updates local state.
+- Accepted formats: mp4 and webm
+- Maximum length: 5 minutes
+- Required aspect ratio: 9:16
+- Trimming performed via WebCodecs
+
+### Automatic trimming
+
+Selecting a file triggers `utils/trimVideoWebCodecs.ts`, which trims the clip in the browser using WebCodecs. Progress is reported via a callback and updates local state.
 
 ### Progress bar
 
-A thin progress bar appears at the bottom of the video preview while conversion is running (`progress > 0 && progress < 100`). It disappears once encoding completes.
+A thin progress bar appears at the bottom of the video preview while trimming is in progress (`progress > 0 && progress < 100`). It disappears once processing completes.
 
 ### Publish button validation
 
-The **Publish** button remains disabled until a converted video is available and required metadata are supplied—at least one topic and a Lightning address. Validation logic lives in `CreateVideoForm.tsx` and is exposed through the `formValid` flag.
+The **Publish** button remains disabled until a trimmed video is available and required metadata are supplied—at least one topic and a Lightning address. Validation logic lives in `CreateVideoForm.tsx` and is exposed through the `formValid` flag.
 
 ## Cross-origin headers
 
-By default, the application sends `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on all routes. These headers enable cross-origin isolation, which is required for future multi-threaded FFmpeg builds in the browser.
+By default, the application sends `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on all routes. These headers enable cross-origin isolation for features like WebCodecs.
 
 Set `ENABLE_ISOLATION=false` to disable these headers and allow loading third-party resources that do not provide COEP/CORP.


### PR DESCRIPTION
## Summary
- test CreateVideoForm directly trimming via WebCodecs and rejecting invalid videos
- document mp4/webm support, five-minute cap, and 9:16 requirement
- clean readme references to FFmpeg/WebM conversion

## Testing
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx` *(no tests found: excluded by config)*

------
https://chatgpt.com/codex/tasks/task_e_6897d12bf7048331955d26247e76cabf