### PR TITLE
fix: move locale check out of root layout

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -1,0 +1,30 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { notFound } from 'next/navigation';
+import { locales } from '@/utils/locales';
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export default async function LocaleLayout({
+  children,
+  params: { locale },
+}: {
+  children: React.ReactNode;
+  params: { locale: string };
+}) {
+  if (!locales.includes(locale as typeof locales[number])) {
+    notFound();
+  }
+
+  const messages = {
+    common: (await import(`@/locales/${locale}/common.json`)).default,
+  };
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
+

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,36 +1,19 @@
 import '../styles/globals.css';
 import Providers from './providers';
 import { LayoutProvider } from '@/context/LayoutContext';
-import { NextIntlClientProvider } from 'next-intl';
-import { locales } from '../utils/locales';
-import { notFound } from 'next/navigation';
 
-export function generateStaticParams() {
-  return locales.map((locale) => ({ locale }));
-}
-
-export default async function RootLayout({
+export default function RootLayout({
   children,
   params: { locale },
 }: {
   children: React.ReactNode;
-  params: { locale: string };
+  params: { locale?: string };
 }) {
-  if (!locales.includes(locale as typeof locales[number])) {
-    notFound();
-  }
-
-  const messages = {
-    common: (await import(`../locales/${locale}/common.json`)).default,
-  };
-
   return (
     <html lang={locale}>
       <body>
         <LayoutProvider>
-          <NextIntlClientProvider locale={locale} messages={messages}>
-            <Providers>{children}</Providers>
-          </NextIntlClientProvider>
+          <Providers>{children}</Providers>
         </LayoutProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- avoid calling `notFound()` in the root layout
- add a locale-aware layout that handles translations and invalid locales

## Testing
- `pnpm test` *(fails: Vitest caught 3 unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897d2cfe1488331aca4615f08489c4f