### PR TITLE
Fix VideoCard source selection for HLS vs MP4 playback

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -180,6 +180,9 @@ export const VideoCard: React.FC<VideoCardProps> = ({
     }
   };
 
+  const source = adaptiveUrl ? adaptiveUrl : videoUrl;
+  const mime = adaptiveUrl ? 'application/x-mpegURL' : 'video/mp4';
+
   return (
     <motion.div
       ref={(el) => {
@@ -198,12 +201,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
     >
       <VideoJsPlayer
         className="video-js pointer-events-none absolute inset-0 h-full w-full object-cover"
-        sources={[
-          {
-            src: manifestUrl ? adaptiveUrl || videoUrl : videoUrl,
-            type: manifestUrl ? 'application/x-mpegURL' : 'video/mp4',
-          },
-        ]}
+        sources={[{ src: source, type: mime }]}
         poster={posterUrl}
         controls={false}
         playsinline


### PR DESCRIPTION
## Summary
- choose actual source and MIME type before rendering VideoJsPlayer
- allow VideoCard to play both HLS manifests and MP4 URLs reliably

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ff780dbc8331836da9cbe0919149