### PR TITLE
chore: mark localStorage modules as client

### DIFF
--- a/apps/web/agents/nostr.comments.ts
+++ b/apps/web/agents/nostr.comments.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import type { Signer } from '@/lib/signers/types';
 import pool from '@/lib/relayPool';

--- a/apps/web/agents/nostr.ts
+++ b/apps/web/agents/nostr.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { Event as NostrEvent, EventTemplate } from 'nostr-tools/pure';
 import type { Signer } from '@/lib/signers/types';
 import pool from '@/lib/relayPool';

--- a/apps/web/components/InstallBanner.tsx
+++ b/apps/web/components/InstallBanner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef, useState } from 'react';
 import useInstallPrompt from '../hooks/useInstallPrompt';
 import analytics from '../utils/analytics';

--- a/apps/web/components/NotificationBell.tsx
+++ b/apps/web/components/NotificationBell.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { Bell } from 'lucide-react';
 import { useNotifications, requestNotificationPermission } from '../hooks/useNotifications';

--- a/apps/web/components/NotificationDrawer.tsx
+++ b/apps/web/components/NotificationDrawer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useRef } from 'react';
 import { useNotifications } from '../hooks/useNotifications';
 import { useRouter } from 'next/navigation';

--- a/apps/web/components/settings/AccountCard.tsx
+++ b/apps/web/components/settings/AccountCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { Card } from '@/components/ui/Card';

--- a/apps/web/components/settings/DataCard.tsx
+++ b/apps/web/components/settings/DataCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import useAlwaysSD from '../../hooks/useAlwaysSD';
 import { Card } from '../ui/Card';

--- a/apps/web/components/settings/LanguageCard.tsx
+++ b/apps/web/components/settings/LanguageCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { useRouter, usePathname, useSearchParams, useParams } from 'next/navigation';
 import useT from '@/hooks/useT';

--- a/apps/web/components/settings/LightningCard.tsx
+++ b/apps/web/components/settings/LightningCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import QRCode from 'qrcode';

--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 import { Card } from '../ui/Card';
 import { useRelays } from '@/hooks/useRelays';

--- a/apps/web/components/settings/PrivacyCard.tsx
+++ b/apps/web/components/settings/PrivacyCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import { Card } from '../ui/Card';
 

--- a/apps/web/components/settings/ProfileCard.tsx
+++ b/apps/web/components/settings/ProfileCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import type { EventTemplate } from 'nostr-tools/pure';

--- a/apps/web/components/settings/StorageCard.tsx
+++ b/apps/web/components/settings/StorageCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import useT from '../../hooks/useT';
 import { Card } from '../ui/Card';

--- a/apps/web/hooks/useAdaptiveSource.ts
+++ b/apps/web/hooks/useAdaptiveSource.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import useAlwaysSD from './useAlwaysSD';
 

--- a/apps/web/hooks/useAlwaysSD.ts
+++ b/apps/web/hooks/useAlwaysSD.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 
 export default function useAlwaysSD() {

--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import { LocalSigner } from '@/lib/signers/local';
 import { Nip07Signer } from '@/lib/signers/nip07';

--- a/apps/web/hooks/useCreatorAnalytics.ts
+++ b/apps/web/hooks/useCreatorAnalytics.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 
 export interface CreatorStats {

--- a/apps/web/hooks/useNotifications.tsx
+++ b/apps/web/hooks/useNotifications.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, {
   createContext,
   useContext,

--- a/apps/web/hooks/useRelays.ts
+++ b/apps/web/hooks/useRelays.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import { getRelays } from '@/lib/nostr';
 

--- a/apps/web/hooks/useVaultGate.ts
+++ b/apps/web/hooks/useVaultGate.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from 'react';
 
 const LS_KEY = 'pd.auth.v1';

--- a/apps/web/lib/nostr.test.ts
+++ b/apps/web/lib/nostr.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+vi.mock('@nostr-dev-kit/ndk', () => {
+  return {
+    default: class {
+      pool = { connectedRelays: () => [] };
+      connect() {
+        return Promise.resolve();
+      }
+    },
+  };
+});
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'https://example.com',
+});
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).localStorage = dom.window.localStorage;
+(global as any).navigator = dom.window.navigator;
+
+import { getRelays } from './nostr';
+
+describe('getRelays', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('reads the latest relay list from localStorage', () => {
+    localStorage.setItem('pd.relays', JSON.stringify(['wss://a']));
+    expect(getRelays()).toEqual(['wss://a']);
+    localStorage.setItem('pd.relays', JSON.stringify(['wss://b']));
+    expect(getRelays()).toEqual(['wss://b']);
+  });
+});
+

--- a/apps/web/lib/signers/local.ts
+++ b/apps/web/lib/signers/local.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { bytesToHex } from '@noble/hashes/utils';
 import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import * as nip19 from 'nostr-tools/nip19';

--- a/packages/mod-dashboard/pages/index.tsx
+++ b/packages/mod-dashboard/pages/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { SimplePool } from 'nostr-tools/pool';


### PR DESCRIPTION
## Summary
- mark Nostr agent and other localStorage consumers with "use client"
- ensure getRelays reads latest relay list by testing localStorage usage

## Testing
- `pnpm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_68982ee210a88331bd47a82e9586d0b2