### PR TITLE
feat(web): make root layout a client component

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,14 +1,17 @@
+"use client";
+
 import '../styles/globals.css';
 import Providers from './providers';
 import { LayoutProvider } from '@/context/LayoutContext';
+import { useParams } from 'next/navigation';
 
 export default function RootLayout({
   children,
-  params: { locale },
 }: {
   children: React.ReactNode;
-  params: { locale?: string };
 }) {
+  const { locale } = useParams<{ locale?: string }>();
+
   return (
     <html lang={locale}>
       <body>


### PR DESCRIPTION
## Summary
- make `apps/web/app/layout.tsx` a client component
- derive locale via `useParams` instead of server params

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*
- `pnpm --filter @paiduan/web build` *(fails: [next-intl] Could not locate request configuration module)*

------
https://chatgpt.com/codex/tasks/task_e_6897deb3fd50833185adf0b3615cd5ac