### PR TITLE
feat: version service worker precache

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ pnpm --filter @paiduan/web build
 pnpm --filter @paiduan/web build:pwa
 ```
 
+After updating client bundles, bump `CACHE_VERSION` in `apps/web/public/sw.js` so
+new deployments invalidate old precaches and prevent `ChunkLoadError`.
+
 Open the app and choose **Install** (or **Add to Home Screen**) to install it.
 
 ## CDN configuration


### PR DESCRIPTION
## Summary
- version precache and runtime caches in service worker
- clean up old caches on activate
- document bumping service worker cache version during builds

## Testing
- `pnpm test` *(fails: Vitest caught unhandled errors and worker out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6897ea2e79188331b62815f536476185