### PR TITLE
feat: close overlay on outside click and escape

### DIFF
--- a/apps/web/components/ui/Overlay.test.tsx
+++ b/apps/web/components/ui/Overlay.test.tsx
@@ -1,0 +1,31 @@
+/* @vitest-environment jsdom */
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import Overlay, { OverlayHost } from './Overlay';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { LayoutContext } from '@/context/LayoutContext';
+
+describe('Overlay', () => {
+  it('closes when clicking the overlay and restores interactions', async () => {
+    const clickSpy = vi.fn();
+    const MockLayoutProvider = ({ children }: { children: React.ReactNode }) => (
+      <LayoutContext.Provider value="mobile">{children}</LayoutContext.Provider>
+    );
+    render(
+      <MockLayoutProvider>
+        <button onClick={clickSpy}>feed</button>
+        <OverlayHost />
+      </MockLayoutProvider>
+    );
+
+    Overlay.open('modal', { content: <div>content</div> });
+    const overlay = document.querySelector('[role="button"][data-state="open"]') as HTMLElement;
+    overlay && fireEvent.click(overlay);
+
+    await waitFor(() => expect(screen.queryByText('content')).toBeNull());
+    fireEvent.click(screen.getByText('feed'));
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+});
+

--- a/apps/web/components/ui/Overlay.tsx
+++ b/apps/web/components/ui/Overlay.tsx
@@ -42,7 +42,15 @@ export function OverlayHost() {
   return (
     <Dialog.Root open onOpenChange={(o) => !o && closeHandler()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50" />
+        <Dialog.Overlay
+          className="fixed inset-0 z-40 bg-black/50"
+          onClick={closeHandler}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') closeHandler();
+          }}
+          role="button"
+          tabIndex={0}
+        />
         <Dialog.Content
           className={contentClass}
           onOpenAutoFocus={(e) => {


### PR DESCRIPTION
## Summary
- ensure overlay closes when clicking outside or pressing Escape
- add test verifying overlay unblocks underlying UI

## Testing
- `pnpm test apps/web/components/ui/Overlay.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689819b4ff3c833185234c39d8621126