### PR TITLE
test: initialize lightning address from profile

### DIFF
--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -58,6 +58,41 @@ describe('CreateVideoForm', () => {
     queryClient.clear();
   });
 
+  it('prefills lightning address from profile', async () => {
+    profileMock = { lud16: 'user@example.com' };
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CreateVideoForm />
+        </QueryClientProvider>,
+      );
+    });
+    await Promise.resolve();
+    const lightningInput = Array.from(container.querySelectorAll('label'))
+      .find((l) => l.textContent?.includes('Lightning address'))!
+      .querySelector('input') as HTMLInputElement;
+    expect(lightningInput.value).toBe('user@example.com');
+  });
+
+  it('starts with empty lightning address when profile missing data', async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CreateVideoForm />
+        </QueryClientProvider>,
+      );
+    });
+    await Promise.resolve();
+    const lightningInput = Array.from(container.querySelectorAll('label'))
+      .find((l) => l.textContent?.includes('Lightning address'))!
+      .querySelector('input') as HTMLInputElement;
+    expect(lightningInput.value).toBe('');
+  });
+
   it('auto trims selected file and keeps publish disabled until form complete', async () => {
     (URL as any).createObjectURL = vi.fn(() => 'blob:mock');
     mockTrim.mockImplementation((_f: any, opts: any, onProgress: any) => {

--- a/apps/web/components/settings/LightningCard.tsx
+++ b/apps/web/components/settings/LightningCard.tsx
@@ -29,6 +29,8 @@ export function LightningCard() {
 
   useEffect(() => {
     if (Array.isArray(meta?.wallets)) setWallets(meta.wallets);
+    else if (typeof meta?.lud16 === 'string' && meta.lud16)
+      setWallets([{ label: '', lnaddr: meta.lud16, default: true }]);
     if (Array.isArray(meta?.zapSplits)) setZapSplits(meta.zapSplits);
   }, [meta]);
 

--- a/apps/web/components/settings/__tests__/LightningCard.test.tsx
+++ b/apps/web/components/settings/__tests__/LightningCard.test.tsx
@@ -13,8 +13,9 @@ vi.mock('@/hooks/useAuth', () => ({
   }),
 }));
 
+let profileMock: any = { wallets: [] };
 vi.mock('@/hooks/useProfile', () => ({
-  useProfile: () => ({ wallets: [] }),
+  useProfile: () => profileMock,
 }));
 
 var publishMock: any;
@@ -41,10 +42,25 @@ describe('LightningCard', () => {
     writeTextMock.mockReset();
     (QRCode.toDataURL as any).mockReset();
     (QRCode.toDataURL as any).mockResolvedValue('data:image/png;base64,qr');
+    profileMock = { wallets: [] };
   });
 
   afterEach(() => {
     cleanup();
+  });
+
+  it('initializes wallet input from profile lud16', async () => {
+    profileMock = { lud16: 'user@example.com' };
+    render(<LightningCard />);
+    expect(await screen.findByDisplayValue('user@example.com')).toBeTruthy();
+  });
+
+  it('starts with empty wallet input when profile has none', async () => {
+    profileMock = {};
+    render(<LightningCard />);
+    fireEvent.click(screen.getByText('Add wallet'));
+    const addrInput = screen.getByPlaceholderText('name@example.com') as HTMLInputElement;
+    expect(addrInput.value).toBe('');
   });
 
   it('adds wallet and saves', async () => {


### PR DESCRIPTION
## Summary
- populate LightningCard wallets from `lud16` when profile has no wallet list
- test CreateVideoForm pre-fills lightning address from profile `lud16` and falls back when absent
- test LightningCard initializes wallet input from profile `lud16` and empty when no wallet data

## Testing
- `pnpm test apps/web/components/settings/__tests__/LightningCard.test.tsx`
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx` *(fails: No test files found, excluded by config)*

------
https://chatgpt.com/codex/tasks/task_e_68983e264ce483318a69d2defda7515a