### PR TITLE
Expose loading state to feed component

### DIFF
--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -2,7 +2,6 @@
 import AppShell from '@/components/layout/AppShell';
 import MainNav from '@/components/layout/MainNav';
 import RightPanel from '@/components/feed/RightPanel';
-import PlaceholderVideo from '@/components/PlaceholderVideo';
 import Feed from '@/components/Feed';
 import useFeed from '@/hooks/useFeed';
 import { useAuth } from '@/hooks/useAuth';
@@ -14,7 +13,7 @@ import { CurrentVideoProvider } from '@/hooks/useCurrentVideo';
 
 export default function FeedPage() {
   const { filterAuthor, setFilterAuthor, selectedVideoAuthor } = useFeedSelection();
-  const { items: videos, loadMore } = useFeed(
+  const { items: videos, loadMore, loading } = useFeed(
     filterAuthor ? { author: filterAuthor } : 'all',
   );
 
@@ -65,11 +64,7 @@ export default function FeedPage() {
         center={
           <div className="feed-container h-full">
             {/* tabs bar you already have can stay on top */}
-            {videos.length === 0 ? (
-              <PlaceholderVideo className="aspect-[9/16] w-full max-w-[420px] mx-auto text-primary" />
-            ) : (
-              <Feed items={videos} loadMore={loadMore} />
-            )}
+            <Feed items={videos} loadMore={loadMore} loading={loading} />
           </div>
         }
         right={<RightPanel author={author} onFilterByAuthor={filterByAuthor} />}

--- a/apps/web/components/Feed.test.tsx
+++ b/apps/web/components/Feed.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Feed from './Feed';
+
+// Ensure React is available globally for components compiled with the classic JSX runtime
+(globalThis as any).React = React;
+
+describe('Feed', () => {
+  it('renders skeleton during loading', () => {
+    const html = renderToStaticMarkup(<Feed items={[]} loading />);
+    expect(html).toContain('bg-text-primary/10');
+  });
+
+  it('renders empty state when no items', () => {
+    const html = renderToStaticMarkup(<Feed items={[]} />);
+    expect(html).toContain('<svg');
+  });
+});

--- a/apps/web/hooks/useFeed.ts
+++ b/apps/web/hooks/useFeed.ts
@@ -135,6 +135,7 @@ export function useFeed(
   const items = query.data?.pages.flatMap((p) => p.items) ?? [];
   const tags = query.data?.pages[0]?.tags ?? [];
   const timedOut = query.data?.pages.some((p) => p.timedOut);
+  const loading = query.isPending || (query.isFetching && items.length === 0);
   const prepend = (item: VideoCardProps) => {
     queryClient.setQueryData(['feed', mode, authors.join(','), limit], (old: any) => {
       if (!old) return old;
@@ -149,6 +150,7 @@ export function useFeed(
     tags,
     prepend,
     loadMore: () => query.fetchNextPage(),
+    loading,
     error: timedOut ? new Error('Relay connection timed out') : undefined,
   };
 }


### PR DESCRIPTION
## Summary
- expose `loading` state from `useFeed` and pass it through the feed page
- render `Feed` for loading and empty states instead of placeholder
- add tests ensuring feed shows skeleton during load and empty state with no items

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*
- `pnpm test apps/web/components/Feed.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68981bb35d588331a47ab5bf37a3b88b