### PR TITLE
Handle NDK connection failures without throwing

### DIFF
--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -30,7 +30,11 @@ async function connectNDK(attempt = 0): Promise<void> {
   try {
     await ndk.connect();
     if (ndk.pool.connectedRelays().length === 0) {
-      throw new Error('No relays connected');
+      console.warn('NDK connected with zero relays');
+      setStatus('error');
+      const delay = Math.min(1000 * 2 ** attempt, 30000);
+      retryTimeout = setTimeout(() => connectNDK(attempt + 1), delay);
+      return;
     }
     setStatus('connected');
   } catch (err) {


### PR DESCRIPTION
## Summary
- prevent `connectNDK` from throwing when zero relays connect
- set error status and retry when no relays are available

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_689819671de88331a2685382b04879b9