### PR TITLE
fix: stabilize layout context for SSR

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,19 +1,18 @@
-"use client";
-
 import '../styles/globals.css';
 import Providers from './providers';
 import { LayoutProvider } from '@/context/LayoutContext';
-import { useParams } from 'next/navigation';
 
 export default function RootLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: { locale?: string };
 }) {
-  const { locale } = useParams<{ locale?: string }>();
+  const { locale } = params;
 
   return (
-    <html lang={locale}>
+    <html lang={locale} suppressHydrationWarning>
       <body>
         <LayoutProvider>
           <Providers>{children}</Providers>

--- a/apps/web/context/LayoutContext.tsx
+++ b/apps/web/context/LayoutContext.tsx
@@ -17,15 +17,32 @@ export function LayoutProvider({ children }: { children: React.ReactNode }) {
   const [layout, setLayout] = useState<LayoutType>('mobile');
 
   useEffect(() => {
-    const stored = window.localStorage.getItem('layout') as LayoutType | null;
-    const initial = stored ?? getLayout(window.innerWidth);
+    // Restore last chosen layout from localStorage so offline launches
+    // still render using the previous preference.
+    const readStored = () => {
+      try {
+        return window.localStorage.getItem('layout') as LayoutType | null;
+      } catch {
+        return null;
+      }
+    };
+
+    const writeStored = (value: LayoutType) => {
+      try {
+        window.localStorage.setItem('layout', value);
+      } catch {
+        // ignore storage write failures (e.g. quota exceeded, private mode)
+      }
+    };
+
+    const initial = readStored() ?? getLayout(window.innerWidth);
     setLayout(initial);
-    window.localStorage.setItem('layout', initial);
+    writeStored(initial);
 
     const handleResize = () => {
       const value = getLayout(window.innerWidth);
       setLayout(value);
-      window.localStorage.setItem('layout', value);
+      writeStored(value);
     };
 
     window.addEventListener('resize', handleResize);


### PR DESCRIPTION
## Summary
- prevent LayoutContext from reading `window` during initial render to avoid hydration mismatch
- convert app layout to server component and forward locale params

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest caught 2 unhandled errors during the test run)*

------
https://chatgpt.com/codex/tasks/task_e_6897f19cba908331a12c5cb1d96aaae4