### PR TITLE
Preserve full H.264 codec string in detectCodec

### DIFF
--- a/apps/web/utils/trimVideoWorker.test.ts
+++ b/apps/web/utils/trimVideoWorker.test.ts
@@ -19,6 +19,10 @@ describe('detectCodec', () => {
     expect(detectCodec(undefined, 'x264')).toBe('avc1');
   });
 
+  it('returns full avc1 codec string when profile and level are present', () => {
+    expect(detectCodec(undefined, 'avc1.640028')).toBe('avc1.640028');
+  });
+
   it('returns null for unknown codecs', () => {
     expect(detectCodec(undefined, 'unknown')).toBeNull();
   });

--- a/apps/web/utils/trimVideoWorker.test.ts
+++ b/apps/web/utils/trimVideoWorker.test.ts
@@ -23,6 +23,15 @@ describe('detectCodec', () => {
     expect(detectCodec(undefined, 'avc1.640028')).toBe('avc1.640028');
   });
 
+  it('extracts codec from blob type parameters', () => {
+    expect(
+      detectCodec('video/mp4; codecs="avc1.4d401e, mp4a.40.2"')
+    ).toBe('avc1.4d401e');
+    expect(
+      detectCodec('video/mp4; codecs="mp4a.40.2,avc1"')
+    ).toBe('avc1');
+  });
+
   it('returns null for unknown codecs', () => {
     expect(detectCodec(undefined, 'unknown')).toBeNull();
   });

--- a/apps/web/utils/trimVideoWorker.ts
+++ b/apps/web/utils/trimVideoWorker.ts
@@ -7,6 +7,7 @@ export function detectCodec(blobType?: string, trackCodec?: string): string | nu
   for (const c of candidates) {
     if (!c) continue;
     const codec = c.toLowerCase();
+    if (/^avc\d\.[0-9a-f]+$/i.test(codec)) return codec;
     if (codec.startsWith('avc') || codec.includes('h264') || codec.includes('x264'))
       return 'avc1';
     if (codec.includes('hvc1') || codec.includes('hev1') || codec.includes('hevc') || codec.includes('h265'))

--- a/apps/web/utils/trimVideoWorker.ts
+++ b/apps/web/utils/trimVideoWorker.ts
@@ -6,16 +6,26 @@ export function detectCodec(blobType?: string, trackCodec?: string): string | nu
   const candidates = [trackCodec, blobType];
   for (const c of candidates) {
     if (!c) continue;
-    const codec = c.toLowerCase();
-    if (/^avc\d\.[0-9a-f]+$/i.test(codec)) return codec;
-    if (codec.startsWith('avc') || codec.includes('h264') || codec.includes('x264'))
-      return 'avc1';
-    if (codec.includes('hvc1') || codec.includes('hev1') || codec.includes('hevc') || codec.includes('h265'))
-      return 'hvc1';
-    if (codec.includes('vp8')) return 'vp8';
-    if (codec.includes('vp9') || codec.includes('vp09')) return 'vp9';
-    if (codec.includes('av01') || codec.includes('av1')) return 'av01';
-    if (codec.includes('mp4v') || codec.includes('mpeg4')) return 'mp4v';
+
+    const match = /codecs?=["']?([^"';]+)/i.exec(c);
+    const list = (match ? match[1] : c).split(',');
+    for (const raw of list) {
+      const codec = raw.trim().toLowerCase();
+      if (!codec) continue;
+      if (/^avc\d\.[0-9a-f]+$/i.test(codec)) return codec;
+      if (codec.startsWith('avc') || codec.includes('h264') || codec.includes('x264')) return 'avc1';
+      if (
+        codec.includes('hvc1') ||
+        codec.includes('hev1') ||
+        codec.includes('hevc') ||
+        codec.includes('h265')
+      )
+        return 'hvc1';
+      if (codec.includes('vp8')) return 'vp8';
+      if (codec.includes('vp9') || codec.includes('vp09')) return 'vp9';
+      if (codec.includes('av01') || codec.includes('av1')) return 'av01';
+      if (codec.includes('mp4v') || codec.includes('mpeg4')) return 'mp4v';
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- keep existing H.264 profile/level when provided to detectCodec
- test detectCodec with full avc1 profile-level string

## Testing
- `pnpm test apps/web/utils/trimVideoWorker.test.ts`
- `node -e "globalThis.self=globalThis; globalThis.LibAV=require('libav.js/webcodecs-avf'); const LibAVWebCodecs=require('./apps/web/node_modules/libavjs-webcodecs-polyfill/dist/libavjs-webcodecs-polyfill.js'); (async () => { await LibAVWebCodecs.load({ polyfill: true }); console.log('VideoDecoder' in globalThis); console.log(await VideoDecoder.isConfigSupported({ codec: 'avc1.640028' })); })();"`

------
https://chatgpt.com/codex/tasks/task_e_68983ac617388331b9f46467c227d685