### PR TITLE
chore: mark localStorage modules as client-only

### DIFF
--- a/apps/web/agents/nostr.ts
+++ b/apps/web/agents/nostr.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { Event as NostrEvent, EventTemplate } from 'nostr-tools/pure';
 import type { Signer } from '@/lib/signers/types';
 import pool from '@/lib/relayPool';

--- a/apps/web/components/InstallBanner.tsx
+++ b/apps/web/components/InstallBanner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef, useState } from 'react';
 import useInstallPrompt from '../hooks/useInstallPrompt';
 import analytics from '../utils/analytics';

--- a/apps/web/components/settings/LanguageCard.tsx
+++ b/apps/web/components/settings/LanguageCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { useRouter, usePathname, useSearchParams, useParams } from 'next/navigation';
 import useT from '@/hooks/useT';

--- a/apps/web/components/settings/NetworkCard.tsx
+++ b/apps/web/components/settings/NetworkCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import { Card } from '../ui/Card';
 import { getRelays, normalizeRelay } from '@/lib/nostr';

--- a/apps/web/components/settings/PrivacyCard.tsx
+++ b/apps/web/components/settings/PrivacyCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import { Card } from '../ui/Card';
 

--- a/apps/web/components/settings/StorageCard.tsx
+++ b/apps/web/components/settings/StorageCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import useT from '../../hooks/useT';
 import { Card } from '../ui/Card';

--- a/apps/web/hooks/useAlwaysSD.ts
+++ b/apps/web/hooks/useAlwaysSD.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 
 export default function useAlwaysSD() {

--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import { LocalSigner } from '@/lib/signers/local';
 import { Nip07Signer } from '@/lib/signers/nip07';

--- a/apps/web/hooks/useCreatorAnalytics.ts
+++ b/apps/web/hooks/useCreatorAnalytics.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 
 export interface CreatorStats {

--- a/apps/web/hooks/useNotifications.tsx
+++ b/apps/web/hooks/useNotifications.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, {
   createContext,
   useContext,

--- a/apps/web/hooks/useRelays.ts
+++ b/apps/web/hooks/useRelays.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import { getRelays, normalizeRelay } from '@/lib/nostr';
 

--- a/apps/web/hooks/useVaultGate.ts
+++ b/apps/web/hooks/useVaultGate.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from 'react';
 
 const LS_KEY = 'pd.auth.v1';

--- a/apps/web/lib/signers/local.ts
+++ b/apps/web/lib/signers/local.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { bytesToHex } from '@noble/hashes/utils';
 import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import * as nip19 from 'nostr-tools/nip19';

--- a/packages/mod-dashboard/pages/index.tsx
+++ b/packages/mod-dashboard/pages/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { SimplePool } from 'nostr-tools/pool';


### PR DESCRIPTION
## Summary
- mark Nostr agent and other localStorage-using modules with `"use client"`
- ensure relay settings and other client-only hooks run in the browser

## Testing
- `pnpm test apps/web/components/settings/__tests__/NetworkCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6898372612fc8331ab22f81f8b3e67d9