### PR TITLE
feat: improve video placeholder accessibility

### DIFF
--- a/apps/web/components/PlaceholderVideo.tsx
+++ b/apps/web/components/PlaceholderVideo.tsx
@@ -1,8 +1,22 @@
 import React from 'react';
+import clsx from 'clsx';
 
-export default function PlaceholderVideo({ className }: { className?: string }) {
+export default function PlaceholderVideo({
+  className,
+  message = 'Loading video…',
+  busy = true,
+}: {
+  className?: string;
+  message?: string;
+  busy?: boolean;
+}) {
   return (
-    <div className={className}>
+    <div
+      className={clsx('relative flex items-center justify-center', className)}
+      role="status"
+      aria-busy={busy}
+      aria-live="polite"
+    >
       <svg
         viewBox="0 0 24 24"
         fill="none"
@@ -10,12 +24,18 @@ export default function PlaceholderVideo({ className }: { className?: string }) 
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
-        className="h-full w-full"
+        className="h-full w-full animate-pulse text-muted"
+        aria-hidden="true"
       >
         <rect x="3" y="3" width="18" height="14" rx="2" ry="2" />
         <line x1="8" y1="21" x2="16" y2="21" />
         <line x1="12" y1="17" x2="12" y2="21" />
       </svg>
+      {message && (
+        <span className="absolute inset-0 flex items-center justify-center text-sm text-muted">
+          {message}
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/web/components/VideoFeed.test.tsx
+++ b/apps/web/components/VideoFeed.test.tsx
@@ -9,6 +9,6 @@ import VideoFeed from './VideoFeed';
 describe('VideoFeed', () => {
   it('renders placeholder when no videos', () => {
     const html = renderToStaticMarkup(<VideoFeed onAuthorClick={() => {}} />);
-    expect(html).toContain('<svg');
+    expect(html).toContain('No videos yet');
   });
 });

--- a/apps/web/components/VideoFeed.tsx
+++ b/apps/web/components/VideoFeed.tsx
@@ -14,7 +14,13 @@ export default function VideoFeed({ onAuthorClick }: { onAuthorClick: (pubkey: s
   });
 
   if (videos.length === 0) {
-    return <PlaceholderVideo className="aspect-[9/16] w-full max-w-[420px] mx-auto text-primary" />;
+    return (
+      <PlaceholderVideo
+        className="aspect-[9/16] w-full max-w-[420px] mx-auto text-primary"
+        message="No videos yet"
+        busy={false}
+      />
+    );
   }
 
   return (
@@ -36,7 +42,7 @@ export default function VideoFeed({ onAuthorClick }: { onAuthorClick: (pubkey: s
               height: `${virtualRow.size}px`,
             }}
           >
-            <PlaceholderVideo className="w-full" />
+            <PlaceholderVideo className="w-full" message="Loading video…" />
           </div>
         ))}
       </div>

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -487,7 +487,11 @@ export default function CreateVideoForm() {
                 className="absolute inset-0 h-full w-full object-cover pointer-events-none"
               />
             ) : (
-              <PlaceholderVideo className="absolute inset-0 h-full w-full object-cover" />
+              <PlaceholderVideo
+                className="absolute inset-0 h-full w-full object-cover"
+                message="No video selected"
+                busy={false}
+              />
             )}
             {isDragActive && (
               <div className="absolute inset-0 flex items-center justify-center bg-black/50 text-white">


### PR DESCRIPTION
## Summary
- add message, aria state, and pulse animation to placeholder video
- show "No videos yet" or "Loading video…" when video feed data isn't ready
- clarify create form placeholder when no video selected

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_68981de38c688331b4461120ba9eb3df