### PR TITLE
Initialize layout context after mount

### DIFF
--- a/apps/web/context/LayoutContext.tsx
+++ b/apps/web/context/LayoutContext.tsx
@@ -10,25 +10,35 @@ function getLayout(width: number): LayoutType {
   return 'mobile';
 }
 
-export const LayoutContext = createContext<LayoutType>('desktop');
+export const LayoutContext = createContext<LayoutType | null>(null);
 
 export function LayoutProvider({ children }: { children: React.ReactNode }) {
-  const [layout, setLayout] = useState<LayoutType>(() => {
-    if (typeof window === 'undefined') return 'desktop';
-    return getLayout(window.innerWidth);
+  const [layout, setLayout] = useState<LayoutType | null>(() => {
+    if (typeof window === 'undefined') return null;
+    const stored = window.localStorage.getItem('layout') as LayoutType | null;
+    return stored;
   });
 
   useEffect(() => {
-    const update = () => setLayout(getLayout(window.innerWidth));
+    const update = () => {
+      const value = getLayout(window.innerWidth);
+      setLayout(value);
+      window.localStorage.setItem('layout', value);
+    };
     update();
     window.addEventListener('resize', update);
     return () => window.removeEventListener('resize', update);
   }, []);
 
+  if (!layout) return null;
+
   return <LayoutContext.Provider value={layout}>{children}</LayoutContext.Provider>;
 }
 
 export function useLayout() {
-  return useContext(LayoutContext);
+  const layout = useContext(LayoutContext);
+  if (!layout) {
+    throw new Error('useLayout must be used within a LayoutProvider');
+  }
+  return layout;
 }
-


### PR DESCRIPTION
## Summary
- initialize layout context with `null` and compute client layout after mount
- block rendering until layout is known and enforce provider usage in `useLayout`
- persist last known layout in `localStorage` for faster startup

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6897d47503ec83318e66bf10e3e97809