### PR TITLE
feat: configure video player looping declaratively

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -196,11 +196,17 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         poster={posterUrl}
         controls={false}
         playsinline
+        loop
         onReady={(player) => {
           playerRef.current = player;
-          player.loop(true);
-          player.muted(true);
-          player.play();
+          if (typeof (player as any).muted === 'function') {
+            (player as any).muted(true);
+          } else {
+            (player as any).muted = true;
+          }
+          if (typeof (player as any).play === 'function') {
+            (player as any).play();
+          }
         }}
         onError={() => setVideoError(true)}
       />


### PR DESCRIPTION
## Summary
- configure video looping declaratively via `loop` prop
- guard player mute/play calls to avoid runtime errors

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`
- `node /tmp/test_loop.js`

------
https://chatgpt.com/codex/tasks/task_e_6897f5f0ffc48331b81b3508afaf6c3e