### PR TITLE
Add next-intl configuration

### DIFF
--- a/apps/web/next-intl.config.ts
+++ b/apps/web/next-intl.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'next-intl';
+import {locales} from './utils/locales';
+
+export default defineConfig({
+  locales,
+  defaultLocale: 'en'
+});

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,5 +1,6 @@
 import withPWA from 'next-pwa';
 import runtimeCaching from 'next-pwa/cache.js';
+import createNextIntlPlugin from 'next-intl/plugin';
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -59,4 +60,8 @@ const withPWAConfig = withPWA({
   },
 });
 
-export default isProd ? withPWAConfig(baseConfig) : baseConfig;
+const withNextIntl = createNextIntlPlugin();
+
+const config = isProd ? withPWAConfig(baseConfig) : baseConfig;
+
+export default withNextIntl(config);


### PR DESCRIPTION
## Summary
- add next-intl config with supported locales
- wrap Next.js config with next-intl plugin

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897dba6df1c8331a65e8f51a733e4b5