### PR TITLE
feat: add mobile drawer toggle

### DIFF
--- a/apps/web/components/feed/RightPanel.test.tsx
+++ b/apps/web/components/feed/RightPanel.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@chakra-ui/react', () => {
     DrawerContent: ({ children, ...props }: any) => <div data-content {...props}>{children}</div>,
     DrawerBody: ({ children, ...props }: any) => <div data-body {...props}>{children}</div>,
     useColorModeValue: (v: any) => v,
+    useDisclosure: () => ({ isOpen: false, onOpen: vi.fn(), onClose: vi.fn() }),
   };
 });
 

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -15,6 +15,7 @@ import {
   DrawerOverlay,
   DrawerBody,
   useColorModeValue,
+  useDisclosure,
 } from '@chakra-ui/react';
 
 export default function RightPanel({
@@ -32,6 +33,7 @@ export default function RightPanel({
   const isDesktop = layout === 'desktop' && !forceDrawer;
   const borderColor = useColorModeValue('gray.200', 'gray.700');
   const cardBg = useColorModeValue('white', 'gray.800');
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const panelContent = (
     <Stack spacing={4}>
@@ -87,13 +89,26 @@ export default function RightPanel({
     return panelContent;
   }
 
-  const isOpen = !!(author || selectedVideoId);
   return (
-    <Drawer isOpen={isOpen} placement="right" onClose={() => {}}>
-      <DrawerOverlay />
-      <DrawerContent>
-        <DrawerBody p={4}>{panelContent}</DrawerBody>
-      </DrawerContent>
-    </Drawer>
+    <>
+      {(author || selectedVideoId) && (
+        <Button
+          position="fixed"
+          bottom={4}
+          right={4}
+          zIndex="overlay"
+          colorScheme="blue"
+          onClick={onOpen}
+        >
+          Comments
+        </Button>
+      )}
+      <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerBody p={4}>{panelContent}</DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- use Chakra's `useDisclosure` to control feed right-panel drawer
- add mobile-only `Comments` trigger and functional onClose

## Testing
- `pnpm test apps/web/components/feed/RightPanel.test.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689825449ef8833197ea768e727c5da1