### PR TITLE
refactor: separate chakra theme config

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,7 +2,7 @@ import '../styles/globals.css';
 import Providers from './providers';
 import { LayoutProvider } from '@/context/LayoutContext';
 import { ColorModeScript } from '@chakra-ui/react';
-import theme from '../styles/theme';
+import themeConfig from '../styles/theme-config';
 
 export default function RootLayout({
   children,
@@ -16,7 +16,7 @@ export default function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <body suppressHydrationWarning>
-        <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+        <ColorModeScript initialColorMode={themeConfig.initialColorMode} />
         <LayoutProvider>
           <Providers>{children}</Providers>
         </LayoutProvider>

--- a/apps/web/styles/theme-config.ts
+++ b/apps/web/styles/theme-config.ts
@@ -1,0 +1,9 @@
+import type { ThemeConfig } from '@chakra-ui/react';
+
+const themeConfig: ThemeConfig = {
+  initialColorMode: 'light',
+  useSystemColorMode: true,
+};
+
+export default themeConfig;
+

--- a/apps/web/styles/theme.ts
+++ b/apps/web/styles/theme.ts
@@ -1,10 +1,9 @@
-import { extendTheme, ThemeConfig } from '@chakra-ui/react';
+'use client';
 
-const config: ThemeConfig = {
-  initialColorMode: 'light',
-  useSystemColorMode: true,
-};
+import { extendTheme } from '@chakra-ui/react';
+import themeConfig from './theme-config';
 
-const theme = extendTheme({ config });
+const theme = extendTheme({ config: themeConfig });
 
 export default theme;
+


### PR DESCRIPTION
## Summary
- split Chakra theme config into server-safe module
- create client theme using extendTheme
- reference theme config in RootLayout color mode script

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689803e00910833180582f3c2989b8db