### PR TITLE
feat(web): add Nostr comments agent and hook

### DIFF
--- a/apps/web/agents/nostr.comments.ts
+++ b/apps/web/agents/nostr.comments.ts
@@ -1,0 +1,60 @@
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+import type { Signer } from '@/lib/signers/types';
+import pool from '@/lib/relayPool';
+import { getRelays } from '@/lib/nostr';
+
+export function subscribe(
+  videoId: string,
+  onEvent: (ev: NostrEvent) => void,
+  onHide?: (id: string) => void,
+): { close: () => void } {
+  const relays = getRelays();
+  const sub = pool.subscribeMany(relays, [{ kinds: [1], '#e': [videoId] }], {
+    onevent: onEvent,
+  });
+
+  let hideSub: { close: () => void } | undefined;
+  if (onHide) {
+    hideSub = pool.subscribeMany(relays, [{ kinds: [9001] }], {
+      onevent: (ev: NostrEvent) => {
+        const tag = ev.tags.find((t) => t[0] === 'e');
+        if (tag) onHide(tag[1]);
+      },
+    });
+  }
+
+  return {
+    close: () => {
+      sub.close();
+      hideSub?.close();
+    },
+  };
+}
+
+export async function sendComment(
+  videoId: string,
+  content: string,
+  signer: Signer,
+  replyTo?: NostrEvent,
+): Promise<NostrEvent> {
+  const relays = getRelays();
+  const pubkey = await signer.getPublicKey();
+  const tags: string[][] = [["e", videoId]];
+  if (replyTo) {
+    tags.push(["e", replyTo.id]);
+    tags.push(["p", replyTo.pubkey]);
+  }
+  const event: any = {
+    kind: 1,
+    created_at: Math.floor(Date.now() / 1000),
+    tags,
+    content,
+    pubkey,
+  };
+  const signed = await signer.signEvent(event);
+  await pool.publish(relays, signed);
+  return signed;
+}
+
+export const comments = { subscribe, sendComment };
+export default comments;

--- a/apps/web/agents/nostr.ts
+++ b/apps/web/agents/nostr.ts
@@ -2,6 +2,7 @@ import type { Event as NostrEvent, EventTemplate } from 'nostr-tools/pure';
 import type { Signer } from '@/lib/signers/types';
 import pool from '@/lib/relayPool';
 import { getRelays } from '@/lib/nostr';
+import comments from './nostr.comments';
 
 /**
  * Repost a Nostr event by ID.
@@ -60,6 +61,7 @@ export async function repost({
 
 export const nostr = {
   repost,
+  comments,
 };
 
 export default nostr;

--- a/apps/web/hooks/useComments.ts
+++ b/apps/web/hooks/useComments.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Event as NostrEvent } from 'nostr-tools/pure';
+import { useAuth } from './useAuth';
+import { nostr } from '@/agents/nostr';
+
+export function useComments(videoId: string) {
+  const { state } = useAuth();
+  const [comments, setComments] = useState<NostrEvent[]>([]);
+  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setComments([]);
+    setHiddenIds(new Set());
+    const sub = nostr.comments.subscribe(
+      videoId,
+      (ev) => {
+        setComments((prev) => {
+          if (prev.find((p) => p.id === ev.id)) return prev;
+          return [...prev, ev].sort((a, b) => a.created_at - b.created_at);
+        });
+      },
+      (id) => setHiddenIds((prev) => new Set(prev).add(id)),
+    );
+    return () => sub.close();
+  }, [videoId]);
+
+  const send = useCallback(
+    async (content: string, replyTo?: NostrEvent) => {
+      if (state.status !== 'ready') throw new Error('signer required');
+      const signed = await nostr.comments.sendComment(
+        videoId,
+        content,
+        state.signer,
+        replyTo,
+      );
+      setComments((prev) => [...prev, signed].sort((a, b) => a.created_at - b.created_at));
+    },
+    [videoId, state],
+  );
+
+  return { comments, hiddenIds, send, canSend: state.status === 'ready' };
+}
+
+export default useComments;


### PR DESCRIPTION
## Summary
- create `nostr.comments` agent with subscribe and send helpers
- add `useComments` hook to surface comment data to components
- refactor `CommentDrawer` to rely on hook instead of direct relay usage

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_68980ef95b808331a3127c3021b83703