### PR TITLE
Guard navigation prefetch by connection status

### DIFF
--- a/apps/web/components/layout/BottomNav.tsx
+++ b/apps/web/components/layout/BottomNav.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useCallback } from 'react';
 import NextLink from 'next/link';
 import { useRouter, usePathname, useSearchParams, useParams } from 'next/navigation';
 import { navigation } from '@/config/navigation';
@@ -22,6 +23,36 @@ export default function BottomNav() {
   const borderColor = useColorModeValue('gray.200', 'gray.700');
   const activeColor = useColorModeValue('blue.600', 'blue.300');
   const inactiveColor = useColorModeValue('gray.600', 'gray.400');
+
+  const prefetch = useCallback(
+    (path: string) => {
+      if (typeof navigator !== 'undefined' && navigator.onLine) {
+        router.prefetch(path);
+      }
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    const handlePrefetch = () => {
+      if (
+        typeof document !== 'undefined' &&
+        document.visibilityState === 'visible' &&
+        typeof navigator !== 'undefined' &&
+        navigator.onLine
+      ) {
+        navigation.forEach(({ path }) => router.prefetch(path));
+      }
+    };
+
+    handlePrefetch();
+    window.addEventListener('online', handlePrefetch);
+    document.addEventListener('visibilitychange', handlePrefetch);
+    return () => {
+      window.removeEventListener('online', handlePrefetch);
+      document.removeEventListener('visibilitychange', handlePrefetch);
+    };
+  }, [router]);
   if (layout === 'desktop') return null;
 
   return (
@@ -53,7 +84,7 @@ export default function BottomNav() {
             aria-label={label}
             aria-current={active ? 'page' : undefined}
             prefetch={false}
-            onMouseEnter={() => router.prefetch(path)}
+            onMouseEnter={() => prefetch(path)}
           >
             <Icon size={24} />
           </ChakraLink>

--- a/apps/web/components/layout/MainNav.tsx
+++ b/apps/web/components/layout/MainNav.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useEffect, useCallback } from 'react';
 import NextLink from 'next/link';
 import SearchBar from '@/components/SearchBar';
 import MiniProfileCard from '@/components/MiniProfileCard';
@@ -49,6 +50,36 @@ export default function MainNav({
   const activeColor = useColorModeValue('blue.600', 'blue.300');
   const hoverBg = useColorModeValue('blue.50', 'whiteAlpha.200');
 
+  const prefetch = useCallback(
+    (path: string) => {
+      if (typeof navigator !== 'undefined' && navigator.onLine) {
+        router.prefetch(path);
+      }
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    const handlePrefetch = () => {
+      if (
+        typeof document !== 'undefined' &&
+        document.visibilityState === 'visible' &&
+        typeof navigator !== 'undefined' &&
+        navigator.onLine
+      ) {
+        navigation.forEach(({ path }) => router.prefetch(path));
+      }
+    };
+
+    handlePrefetch();
+    window.addEventListener('online', handlePrefetch);
+    document.addEventListener('visibilitychange', handlePrefetch);
+    return () => {
+      window.removeEventListener('online', handlePrefetch);
+      document.removeEventListener('visibilitychange', handlePrefetch);
+    };
+  }, [router]);
+
   return (
     <VStack p="1.2rem" spacing={4} align="stretch">
       <ChakraLink as={NextLink} href="/" pl={5} prefetch>
@@ -80,7 +111,7 @@ export default function MainNav({
                 fontWeight="bold"
                 aria-current={active ? 'page' : undefined}
                 prefetch={false}
-                onMouseEnter={() => router.prefetch(path)}
+                onMouseEnter={() => prefetch(path)}
                 color={active ? activeColor : muted}
                 bg={active ? hoverBg : 'transparent'}
                 _hover={{ bg: hoverBg, color: activeColor }}


### PR DESCRIPTION
## Summary
- add reusable prefetch helper in `MainNav` and `BottomNav`
- prefetch navigation routes only when document is visible and device is online

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897d629161c8331a3a7ba344a0a4f68