### PR TITLE
refactor: drop mobile comments button

### DIFF
--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -12,7 +12,7 @@ import { useFeedSelection } from '@/store/feedSelection';
 import { CurrentVideoProvider } from '@/hooks/useCurrentVideo';
 
 export default function FeedPage() {
-  const { filterAuthor, setFilterAuthor, selectedVideoAuthor } = useFeedSelection();
+  const { filterAuthor, setFilterAuthor } = useFeedSelection();
   const { items: videos, loadMore, loading } = useFeed(
     filterAuthor ? { author: filterAuthor } : 'all',
   );
@@ -24,7 +24,6 @@ export default function FeedPage() {
   const myFollowerCount = useFollowerCount(
     auth.status === 'ready' ? auth.pubkey : undefined,
   );
-  const authorFollowerCount = useFollowerCount(selectedVideoAuthor);
   const meProfile = useProfile(auth.status === 'ready' ? auth.pubkey : undefined);
   const me =
     auth.status === 'ready'
@@ -41,18 +40,6 @@ export default function FeedPage() {
           stats: { followers: 0, following: 0 },
         };
 
-  const authorProfile = useProfile(selectedVideoAuthor);
-  const author =
-    selectedVideoAuthor && authorProfile
-      ? {
-          avatar: authorProfile.picture || `/api/avatar/${selectedVideoAuthor}`,
-          name: authorProfile.name || selectedVideoAuthor.slice(0, 8),
-          username: authorProfile.name || selectedVideoAuthor.slice(0, 8),
-          pubkey: selectedVideoAuthor,
-          followers: authorFollowerCount,
-        }
-      : undefined;
-
   function filterByAuthor(pubkey: string) {
     setFilterAuthor(pubkey);
   }
@@ -67,7 +54,7 @@ export default function FeedPage() {
             <Feed items={videos} loadMore={loadMore} loading={loading} />
           </div>
         }
-        right={<RightPanel author={author} onFilterByAuthor={filterByAuthor} />}
+        right={<RightPanel onFilterByAuthor={filterByAuthor} />}
       />
     </CurrentVideoProvider>
   );

--- a/apps/web/components/feed/RightPanel.stories.tsx
+++ b/apps/web/components/feed/RightPanel.stories.tsx
@@ -1,24 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import RightPanel from './RightPanel';
 import { LayoutContext, LayoutType } from '@/context/LayoutContext';
+import { useFeedSelection } from '@/store/feedSelection';
 
 const meta = { title: 'Feed/RightPanel' };
 export default meta;
 
-const author = {
-  avatar: '/offline.jpg',
-  name: 'Alice',
-  username: 'alice',
-  pubkey: 'pubkey',
-  followers: 123,
-};
-
 const Template = (layout: LayoutType) => {
-  const Story = () => (
-    <LayoutContext.Provider value={layout}>
-      <RightPanel author={author} onFilterByAuthor={() => {}} />
-    </LayoutContext.Provider>
-  );
+  const Story = () => {
+    const setSelected = useFeedSelection((s) => s.setSelectedVideo);
+    useEffect(() => {
+      setSelected('vid1', 'pubkey');
+    }, [setSelected]);
+    return (
+      <LayoutContext.Provider value={layout}>
+        <RightPanel onFilterByAuthor={() => {}} />
+      </LayoutContext.Provider>
+    );
+  };
   Story.displayName = 'RightPanelStory';
   return Story;
 };

--- a/apps/web/components/feed/RightPanel.test.tsx
+++ b/apps/web/components/feed/RightPanel.test.tsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import RightPanel from '@/components/feed/RightPanel';
 import { LayoutContext } from '@/context/LayoutContext';
 
+const disclosureState = { isOpen: false };
 vi.mock('@chakra-ui/react', () => {
   const React = require('react');
   return {
@@ -17,28 +18,57 @@ vi.mock('@chakra-ui/react', () => {
     DrawerContent: ({ children, ...props }: any) => <div data-content {...props}>{children}</div>,
     DrawerBody: ({ children, ...props }: any) => <div data-body {...props}>{children}</div>,
     useColorModeValue: (v: any) => v,
-    useDisclosure: () => ({ isOpen: false, onOpen: vi.fn(), onClose: vi.fn() }),
+    useDisclosure: () => ({ isOpen: disclosureState.isOpen, onClose: vi.fn() }),
   };
 });
 
 vi.mock('next/link', () => ({ default: (props: any) => <a {...props} /> }));
 vi.mock('next/image', () => ({ default: (props: any) => <img {...props} /> }));
 vi.mock('next/navigation', () => ({ useRouter: () => ({ prefetch: () => {} }) }));
+vi.mock('@/components/comments/Thread', () => ({ default: () => <div data-thread /> }));
+vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({ picture: '/a.jpg', name: 'A' }) }));
+vi.mock('@/hooks/useFollowerCount', () => ({ default: () => 1 }));
+const feedSelectionState = {
+  selectedVideoId: undefined as string | undefined,
+  selectedVideoAuthor: undefined as string | undefined,
+};
 vi.mock('@/store/feedSelection', () => ({
-  useFeedSelection: () => ({ selectedVideoId: undefined, selectedVideoAuthor: undefined }),
+  useFeedSelection: () => feedSelectionState,
 }));
 
 (globalThis as any).React = React;
 
 describe('RightPanel', () => {
   it('renders in a drawer when forced', () => {
-    const author = { avatar: '/a.jpg', name: 'A', username: 'a', pubkey: 'pk', followers: 1 };
     const html = renderToStaticMarkup(
       <LayoutContext.Provider value="desktop">
-        <RightPanel author={author} onFilterByAuthor={() => {}} forceDrawer />
+        <RightPanel onFilterByAuthor={() => {}} forceDrawer />
       </LayoutContext.Provider>,
     );
     expect(html).toContain('data-drawer');
+  });
+
+  it('renders content only when drawer is open', () => {
+    feedSelectionState.selectedVideoId = 'vid123';
+    feedSelectionState.selectedVideoAuthor = 'pk';
+
+    disclosureState.isOpen = false;
+    const closedHtml = renderToStaticMarkup(
+      <LayoutContext.Provider value="mobile">
+        <RightPanel onFilterByAuthor={() => {}} />
+      </LayoutContext.Provider>,
+    );
+    expect(closedHtml).not.toContain('data-thread');
+    expect(closedHtml).not.toContain('1');
+
+    disclosureState.isOpen = true;
+    const openHtml = renderToStaticMarkup(
+      <LayoutContext.Provider value="mobile">
+        <RightPanel onFilterByAuthor={() => {}} />
+      </LayoutContext.Provider>,
+    );
+    expect(openHtml).toContain('data-thread');
+    expect(openHtml).toContain('1');
   });
 });
 


### PR DESCRIPTION
## Summary
- remove floating Comments button and rely on action bar for comment access
- load author info and comments only when the drawer is open
- simplify feed page data fetching and adjust tests

## Testing
- `pnpm test apps/web/components/feed/RightPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689829e88c6c833199709a3a4628d8de