### PR TITLE
chore(sw): load workbox from CDN

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,10 +1,5 @@
-try {
-  // Use a relative path so the service worker can locate the bundled
-  // Workbox script regardless of the deployment base path.
-  importScripts('./workbox-sw.js');
-} catch (err) {
-  importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.3.0/workbox-sw.js');
-}
+// Use CDN-hosted Workbox script to avoid path issues on sub-path deployments.
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.3.0/workbox-sw.js');
 
 workbox.loadModule('workbox-routing');
 workbox.loadModule('workbox-strategies');


### PR DESCRIPTION
## Summary
- use CDN-hosted Workbox script in the service worker to avoid base-path 404s

## Testing
- `pnpm --filter @paiduan/web build` *(fails: Export encountered an error on /create/page)*
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*
- `curl http://localhost:3000/sw.js | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689811dd0cac8331b85e01b4af4f0dc7