### PR TITLE
Dispose video.js player on unmount

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -52,6 +52,12 @@ export const VideoCard: React.FC<VideoCardProps> = ({
 }) => {
   const router = useRouter();
   const playerRef = useRef<videojs.Player | null>(null);
+  useEffect(() => {
+    return () => {
+      playerRef.current?.dispose();
+      playerRef.current = null;
+    };
+  }, []);
   const containerRef = useRef<HTMLDivElement>(null);
   const [muted, setMuted] = useState(true);
   const [speedMode, setSpeedMode] = useState(false);


### PR DESCRIPTION
## Summary
- dispose video.js player when VideoCard unmounts to release resources

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6898101d9ba4833195d81221d04971e1