### PR TITLE
Sync Chakra color mode with next-themes

### DIFF
--- a/apps/web/app/providers.test.tsx
+++ b/apps/web/app/providers.test.tsx
@@ -1,0 +1,64 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Providers from './providers';
+import { useTheme } from 'next-themes';
+import { useColorMode } from '@chakra-ui/react';
+import { vi } from 'vitest';
+
+// Ensure React is available globally for components compiled with the classic JSX runtime
+(globalThis as any).React = React;
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+vi.mock('@/components/ui/Overlay', () => ({ OverlayHost: () => null }));
+
+function TestComponent() {
+  const { setTheme } = useTheme();
+  const { colorMode } = useColorMode();
+
+  return (
+    <>
+      <div data-testid="tailwind" className="bg-white dark:bg-black" />
+      <div data-testid="chakra">{colorMode}</div>
+      <button onClick={() => setTheme('dark')}>dark</button>
+      <button onClick={() => setTheme('light')}>light</button>
+    </>
+  );
+}
+
+describe('Providers theme sync', () => {
+  it('syncs next-themes with chakra color mode', async () => {
+    const user = userEvent.setup();
+    render(
+      <Providers>
+        <TestComponent />
+      </Providers>,
+    );
+
+    expect(screen.getByTestId('chakra').textContent).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    await user.click(screen.getByText('dark'));
+    await waitFor(() => expect(screen.getByTestId('chakra').textContent).toBe('dark'));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    await user.click(screen.getByText('light'));
+    await waitFor(() => expect(screen.getByTestId('chakra').textContent).toBe('light'));
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,19 +1,34 @@
 'use client';
 
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, useColorMode } from '@chakra-ui/react';
 import theme from '../styles/theme';
-import { ThemeProvider } from 'next-themes';
+import { ThemeProvider, useTheme } from 'next-themes';
 import { ModqueueProvider } from '@/context/modqueueContext';
 import { GestureProvider } from '@paiduan/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
 import { OverlayHost } from '@/components/ui/Overlay';
 import { NotificationsProvider } from '@/hooks/useNotifications';
+import { useEffect } from 'react';
+
+function ColorModeSync() {
+  const { resolvedTheme } = useTheme();
+  const { setColorMode } = useColorMode();
+
+  useEffect(() => {
+    if (resolvedTheme) {
+      setColorMode(resolvedTheme as 'light' | 'dark');
+    }
+  }, [resolvedTheme, setColorMode]);
+
+  return null;
+}
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ChakraProvider theme={theme}>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <ColorModeSync />
         <GestureProvider>
           <ModqueueProvider>
             <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary
- keep Chakra's color mode in sync with next-themes by listening for theme changes
- add unit test ensuring theme toggles update both Chakra color mode and Tailwind dark class

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test apps/web/app/providers.test.tsx`
- `pnpm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68983c221f388331bb354a1497080b31