### PR TITLE
feat(web): add relays hook and reconnect NDK

### DIFF
--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,36 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Card } from '../ui/Card';
-import { getRelays, parseRelays } from '@/lib/nostr';
-import relaysConfig from '@/relays.json';
+import { useRelays } from '@/hooks/useRelays';
 
 export function NetworkCard() {
-  const [relays, setRelays] = useState<string[]>(() => parseRelays(relaysConfig) ?? []);
+  const { relays, addRelay, removeRelay } = useRelays();
   const [input, setInput] = useState('');
 
-  // persist relays to localStorage whenever they change
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      window.localStorage.setItem('pd.relays', JSON.stringify(relays));
-      window.dispatchEvent(new Event('pd.relays')); // notify listeners
-    } catch {
-      /* ignore */
-    }
-  }, [relays]);
-
-  useEffect(() => {
-    setRelays(getRelays());
-  }, []);
-
-  const addRelay = () => {
-    const url = input.trim();
-    if (!url || relays.includes(url)) return;
-    setRelays((prev) => [...prev, url]);
+  const handleAdd = () => {
+    addRelay(input);
     setInput('');
-  };
-
-  const removeRelay = (url: string) => {
-    setRelays((prev) => prev.filter((r) => r !== url));
   };
 
   return (
@@ -44,13 +22,13 @@ export function NetworkCard() {
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault();
-                addRelay();
+                handleAdd();
               }
             }}
             placeholder="wss://relay.example.com"
             className="flex-1 rounded bg-text-primary/10 p-2 text-sm outline-none"
           />
-          <button type="button" onClick={addRelay} className="btn btn-outline">
+          <button type="button" onClick={handleAdd} className="btn btn-outline">
             Add
           </button>
         </div>

--- a/apps/web/hooks/useRelays.ts
+++ b/apps/web/hooks/useRelays.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { getRelays } from '@/lib/nostr';
+
+export function useRelays() {
+  const [relays, setRelays] = useState<string[]>(() => getRelays());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem('pd.relays', JSON.stringify(relays));
+      window.dispatchEvent(new CustomEvent('pd.relays', { detail: relays }));
+    } catch {
+      /* ignore */
+    }
+  }, [relays]);
+
+  function addRelay(url: string) {
+    const next = url.trim();
+    if (!next) return;
+    setRelays((prev) => (prev.includes(next) ? prev : [...prev, next]));
+  }
+
+  function removeRelay(url: string) {
+    setRelays((prev) => prev.filter((r) => r !== url));
+  }
+
+  return { relays, addRelay, removeRelay };
+}
+
+export default useRelays;

--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -50,8 +50,9 @@ void connectNDK();
 
 // update relay connections when the list changes
 if (typeof window !== 'undefined') {
-  window.addEventListener('pd.relays', () => {
-    ndk.explicitRelayUrls = getRelays();
+  window.addEventListener('pd.relays', (e) => {
+    const relays = (e as CustomEvent<string[]>).detail ?? getRelays();
+    ndk.explicitRelayUrls = relays;
     void connectNDK();
   });
 }


### PR DESCRIPTION
## Summary
- add `useRelays` hook to manage relay list and persist to storage
- update `NetworkCard` to use `useRelays`
- reconnect NDK when relay list changes via `pd.relays`

## Testing
- `pnpm test` *(fails: DataCloneError, worker out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68982bce2b7c8331841c767fcac7d43c