### PR TITLE
Abort in-flight video source checks

### DIFF
--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createRoot } from 'react-dom/client';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // Ensure React is available globally for components compiled with the classic JSX runtime
@@ -34,16 +34,19 @@ vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({ picture: '', name: '
 vi.mock('@/hooks/useProfiles', () => ({ prefetchProfile: () => Promise.resolve() }));
 vi.mock('@/agents/nostr', () => ({ nostr: { repost: () => Promise.resolve() } }));
 
-vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ headers: new Headers({ 'content-type': 'video/mp4' }) })));
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
 
 const { default: VideoCard } = await import('./VideoCard');
 
 afterEach(() => {
   cleanup();
+  fetchMock.mockReset();
 });
 
 describe('VideoCard', () => {
   it('mounts and unmounts without throwing NotFoundError', () => {
+    fetchMock.mockResolvedValue({ headers: new Headers({ 'content-type': 'video/mp4' }) });
     const div = document.createElement('div');
     document.body.appendChild(div);
     const root = createRoot(div);
@@ -61,7 +64,35 @@ describe('VideoCard', () => {
     }).not.toThrow();
   });
 
+  it('aborts in-flight requests on unmount', async () => {
+    const abortSpy = vi.fn();
+    fetchMock.mockImplementation((_url, options: any) => {
+      return new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          abortSpy();
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+    });
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    const props = {
+      videoUrl: 'video.mp4',
+      author: 'author',
+      caption: 'caption',
+      eventId: 'event',
+      lightningAddress: 'la',
+      pubkey: 'pk',
+    };
+    root.render(<VideoCard {...props} />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    root.unmount();
+    expect(abortSpy).toHaveBeenCalled();
+  });
+
   it('toggles mute state with action bar button', async () => {
+    fetchMock.mockResolvedValue({ headers: new Headers({ 'content-type': 'video/mp4' }) });
     const props = {
       videoUrl: 'video.mp4',
       author: 'author',


### PR DESCRIPTION
## Summary
- cancel HEAD requests in `VideoCard` with `AbortController`
- handle `AbortError` to avoid spurious errors
- add regression test for aborting pending video source checks

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68982c661660833182f3940700c848c5