### PR TITLE
Fix async locale resolution in i18n request config

### DIFF
--- a/apps/web/i18n/request.ts
+++ b/apps/web/i18n/request.ts
@@ -1,7 +1,7 @@
 import {getRequestConfig} from 'next-intl/server';
 
 export default getRequestConfig(async ({requestLocale}) => {
-  const locale = requestLocale ?? 'en';
+  const locale = (await requestLocale) ?? 'en';
 
   return {
     locale,


### PR DESCRIPTION
## Summary
- await `requestLocale` before loading locale messages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6897e10e96cc833183b0dc1135766f63