### PR TITLE
fallback to lud16 when wallets missing

### DIFF
--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -21,7 +21,8 @@ vi.mock('../../hooks/useAuth', () => ({
   }),
 }));
 
-vi.mock('../../hooks/useProfile', () => ({ useProfile: () => ({}) }));
+let profileMock: any = {};
+vi.mock('../../hooks/useProfile', () => ({ useProfile: () => profileMock }));
 vi.mock('../../hooks/useFollowing', () => ({ default: () => ({ following: [] }) }));
 vi.mock('../../lib/nostr', () => ({ getRelays: () => [] }));
 
@@ -53,6 +54,7 @@ describe('CreateVideoForm', () => {
       }
       return el;
     });
+    profileMock = {};
     queryClient.clear();
   });
 
@@ -146,6 +148,24 @@ describe('CreateVideoForm', () => {
     await Promise.resolve();
 
     expect(mockTrim).toHaveBeenCalledWith(file, { start: 0, end: 300 }, expect.any(Function));
+  });
+
+  it('prefills lightning address with lud16 when wallets empty', async () => {
+    profileMock = { wallets: [], lud16: 'alice@test' };
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CreateVideoForm />
+        </QueryClientProvider>,
+      );
+    });
+    await Promise.resolve();
+    const lightningInput = Array.from(container.querySelectorAll('label'))
+      .find((l) => l.textContent?.includes('Lightning address'))!
+      .querySelector('input') as HTMLInputElement;
+    expect(lightningInput.value).toBe('alice@test');
   });
 
   it('rejects non-9:16 aspect ratio', async () => {

--- a/apps/web/components/create/CreateVideoForm.tsx
+++ b/apps/web/components/create/CreateVideoForm.tsx
@@ -85,7 +85,7 @@ export default function CreateVideoForm() {
   const { following } = useFollowing(state.status === 'ready' ? state.pubkey : undefined);
   const profiles = useProfiles(following);
 
-  const walletAddrs = Array.isArray(profile?.wallets)
+  const walletAddrs = Array.isArray(profile?.wallets) && profile.wallets.length > 0
     ? [
         ...profile.wallets.filter((w: any) => w?.default).map((w: any) => w.lnaddr),
         ...profile.wallets.filter((w: any) => !w?.default).map((w: any) => w.lnaddr),
@@ -113,9 +113,10 @@ export default function CreateVideoForm() {
 
   useEffect(() => {
     if (!lightningAddress) {
-      const def = Array.isArray(profile?.wallets)
-        ? profile.wallets.find((w: any) => w?.default)?.lnaddr
-        : profile?.lud16;
+      const def =
+        Array.isArray(profile?.wallets) && profile.wallets.length > 0
+          ? profile.wallets.find((w: any) => w?.default)?.lnaddr
+          : profile?.lud16;
       if (def) setValue('lightningAddress', def);
     }
   }, [profile, lightningAddress, setValue]);

--- a/apps/web/components/settings/LightningCard.tsx
+++ b/apps/web/components/settings/LightningCard.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import QRCode from 'qrcode';

--- a/apps/web/hooks/useProfiles.test.ts
+++ b/apps/web/hooks/useProfiles.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as nostrKinds from 'nostr-tools/kinds';
+vi.mock('@/lib/db', () => ({ getEventsByPubkey: vi.fn(), saveEvent: vi.fn() }));
+vi.mock('@/lib/relayPool', () => ({ default: { subscribeMany: vi.fn() } }));
+vi.mock('@/lib/nostr', () => ({ getRelays: () => [] }));
+
+import { prefetchProfile } from './useProfiles';
+import { queryClient } from '@/lib/queryClient';
+import relayPool from '@/lib/relayPool';
+import { getEventsByPubkey } from '@/lib/db';
+
+const subscribeMany = relayPool.subscribeMany as any;
+
+describe('fetchProfile', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  it('returns lud16 and wallets when cached event has only lud16', async () => {
+    getEventsByPubkey.mockResolvedValueOnce([
+      { kind: nostrKinds.Metadata, content: JSON.stringify({ lud16: 'alice@test' }) },
+    ]);
+
+    await prefetchProfile('pk1');
+    const data: any = queryClient.getQueryData(['profile', 'pk1']);
+    expect(data?.lud16).toBe('alice@test');
+    expect(data?.wallets).toEqual([
+      { label: 'Default', lnaddr: 'alice@test', default: true },
+    ]);
+    expect(subscribeMany).not.toHaveBeenCalled();
+  });
+
+  it('sets lud16 from default wallet when missing', async () => {
+    getEventsByPubkey.mockResolvedValueOnce([
+      {
+        kind: nostrKinds.Metadata,
+        content: JSON.stringify({ wallets: [{ label: 'Main', lnaddr: 'bob@test', default: true }] }),
+      },
+    ]);
+
+    await prefetchProfile('pk2');
+    const data: any = queryClient.getQueryData(['profile', 'pk2']);
+    expect(data?.lud16).toBe('bob@test');
+    expect(data?.wallets).toEqual([
+      { label: 'Main', lnaddr: 'bob@test', default: true },
+    ]);
+    expect(subscribeMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- use profile.lud16 when wallet list is empty in create form defaults
- ensure profile fetch populates both wallets and lud16 fields
- mark LightningCard as client component

## Testing
- `pnpm test apps/web/hooks/useProfiles.test.ts`
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx` *(fails: No test files found, excludes apps/web/components/create/CreateVideoForm*.test.tsx)*
- `pnpm test apps/web/components/create/CreateVideoForm.profiles.test.tsx` *(fails: No test files found, excludes apps/web/components/create/CreateVideoForm*.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68983ba34d188331aecf768cda6602bc