### PR TITLE
Add next-intl request configuration

### DIFF
--- a/apps/web/i18n/request.ts
+++ b/apps/web/i18n/request.ts
@@ -1,0 +1,10 @@
+import {getRequestConfig} from 'next-intl/server';
+
+export default getRequestConfig(async ({requestLocale}) => {
+  const locale = requestLocale ?? 'en';
+
+  return {
+    locale,
+    messages: (await import(`../locales/${locale}/common.json`)).default
+  };
+});


### PR DESCRIPTION
## Summary
- add missing next-intl request configuration file so locale messages load

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897df184c908331a319175f1dcc28af