### PR TITLE
feat(web): add root error boundary

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from 'react';
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error }: ErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const isChunkError =
+    error.name === 'ChunkLoadError' || /loading chunk/i.test(error.message);
+
+  const reload = () => window.location.reload();
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4 text-center">
+      {isChunkError ? (
+        <>
+          <h2 className="mb-4 text-2xl font-semibold">
+            A new version is available
+          </h2>
+          <p className="mb-6">Please reload the page to continue.</p>
+        </>
+      ) : (
+        <h2 className="mb-6 text-2xl font-semibold">Something went wrong</h2>
+      )}
+      <button onClick={reload} className="btn btn-primary">
+        Reload
+      </button>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- handle failed chunk loads by showing a refresh prompt
- provide global error page with reload button

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897e7f1ba6483318f774ba7bb16ef39