### PR TITLE
Fix video error handling in VideoCard

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -77,7 +77,11 @@ export const VideoCard: React.FC<VideoCardProps> = ({
 
   useEffect(() => {
     if (!videoError) return;
-    const err = playerRef.current?.error();
+    const player = playerRef.current;
+    const err =
+      player && typeof (player as any).error === 'function'
+        ? (player as any).error()
+        : (player as any)?.error;
     if (err) console.error('Video playback error:', err);
   }, [videoError]);
 


### PR DESCRIPTION
## Summary
- check video.js error function/property before logging

## Testing
- `pnpm test` *(fails: Error: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689800ccc3388331b3ab6863b1567000