### PR TITLE
chore: init ColorModeScript before hydration

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,8 @@
 import '../styles/globals.css';
 import Providers from './providers';
 import { LayoutProvider } from '@/context/LayoutContext';
+import { ColorModeScript } from '@chakra-ui/react';
+import theme from '../styles/theme';
 
 export default function RootLayout({
   children,
@@ -13,7 +15,8 @@ export default function RootLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body>
+      <body suppressHydrationWarning>
+        <ColorModeScript initialColorMode={theme.config.initialColorMode} />
         <LayoutProvider>
           <Providers>{children}</Providers>
         </LayoutProvider>

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
 import theme from '../styles/theme';
 import { ThemeProvider } from 'next-themes';
 import { ModqueueProvider } from '@/context/modqueueContext';
@@ -13,7 +13,6 @@ import { NotificationsProvider } from '@/hooks/useNotifications';
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ChakraProvider theme={theme}>
-      <ColorModeScript initialColorMode={theme.config.initialColorMode} />
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
         <GestureProvider>
           <ModqueueProvider>


### PR DESCRIPTION
## Summary
- render Chakra UI ColorModeScript in root layout before hydration
- remove duplicate ColorModeScript from providers

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6898024eebbc8331b87a0d9575535c77