### PR TITLE
feat(web): include orientation in layout

### DIFF
--- a/apps/web/context/LayoutContext.tsx
+++ b/apps/web/context/LayoutContext.tsx
@@ -4,8 +4,10 @@ import { createContext, useContext, useEffect, useState } from 'react';
 
 export type LayoutType = 'desktop' | 'tablet' | 'mobile';
 
-function getLayout(width: number): LayoutType {
-  if (width >= 1024) return 'desktop';
+function getLayout(width: number, height: number): LayoutType {
+  const isPortrait = height >= width;
+  const desktopWidth = isPortrait ? 1280 : 1024;
+  if (width >= desktopWidth) return 'desktop';
   if (width >= 640) return 'tablet';
   return 'mobile';
 }
@@ -35,18 +37,23 @@ export function LayoutProvider({ children }: { children: React.ReactNode }) {
       }
     };
 
-    const initial = readStored() ?? getLayout(window.innerWidth);
+    const initial = readStored() ?? getLayout(window.innerWidth, window.innerHeight);
     setLayout(initial);
     writeStored(initial);
 
     const handleResize = () => {
-      const value = getLayout(window.innerWidth);
+      const value = getLayout(window.innerWidth, window.innerHeight);
       setLayout(value);
       writeStored(value);
     };
 
+    const mql = window.matchMedia('(orientation: portrait)');
+    mql.addEventListener('change', handleResize);
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    return () => {
+      mql.removeEventListener('change', handleResize);
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   return <LayoutContext.Provider value={layout}>{children}</LayoutContext.Provider>;


### PR DESCRIPTION
## Summary
- adjust layout calculation to consider orientation, defaulting portrait to tablet unless very wide
- listen for orientation changes and recompute layout on change or resize

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test apps/web` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897f7ab534483318388d50cb1bb1a8e