### PR TITLE
feat: responsive layout with collapsible right panel

### DIFF
--- a/apps/web/components/feed/RightPanel.test.tsx
+++ b/apps/web/components/feed/RightPanel.test.tsx
@@ -1,0 +1,43 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import RightPanel from '@/components/feed/RightPanel';
+import { LayoutContext } from '@/context/LayoutContext';
+
+vi.mock('@chakra-ui/react', () => {
+  const React = require('react');
+  return {
+    Box: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+    Stack: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Drawer: ({ children, ...props }: any) => <div data-drawer {...props}>{children}</div>,
+    DrawerOverlay: ({ children, ...props }: any) => <div data-overlay {...props}>{children}</div>,
+    DrawerContent: ({ children, ...props }: any) => <div data-content {...props}>{children}</div>,
+    DrawerBody: ({ children, ...props }: any) => <div data-body {...props}>{children}</div>,
+    useColorModeValue: (v: any) => v,
+  };
+});
+
+vi.mock('next/link', () => ({ default: (props: any) => <a {...props} /> }));
+vi.mock('next/image', () => ({ default: (props: any) => <img {...props} /> }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ prefetch: () => {} }) }));
+vi.mock('@/store/feedSelection', () => ({
+  useFeedSelection: () => ({ selectedVideoId: undefined, selectedVideoAuthor: undefined }),
+}));
+
+(globalThis as any).React = React;
+
+describe('RightPanel', () => {
+  it('renders in a drawer when forced', () => {
+    const author = { avatar: '/a.jpg', name: 'A', username: 'a', pubkey: 'pk', followers: 1 };
+    const html = renderToStaticMarkup(
+      <LayoutContext.Provider value="desktop">
+        <RightPanel author={author} onFilterByAuthor={() => {}} forceDrawer />
+      </LayoutContext.Provider>,
+    );
+    expect(html).toContain('data-drawer');
+  });
+});
+

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -21,14 +21,16 @@ import {
 export default function RightPanel({
   author,
   onFilterByAuthor,
+  forceDrawer = false,
 }: {
   author?: { avatar: string; name: string; username: string; pubkey: string; followers: number };
   onFilterByAuthor: (pubkey: string) => void;
+  forceDrawer?: boolean;
 }) {
   const { selectedVideoId, selectedVideoAuthor } = useFeedSelection();
   const router = useRouter();
   const layout = useLayout();
-  const isDesktop = layout === 'desktop';
+  const isDesktop = layout === 'desktop' && !forceDrawer;
   const borderColor = useColorModeValue('gray.200', 'gray.700');
   const cardBg = useColorModeValue('white', 'gray.800');
 

--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -2,7 +2,13 @@
 import React from 'react';
 import BottomNav from './BottomNav';
 import { useLayout } from '@/context/LayoutContext';
-import { Grid, GridItem, Box, useColorModeValue } from '@chakra-ui/react';
+import {
+  Grid,
+  GridItem,
+  Box,
+  useBreakpointValue,
+  useColorModeValue,
+} from '@chakra-ui/react';
 
 export default function AppShell({
   left,
@@ -16,10 +22,37 @@ export default function AppShell({
   const layout = useLayout();
   const isDesktop = layout === 'desktop';
   const hasRight = !!right;
+
+  // Responsive column widths
+  const leftColumnWidth = useBreakpointValue({
+    base: '0px',
+    lg: 'clamp(240px, 20vw, 300px)',
+  });
+  const rightColumnWidth = useBreakpointValue({
+    base: '0px',
+    lg: 'clamp(280px, 25vw, 400px)',
+  });
+
+  // Numeric widths for layout calculations
+  const leftWidthPx = useBreakpointValue({ base: 0, lg: 260 });
+  const rightWidthPx = useBreakpointValue({ base: 0, lg: 360 });
+
+  const [windowWidth, setWindowWidth] = React.useState(0);
+  React.useEffect(() => {
+    const handle = () => setWindowWidth(window.innerWidth);
+    handle();
+    window.addEventListener('resize', handle);
+    return () => window.removeEventListener('resize', handle);
+  }, []);
+
+  const containerWidth = Math.min(windowWidth, 1400);
+  const feedWidth = containerWidth - (leftWidthPx ?? 0) - (hasRight ? rightWidthPx ?? 0 : 0);
+  const collapseRight = hasRight && feedWidth < 640;
+
   const templateColumns = isDesktop
-    ? hasRight
-      ? '300px 1fr 400px'
-      : '300px 1fr'
+    ? hasRight && !collapseRight
+      ? `${leftColumnWidth} 1fr ${rightColumnWidth}`
+      : `${leftColumnWidth} 1fr`
     : '1fr';
   const bg = useColorModeValue('gray.50', 'gray.900');
   const surface = useColorModeValue('white', 'gray.800');
@@ -59,7 +92,7 @@ export default function AppShell({
         </GridItem>
 
         {/* Right column: author info & comments (sticky on desktop) */}
-        {hasRight && isDesktop && (
+        {hasRight && isDesktop && !collapseRight && (
           <GridItem
             as="aside"
             borderLeft="1px"
@@ -69,11 +102,20 @@ export default function AppShell({
             h="100vh"
             overflowY="auto"
           >
-            {right}
+            {React.isValidElement(right)
+              ? React.cloneElement(right as React.ReactElement<any>, {
+                  forceDrawer: collapseRight,
+                })
+              : right}
           </GridItem>
         )}
       </Grid>
-      {hasRight && !isDesktop && right}
+      {hasRight && (!isDesktop || collapseRight) &&
+        (React.isValidElement(right)
+          ? React.cloneElement(right as React.ReactElement<any>, {
+              forceDrawer: collapseRight,
+            })
+          : right)}
       {layout !== 'desktop' && <BottomNav />}
     </Box>
   );


### PR DESCRIPTION
## Summary
- use Chakra responsive values for AppShell columns and collapse right panel when feed gets narrow
- add `forceDrawer` option to RightPanel for drawer fallback
- cover RightPanel drawer behaviour with a unit test

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` *(fails: Vitest caught unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897fa0e47548331a0a10f94b47f0904