### PR TITLE
feat: cache creator analytics for offline

### DIFF
--- a/apps/web/hooks/useCreatorAnalytics.ts
+++ b/apps/web/hooks/useCreatorAnalytics.ts
@@ -15,31 +15,98 @@ export default function useCreatorAnalytics(pubkey?: string) {
   const [data, setData] = useState<CreatorStats | null>(null);
   const [error, setError] = useState<any>(null);
   const [loading, setLoading] = useState<boolean>(false);
+  const [offline, setOffline] = useState<boolean>(
+    typeof navigator !== 'undefined' ? !navigator.onLine : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    function handleOnline() {
+      setOffline(false);
+    }
+    function handleOffline() {
+      setOffline(true);
+    }
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
 
   useEffect(() => {
     if (!pubkey) return;
+    let es: EventSource | null = null;
+
+    if (offline) {
+      setLoading(false);
+      if (typeof window !== 'undefined') {
+        try {
+          const raw = window.localStorage.getItem(`creator-analytics:${pubkey}`);
+          if (raw) setData(JSON.parse(raw));
+        } catch {
+          /* ignore */
+        }
+      }
+      return;
+    }
+
     setLoading(true);
+    setError(null);
     fetch(`/api/creator-stats?pubkey=${pubkey}`, { headers: { 'x-pubkey': pubkey } })
       .then((res) => {
         if (!res.ok) throw new Error(String(res.status));
         return res.json();
       })
-      .then((json) => setData(json))
+      .then((json) => {
+        setData(json);
+        if (typeof window !== 'undefined') {
+          try {
+            window.localStorage.setItem(
+              `creator-analytics:${pubkey}`,
+              JSON.stringify(json),
+            );
+          } catch {
+            /* ignore */
+          }
+        }
+      })
       .catch((err) => setError(err))
       .finally(() => setLoading(false));
 
-    const es = new EventSource(`/api/creator-stats?pubkey=${pubkey}&stream=1`);
+    es = new EventSource(`/api/creator-stats?pubkey=${pubkey}&stream=1`);
     es.onmessage = (ev) => {
       try {
-        setData(JSON.parse(ev.data));
+        const json = JSON.parse(ev.data);
+        setData(json);
+        if (typeof window !== 'undefined') {
+          try {
+            window.localStorage.setItem(
+              `creator-analytics:${pubkey}`,
+              JSON.stringify(json),
+            );
+          } catch {
+            /* ignore */
+          }
+        }
       } catch {
         /* ignore */
       }
     };
-    return () => {
-      es.close();
+    es.onerror = () => {
+      if (typeof navigator !== 'undefined' && !navigator.onLine) {
+        setOffline(true);
+      }
     };
-  }, [pubkey]);
 
-  return { data, error, loading };
+    return () => {
+      es?.close();
+    };
+  }, [pubkey, offline]);
+
+  return { data, error, loading, offline };
 }


### PR DESCRIPTION
## Summary
- cache creator analytics results in localStorage
- detect offline status and return cached stats
- reopen analytics stream and sync data when back online

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot set property navigator of #<Object>; ERR_WORKER_OUT_OF_MEMORY)*

------
https://chatgpt.com/codex/tasks/task_e_6897d958aa788331ac8e35e9ded3693c