### PR TITLE
Add MIME types and error logging in VideoCard

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -76,6 +76,12 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const setSelectedVideo = useFeedSelection((s) => s.setSelectedVideo);
 
   useEffect(() => {
+    if (!videoError) return;
+    const err = playerRef.current?.error();
+    if (err) console.error('Video playback error:', err);
+  }, [videoError]);
+
+  useEffect(() => {
     if (inView) {
       setCurrent({ eventId, pubkey, caption, posterUrl });
       setSelectedVideo(eventId, pubkey);
@@ -192,7 +198,12 @@ export const VideoCard: React.FC<VideoCardProps> = ({
     >
       <VideoJsPlayer
         className="video-js pointer-events-none absolute inset-0 h-full w-full object-cover"
-        sources={[{ src: manifestUrl ? adaptiveUrl || videoUrl : videoUrl }]}
+        sources={[
+          {
+            src: manifestUrl ? adaptiveUrl || videoUrl : videoUrl,
+            type: manifestUrl ? 'application/x-mpegURL' : 'video/mp4',
+          },
+        ]}
         poster={posterUrl}
         controls={false}
         playsinline


### PR DESCRIPTION
## Summary
- provide explicit MIME types in video.js `sources` array
- log persistent player errors for debugging

## Testing
- `pnpm lint --filter @paiduan/web`
- `NODE_OPTIONS=--max_old_space_size=4096 pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6897fb776d308331b3c4f01180bb5a54