### PR TITLE
fix: handle NDK pool status API change

### DIFF
--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -1,5 +1,5 @@
 'use client';
-import NDK, { NDKRelayStatus } from '@nostr-dev-kit/ndk';
+import NDK from '@nostr-dev-kit/ndk';
 import { getPublicKey } from 'nostr-tools/pure';
 import { hexToBytes } from 'nostr-tools/utils';
 import relaysConfig from '../relays.json';
@@ -29,8 +29,7 @@ async function connectNDK(attempt = 0): Promise<void> {
   setStatus('connecting');
   try {
     await ndk.connect();
-    const statuses = ndk.pool.status ? Array.from(ndk.pool.status.values()) : [];
-    if (!statuses.some((s) => s === NDKRelayStatus.CONNECTED)) {
+    if (ndk.pool.connectedRelays().length === 0) {
       throw new Error('No relays connected');
     }
     setStatus('connected');


### PR DESCRIPTION
## Summary
- check relay connections using `connectedRelays` instead of deprecated `pool.status`
- remove unused NDK relay status import

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897dd9ee1108331a4d7f16d06be3c72