### PR TITLE
Hydrate relay settings from storage on initial render

### DIFF
--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,10 +1,30 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card } from '../ui/Card';
-import { useRelays } from '@/hooks/useRelays';
+import { getRelays } from '@/lib/nostr';
 
 export function NetworkCard() {
-  const { relays, addRelay, removeRelay } = useRelays();
+  const [relays, setRelays] = useState<string[]>(() => getRelays());
   const [input, setInput] = useState('');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem('pd.relays', JSON.stringify(relays));
+      window.dispatchEvent(new CustomEvent('pd.relays', { detail: relays }));
+    } catch {
+      /* ignore */
+    }
+  }, [relays]);
+
+  function addRelay(url: string) {
+    const next = url.trim();
+    if (!next) return;
+    setRelays((prev) => (prev.includes(next) ? prev : [...prev, next]));
+  }
+
+  function removeRelay(url: string) {
+    setRelays((prev) => prev.filter((r) => r !== url));
+  }
 
   const handleAdd = () => {
     addRelay(input);

--- a/apps/web/components/settings/__tests__/NetworkCard.test.tsx
+++ b/apps/web/components/settings/__tests__/NetworkCard.test.tsx
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, beforeEach, expect } from 'vitest';
+import NetworkCard from '../NetworkCard';
+
+describe('NetworkCard', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders stored relays without flashing defaults', () => {
+    localStorage.setItem('pd.relays', JSON.stringify(['wss://relay.example.com']));
+    render(<NetworkCard />);
+    screen.getByText('wss://relay.example.com');
+    expect(screen.queryByText('No relays configured.')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Initialize NetworkCard relay list from storage on first render
- Persist relay updates and manage add/remove locally
- Test to ensure stored relays render without default flash

## Testing
- `pnpm lint`
- `pnpm test apps/web/components/settings/__tests__/NetworkCard.test.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68982df53ed48331ba85363bca75c8ca