### PR TITLE
feat: show loading placeholder in VideoCard

### DIFF
--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createRoot } from 'react-dom/client';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // Ensure React is available globally for components compiled with the classic JSX runtime
@@ -58,6 +58,24 @@ describe('VideoCard', () => {
     const { unmount } = render(<VideoCard {...props} />);
     expect(loadSource).toHaveBeenCalled();
     expect(() => unmount()).not.toThrow();
+  });
+
+  it('shows and hides placeholder around video load', async () => {
+    const props = {
+      videoUrl: 'video.mp4',
+      author: 'author',
+      caption: 'caption',
+      eventId: 'event',
+      pubkey: 'pk',
+      zap: <div />,
+    };
+    const { container } = render(<VideoCard {...props} />);
+    await screen.findByText('Loading video…');
+    const video = container.querySelector('video') as HTMLVideoElement;
+    fireEvent.loadedData(video);
+    await waitFor(() => {
+      expect(screen.queryByText('Loading video…')).toBeNull();
+    });
   });
 
   it('toggles mute state with action bar button', async () => {

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -17,6 +17,7 @@ import { useFeedSelection } from '@/store/feedSelection';
 import { useAuth } from '@/hooks/useAuth';
 import { useProfile } from '@/hooks/useProfile';
 import { prefetchProfile } from '@/hooks/useProfiles';
+import PlaceholderVideo from './PlaceholderVideo';
 
 export interface VideoCardProps {
   videoUrl: string;
@@ -69,6 +70,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   const isFollowing = following.includes(pubkey);
   const { online } = useNetworkState();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [showPlayIndicator, setShowPlayIndicator] = useState(false);
   const [isPlaying, setIsPlaying] = useState(true);
@@ -181,10 +183,13 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       onPointerLeave={handlePointerUp}
       {...bind()}
     >
+      {!loaded && !errorMessage && (
+        <PlaceholderVideo className="absolute inset-0 h-full w-full" message="Loading video…" />
+      )}
       {!errorMessage && (
         <video
           ref={playerRef}
-          className="pointer-events-none absolute inset-0 h-full w-full object-cover"
+          className={`pointer-events-none absolute inset-0 h-full w-full object-cover ${loaded ? '' : 'hidden'}`}
           loop
           muted={muted}
           playsInline
@@ -192,6 +197,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           autoPlay={isPlaying}
           src={!manifestUrl ? videoUrl : undefined}
           onLoadedData={() => {
+            setLoaded(true);
             const video = getPlayer();
             if (video) {
               video.muted = true;


### PR DESCRIPTION
## Summary
- show a placeholder while videos load in `VideoCard`
- track video load state and reveal video once ready
- test placeholder visibility before and after the load event

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6898375a3d8883318d002e7a60080e89