### PR TITLE
check relay connections before NDK ops

### DIFF
--- a/apps/web/lib/relayPool.ts
+++ b/apps/web/lib/relayPool.ts
@@ -4,6 +4,12 @@ import { SimplePool, Relay } from 'nostr-tools';
 
 const simplePool = new SimplePool();
 
+function ensureConnected(op: string): boolean {
+  if (ndk.pool.connectedRelays().length > 0) return true;
+  console.warn(`relayPool.${op} called with no connected relays`);
+  return false;
+}
+
 // Lightweight wrapper around NDK providing a SimplePool-like interface
 // used throughout the app. When a relay list is provided the underlying
 // SimplePool is used directly, otherwise the shared NDK instance
@@ -12,6 +18,8 @@ const simplePool = new SimplePool();
 export default {
   subscribeMany(relays: (string | Relay)[] = [], filters: any[], handlers: any) {
     if (relays.length > 0) return simplePool.subscribeMany(relays, filters, handlers);
+
+    if (!ensureConnected('subscribeMany')) return { close: () => {} } as { close: () => void };
 
     const sub = ndk.subscribe(filters);
     if (handlers?.onevent) {
@@ -26,12 +34,16 @@ export default {
   async list(relays: (string | Relay)[] = [], filters: any[]) {
     if (relays.length > 0) return simplePool.list(relays, filters);
 
+    if (!ensureConnected('list')) return [];
+
     const events = await ndk.fetchEvents(filters);
     return Array.from(events).map((e: any) => (e.rawEvent ? e.rawEvent() : e));
   },
 
   async get(relays: (string | Relay)[] = [], filter: any) {
     if (relays.length > 0) return simplePool.get(relays, filter);
+
+    if (!ensureConnected('get')) return null;
 
     const ev = await ndk.fetchEvent(filter);
     return ev ? (ev.rawEvent ? ev.rawEvent() : ev) : null;
@@ -42,6 +54,8 @@ export default {
       const raw = event instanceof NDKEvent ? event.rawEvent() : event;
       return simplePool.publish(relays, raw);
     }
+
+    if (!ensureConnected('publish')) return;
 
     const ndkEvent = event instanceof NDKEvent ? event : new NDKEvent(ndk, event);
     await ndk.publish(ndkEvent);


### PR DESCRIPTION
## Summary
- ensure relayPool only calls NDK when relays are connected
- warn and bail early when publishing or subscribing without connections

## Testing
- `pnpm lint`
- `pnpm test apps/web/lib/__tests__/relays.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689839adfbd88331b7401263c853685f