### PR TITLE
feat(web): cache follower counts

### DIFF
--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -7,7 +7,7 @@ import Feed from '@/components/Feed';
 import useFeed from '@/hooks/useFeed';
 import { useAuth } from '@/hooks/useAuth';
 import useFollowing from '@/hooks/useFollowing';
-import useFollowers from '@/hooks/useFollowers';
+import useFollowerCount from '@/hooks/useFollowerCount';
 import { useProfile } from '@/hooks/useProfile';
 import { useFeedSelection } from '@/store/feedSelection';
 import { CurrentVideoProvider } from '@/hooks/useCurrentVideo';
@@ -22,8 +22,10 @@ export default function FeedPage() {
   const { following } = useFollowing(
     auth.status === 'ready' ? auth.pubkey : undefined,
   );
-  const myFollowers = useFollowers(auth.status === 'ready' ? auth.pubkey : undefined);
-  const authorFollowers = useFollowers(selectedVideoAuthor);
+  const myFollowerCount = useFollowerCount(
+    auth.status === 'ready' ? auth.pubkey : undefined,
+  );
+  const authorFollowerCount = useFollowerCount(selectedVideoAuthor);
   const meProfile = useProfile(auth.status === 'ready' ? auth.pubkey : undefined);
   const me =
     auth.status === 'ready'
@@ -31,7 +33,7 @@ export default function FeedPage() {
           avatar: meProfile?.picture || `/api/avatar/${auth.pubkey}`,
           name: meProfile?.name || auth.pubkey.slice(0, 8),
           username: meProfile?.name || auth.pubkey.slice(0, 8),
-          stats: { followers: myFollowers.length, following: following.length },
+          stats: { followers: myFollowerCount, following: following.length },
         }
       : {
           avatar: '/api/avatar/me',
@@ -48,7 +50,7 @@ export default function FeedPage() {
           name: authorProfile.name || selectedVideoAuthor.slice(0, 8),
           username: authorProfile.name || selectedVideoAuthor.slice(0, 8),
           pubkey: selectedVideoAuthor,
-          followers: authorFollowers.length,
+          followers: authorFollowerCount,
         }
       : undefined;
 

--- a/apps/web/app/p/[pubkey]/page.tsx
+++ b/apps/web/app/p/[pubkey]/page.tsx
@@ -8,7 +8,7 @@ import type { Filter } from 'nostr-tools/filter';
 import { toast } from 'react-hot-toast';
 import VideoCard, { VideoCardProps } from '@/components/VideoCard';
 import useFollowing from '@/hooks/useFollowing';
-import useFollowers from '@/hooks/useFollowers';
+import useFollowerCount from '@/hooks/useFollowerCount';
 import SearchBar from '@/components/SearchBar';
 import { useAuth } from '@/hooks/useAuth';
 import { getRelays } from '@/lib/nostr';
@@ -26,7 +26,7 @@ export default function ProfilePage() {
   const { following, follow, unfollow } = useFollowing(
     state.status === 'ready' ? state.pubkey : undefined,
   );
-  const followers = useFollowers(pubkey);
+  const followerCount = useFollowerCount(pubkey);
 
   const isFollowing = pubkey ? following.includes(pubkey) : false;
 
@@ -178,7 +178,7 @@ export default function ProfilePage() {
             >
               {isFollowing ? 'Unfollow' : 'Follow'}
             </button>
-            <div className="text-sm">{followers.length} followers</div>
+            <div className="text-sm">{followerCount} followers</div>
           </div>
         </div>
       </div>

--- a/apps/web/hooks/useFollowerCount.test.tsx
+++ b/apps/web/hooks/useFollowerCount.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+vi.mock('@/lib/relayPool', () => ({
+  default: {
+    subscribeMany: vi.fn((_relays: any, _filters: any, opts: any) => {
+      setTimeout(() => {
+        opts.onevent({ pubkey: 'pk1' });
+        opts.onevent({ pubkey: 'pk2' });
+        setTimeout(() => opts.oneose && opts.oneose(), 0);
+      }, 0);
+      return { close: vi.fn() };
+    }),
+  },
+}));
+vi.mock('@/lib/nostr', () => ({ getRelays: () => ['wss://example.com'] }));
+
+import useFollowerCount from './useFollowerCount';
+import pool from '@/lib/relayPool';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'https://example.com',
+});
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).navigator = dom.window.navigator;
+
+function TestComponent() {
+  const count = useFollowerCount('me');
+  return <div data-count={count}></div>;
+}
+
+describe('useFollowerCount', () => {
+  const subscribeMany = vi.mocked(pool.subscribeMany);
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    subscribeMany.mockClear();
+  });
+
+  it('caches follower count and avoids repeat subscriptions', async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(subscribeMany).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('div')?.getAttribute('data-count')).toBe('2');
+    root.unmount();
+
+    const container2 = document.createElement('div');
+    const root2 = createRoot(container2);
+    await act(async () => {
+      root2.render(<TestComponent />);
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(subscribeMany).toHaveBeenCalledTimes(1);
+    expect(container2.querySelector('div')?.getAttribute('data-count')).toBe('2');
+  });
+});

--- a/apps/web/hooks/useFollowerCount.ts
+++ b/apps/web/hooks/useFollowerCount.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import { useEffect, useState } from 'react';
 import * as nostrKinds from 'nostr-tools/kinds';
 import type { Filter } from 'nostr-tools/filter';
@@ -26,13 +27,14 @@ function loadCache(pubkey: string): FollowerCache | null {
   }
 }
 
-export function useFollowers(pubkey?: string) {
-  const [followers, setFollowers] = useState<string[]>([]);
+export function useFollowerCount(pubkey?: string) {
+  const [count, setCount] = useState(0);
+
   useEffect(() => {
     if (!pubkey) return;
     const cached = loadCache(pubkey);
-    if (cached?.list) {
-      setFollowers(cached.list);
+    if (cached) {
+      setCount(cached.count);
       return;
     }
     const seen = new Set<string>();
@@ -40,10 +42,10 @@ export function useFollowers(pubkey?: string) {
       getRelays(),
       [{ kinds: [nostrKinds.Contacts], '#p': [pubkey] } as Filter],
       {
-        onevent: (ev) => {
+        onevent: (ev: any) => {
           if (!seen.has(ev.pubkey)) {
             seen.add(ev.pubkey);
-            setFollowers(Array.from(seen));
+            setCount(seen.size);
           }
         },
         oneose: () => {
@@ -64,7 +66,8 @@ export function useFollowers(pubkey?: string) {
     );
     return () => sub.close();
   }, [pubkey]);
-  return followers;
+
+  return count;
 }
 
-export default useFollowers;
+export default useFollowerCount;


### PR DESCRIPTION
## Summary
- add `useFollowerCount` hook that caches follower totals in localStorage
- reuse cache in `useFollowers` and close subs after EOSE
- switch feed and profile pages to `useFollowerCount`

## Testing
- `pnpm test apps/web/hooks/useFollowerCount.test.tsx`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6898038d56e8833193ea337a4b25c46f