### PR TITLE
Validate relay URLs and add tests

### DIFF
--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Card } from '../ui/Card';
-import { getRelays } from '@/lib/nostr';
+import { getRelays, normalizeRelay } from '@/lib/nostr';
 
 export function NetworkCard() {
   const [relays, setRelays] = useState<string[]>(() => getRelays());
@@ -17,9 +17,9 @@ export function NetworkCard() {
   }, [relays]);
 
   function addRelay(url: string) {
-    const next = url.trim();
-    if (!next) return;
-    setRelays((prev) => (prev.includes(next) ? prev : [...prev, next]));
+    const normalized = normalizeRelay(url.trim());
+    if (!normalized) return;
+    setRelays((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
   }
 
   function removeRelay(url: string) {

--- a/apps/web/components/settings/__tests__/NetworkCard.test.tsx
+++ b/apps/web/components/settings/__tests__/NetworkCard.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, beforeEach, expect } from 'vitest';
 import NetworkCard from '../NetworkCard';
 
@@ -14,5 +15,26 @@ describe('NetworkCard', () => {
     render(<NetworkCard />);
     screen.getByText('wss://relay.example.com');
     expect(screen.queryByText('No relays configured.')).toBeNull();
+  });
+
+  it('adds only valid relay URLs', async () => {
+    render(<NetworkCard />);
+    const input = screen.getAllByPlaceholderText('wss://relay.example.com')[0];
+    const add = screen.getAllByText('Add')[0];
+    const user = userEvent.setup();
+
+    await user.type(input, 'wss:relay.example.com');
+    await user.click(add);
+    expect(screen.queryByText('wss:relay.example.com')).toBeNull();
+
+    await user.clear(input);
+    await user.type(input, 'http://relay.example.com');
+    await user.click(add);
+    expect(screen.queryByText('http://relay.example.com')).toBeNull();
+
+    await user.clear(input);
+    await user.type(input, 'relay.example.com');
+    await user.click(add);
+    screen.getByText('wss://relay.example.com');
   });
 });

--- a/apps/web/hooks/useRelays.ts
+++ b/apps/web/hooks/useRelays.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getRelays } from '@/lib/nostr';
+import { getRelays, normalizeRelay } from '@/lib/nostr';
 
 export function useRelays() {
   const [relays, setRelays] = useState<string[]>(() => getRelays());
@@ -15,9 +15,9 @@ export function useRelays() {
   }, [relays]);
 
   function addRelay(url: string) {
-    const next = url.trim();
-    if (!next) return;
-    setRelays((prev) => (prev.includes(next) ? prev : [...prev, next]));
+    const normalized = normalizeRelay(url.trim());
+    if (!normalized) return;
+    setRelays((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
   }
 
   function removeRelay(url: string) {

--- a/apps/web/lib/__tests__/relays.test.ts
+++ b/apps/web/lib/__tests__/relays.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRelay, parseRelays } from '@/lib/nostr';
+
+describe('normalizeRelay', () => {
+  it('accepts valid relay URLs', () => {
+    expect(normalizeRelay('wss://relay.example.com')).toBe('wss://relay.example.com');
+  });
+
+  it('adds default wss scheme', () => {
+    expect(normalizeRelay('relay.example.com')).toBe('wss://relay.example.com');
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(normalizeRelay('wss:relay.example.com')).toBeUndefined();
+    expect(normalizeRelay('http://relay.example.com')).toBeUndefined();
+  });
+});
+
+describe('parseRelays', () => {
+  it('filters out invalid entries', () => {
+    const input = ['wss://relay.example.com', 'http://bad', 'wss:relay.example.com'];
+    expect(parseRelays(input)).toEqual(['wss://relay.example.com']);
+  });
+
+  it('parses comma separated strings', () => {
+    expect(parseRelays('wss://relay.example.com, http://bad')).toEqual([
+      'wss://relay.example.com',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize relay URLs and validate schemes
- centralize relay validation in helper used by hooks and settings
- test valid and invalid relay URLs

## Testing
- `pnpm test apps/web/lib/__tests__/relays.test.ts apps/web/components/settings/__tests__/NetworkCard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68983089f2608331ba766b080ae5c821