### PR TITLE
Propagate fatal HLS errors to VideoCard

### DIFF
--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -34,8 +34,9 @@ const loadSource = vi.fn();
 const play = vi.fn(() => Promise.resolve());
 const pause = vi.fn();
 const onStateChange = vi.fn(() => () => {});
+const onError = vi.fn(() => () => {});
 vi.mock('@/agents/playback', () => ({
-  playback: { loadSource, play, pause, onStateChange },
+  playback: { loadSource, play, pause, onStateChange, onError },
 }));
 
 const { default: VideoCard } = await import('./VideoCard');

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -93,11 +93,15 @@ export const VideoCard: React.FC<VideoCardProps> = ({
     const video = playerRef.current;
     if (!video) return;
     playback.loadSource(video, { videoUrl, manifestUrl });
-    const off = playback.onStateChange((state) => {
+    const offState = playback.onStateChange((state) => {
       setIsPlaying(state === 'playing');
     });
+    const offError = playback.onError((message) => {
+      setErrorMessage(message);
+    });
     return () => {
-      off();
+      offState();
+      offError();
     };
   }, [manifestUrl, videoUrl]);
 

--- a/apps/web/hooks/useAdaptiveSource.ts
+++ b/apps/web/hooks/useAdaptiveSource.ts
@@ -1,8 +1,9 @@
-import Hls from 'hls.js';
+import Hls, { ErrorData } from 'hls.js';
 
 export default function initHls(
   manifestUrl: string | undefined,
   video: HTMLVideoElement | null,
+  onError?: (data: ErrorData) => void,
 ): Hls | null {
   if (!manifestUrl || !video) return null;
 
@@ -21,6 +22,7 @@ export default function initHls(
             break;
           default:
             hls.destroy();
+            onError?.(data);
             break;
         }
       }


### PR DESCRIPTION
## Summary
- allow `initHls` to accept an error callback when fatal HLS errors occur
- broadcast playback errors and expose `onError` listener
- VideoCard listens for playback errors and shows a fallback message

## Testing
- `pnpm test` *(fails: ERR_WORKER_OUT_OF_MEMORY)*
- `pnpm test apps/web/components/VideoCard.test.tsx`
- `pnpm lint --filter @paiduan/web`


------
https://chatgpt.com/codex/tasks/task_e_68983aadca508331a005a979088c00bf