### PR TITLE
Convert CommentDrawer into controlled component with optional autofocus

### DIFF
--- a/apps/web/components/CommentDrawer.stories.tsx
+++ b/apps/web/components/CommentDrawer.stories.tsx
@@ -7,12 +7,16 @@ const meta = { title: 'Overlays/CommentDrawer' };
 export default meta;
 
 const Template = (layout: LayoutType) => {
-  const Story = () => (
-    <LayoutContext.Provider value={layout}>
-      <OverlayHost />
-      <button onClick={() => CommentDrawer({ videoId: 'video1' })}>Open</button>
-    </LayoutContext.Provider>
-  );
+  const Story = () => {
+    const [open, setOpen] = React.useState(false);
+    return (
+      <LayoutContext.Provider value={layout}>
+        <OverlayHost />
+        <button onClick={() => setOpen(true)}>Open</button>
+        <CommentDrawer videoId="video1" open={open} onOpenChange={setOpen} />
+      </LayoutContext.Provider>
+    );
+  };
   Story.displayName = 'CommentDrawerStory';
   return Story;
 };

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -58,6 +58,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const [seekPreview, setSeekPreview] = useState(0);
   const adaptiveUrl = useAdaptiveSource(manifestUrl, playerRef);
   const [commentCount, setCommentCount] = useState(0);
+  const [commentsOpen, setCommentsOpen] = useState(false);
   const [reposted, setReposted] = useState(false);
   const holdTimer = useRef<number>();
   const [{ opacity }, api] = useSpring(() => ({ opacity: 0 }));
@@ -302,13 +303,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         </button>
         <button
           className="relative hover:text-accent-primary disabled:opacity-50 lg:hidden"
-          onClick={() =>
-            online &&
-            CommentDrawer({
-              videoId: eventId,
-              onCountChange: setCommentCount,
-            })
-          }
+          onClick={() => online && setCommentsOpen(true)}
           disabled={!online}
           title={!online ? 'Offline – reconnect to interact.' : undefined}
         >
@@ -317,6 +312,13 @@ export const VideoCard: React.FC<VideoCardProps> = ({
             <span className="absolute -right-2 -top-2 text-xs text-primary">{commentCount}</span>
           )}
         </button>
+        <CommentDrawer
+          videoId={eventId}
+          onCountChange={setCommentCount}
+          open={commentsOpen}
+          onOpenChange={setCommentsOpen}
+          autoFocus={false}
+        />
         <ZapButton
           lightningAddress={lightningAddress}
           eventId={eventId}

--- a/apps/web/components/ui/Overlay.tsx
+++ b/apps/web/components/ui/Overlay.tsx
@@ -7,6 +7,7 @@ export type OverlayKind = 'modal' | 'drawer';
 interface OverlayProps {
   content: ReactNode;
   onClose?: () => void;
+  autoFocus?: boolean;
 }
 
 interface OverlayState {
@@ -42,7 +43,14 @@ export function OverlayHost() {
     <Dialog.Root open onOpenChange={(o) => !o && closeHandler()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50" />
-        <Dialog.Content className={contentClass}>{state.props.content}</Dialog.Content>
+        <Dialog.Content
+          className={contentClass}
+          onOpenAutoFocus={(e) => {
+            if (state.props.autoFocus === false) e.preventDefault();
+          }}
+        >
+          {state.props.content}
+        </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
   );


### PR DESCRIPTION
## Summary
- Replace function-based `CommentDrawer` with `<CommentDrawer />` component that opens via `open` prop
- Add optional autofocus handling to Overlay and allow disabling focus on drawer open
- Update `VideoCard` and storybook usage to control the drawer and respect new API

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689810cecee083318ea751886c33f651