### PR TITLE
feat: add scroll snap to feed

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -59,7 +59,10 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   }
 
   return (
-    <div ref={parentRef} className="relative h-full w-full overflow-auto">
+    <div
+      ref={parentRef}
+      className="relative h-full w-full overflow-auto snap-y snap-mandatory scrollbar-none"
+    >
       <div
         style={{
           height: rowVirtualizer.getTotalSize(),
@@ -73,7 +76,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
             <div
               key={item.eventId ?? virtualRow.index}
               ref={rowVirtualizer.measureElement}
-              className="absolute top-0 left-0 w-full"
+              className="absolute top-0 left-0 w-full snap-start"
               style={{
                 transform: `translateY(${virtualRow.start}px)`,
                 height: `${virtualRow.size}px`,

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -56,6 +56,13 @@ body {
   .break-inside-avoid {
     break-inside: avoid;
   }
+  .scrollbar-none {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-none::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- add scroll snapping and hidden scrollbar to feed
- add utility class for hiding scrollbars

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6897fd8e1bfc83319bb158997bf98119