### PR TITLE
fix: guard video.js disposal

### DIFF
--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -1,0 +1,71 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+
+// Ensure React is available globally for components compiled with the classic JSX runtime
+(globalThis as any).React = React;
+
+vi.mock('@videojs-player/react', () => {
+  const React = require('react');
+  return {
+    VideoPlayer: ({ onReady }: any) => {
+      const element: any = { parentNode: {} };
+      const player = {
+        el: () => element,
+        dispose: vi.fn(() => {
+          if (!element.parentNode) {
+            throw new DOMException('NotFoundError');
+          }
+          element.parentNode = null;
+        }),
+        muted: () => {},
+        play: () => ({ catch: () => {} }),
+      } as any;
+      React.useEffect(() => {
+        onReady?.(player);
+        return () => player.dispose();
+      }, []);
+      return <div />;
+    },
+  };
+});
+
+vi.mock('./ZapButton', () => ({ default: () => <div /> }));
+vi.mock('./CommentDrawer', () => ({ default: () => <div /> }));
+vi.mock('./ReportModal', () => ({ default: () => null }));
+
+vi.mock('../hooks/useFollowing', () => ({ default: () => ({ following: [], follow: () => {} }) }));
+vi.mock('react-use', () => ({ useNetworkState: () => ({ online: true }) }));
+vi.mock('../hooks/useAdaptiveSource', () => ({ default: () => undefined }));
+vi.mock('react-intersection-observer', () => ({ useInView: () => ({ ref: () => {}, inView: true }) }));
+vi.mock('../hooks/useCurrentVideo', () => ({ useCurrentVideo: () => ({ setCurrent: () => {} }) }));
+vi.mock('@/store/feedSelection', () => ({ useFeedSelection: () => ({ setSelectedVideo: () => {} }) }));
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ state: { status: 'ready', pubkey: 'pk', signer: {} } }) }));
+vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({ picture: '', name: 'author' }) }));
+vi.mock('@/hooks/useProfiles', () => ({ prefetchProfile: () => Promise.resolve() }));
+vi.mock('@/agents/nostr', () => ({ nostr: { repost: () => Promise.resolve() } }));
+
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ headers: new Headers({ 'content-type': 'video/mp4' }) })));
+
+const { default: VideoCard } = await import('./VideoCard');
+
+describe('VideoCard', () => {
+  it('mounts and unmounts without throwing NotFoundError', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    const props = {
+      videoUrl: 'video.mp4',
+      author: 'author',
+      caption: 'caption',
+      eventId: 'event',
+      lightningAddress: 'la',
+      pubkey: 'pk',
+    };
+    expect(() => {
+      root.render(<VideoCard {...props} />);
+      root.unmount();
+    }).not.toThrow();
+  });
+});

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -54,7 +54,13 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const playerRef = useRef<videojs.Player | null>(null);
   useEffect(() => {
     return () => {
-      playerRef.current?.dispose();
+      // @videojs-player/react disposes the player for us. Only dispose
+      // manually if the element is still attached to the DOM to avoid
+      // NotFoundError exceptions.
+      const el = playerRef.current?.el();
+      if (el?.parentNode) {
+        playerRef.current?.dispose();
+      }
       playerRef.current = null;
     };
   }, []);

--- a/test/stubs/videojs-http-streaming.ts
+++ b/test/stubs/videojs-http-streaming.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'apps/web'),
       ui: path.resolve(__dirname, 'packages/ui/src'),
+      '@videojs/http-streaming': path.resolve(
+        __dirname,
+        'test/stubs/videojs-http-streaming.ts',
+      ),
     },
   },
 


### PR DESCRIPTION
## Summary
- avoid double-disposing `video.js` by ensuring the player element is still attached before calling `dispose`
- add unit test covering mount/unmount for `VideoCard`
- stub `@videojs/http-streaming` in vitest config for tests

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68981dd8dfcc8331a66d6da569121d46