### PR TITLE
refactor: route uploads and publishing through agents

### DIFF
--- a/apps/web/agents/bus.ts
+++ b/apps/web/agents/bus.ts
@@ -1,0 +1,31 @@
+export type AppEvent =
+  | { type: 'upload.progress'; id: string; pct: number }
+  | { type: 'upload.complete'; id: string }
+  | { type: 'nostr.published'; id?: string }
+  | { type: 'nostr.error'; error: string };
+
+export type Unsub = () => void;
+
+class EventBus {
+  private listeners: {
+    [K in AppEvent['type']]?: Array<(e: Extract<AppEvent, { type: K }>) => void>;
+  } = {};
+
+  emit<E extends AppEvent>(event: E): void {
+    this.listeners[event.type]?.forEach((cb) => cb(event as any));
+  }
+
+  on<T extends AppEvent['type']>(
+    type: T,
+    cb: (event: Extract<AppEvent, { type: T }>) => void,
+  ): Unsub {
+    (this.listeners[type] ??= []).push(cb as any);
+    return () => {
+      const arr = this.listeners[type];
+      if (!arr) return;
+      this.listeners[type] = arr.filter((fn) => fn !== cb);
+    };
+  }
+}
+
+export const bus = new EventBus();

--- a/apps/web/agents/media.ts
+++ b/apps/web/agents/media.ts
@@ -1,0 +1,91 @@
+import type { EventTemplate } from 'nostr-tools/pure';
+
+interface ZapSplit {
+  lnaddr: string;
+  pct: number;
+}
+
+interface VideoEventParams {
+  caption: string;
+  topics: string;
+  license: string;
+  lightningAddress: string;
+  zapSplits: ZapSplit[];
+  nsfw: boolean;
+  dimensions: { width: number; height: number };
+  video: string;
+  poster: string;
+  manifest?: string;
+  mimeTag: string;
+  pubkey: string;
+}
+
+export function createVideoEvent(params: VideoEventParams): EventTemplate & {
+  pubkey: string;
+} {
+  const {
+    caption,
+    topics,
+    license,
+    lightningAddress,
+    zapSplits,
+    nsfw,
+    dimensions,
+    video,
+    poster,
+    manifest,
+    mimeTag,
+    pubkey,
+  } = params;
+
+  const topicList = topics
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+  const totalPctSubmit = zapSplits.reduce((sum, s) => sum + s.pct, 0);
+  const dim = `${dimensions.width}x${dimensions.height}`;
+
+  const tags: string[][] = [
+    ['title', caption],
+    ['published_at', Math.floor(Date.now() / 1000).toString()],
+    ['imeta', `dim ${dim}`, `url ${video}`, mimeTag, `image ${poster}`],
+    ...topicList.map((t) => ['t', t]),
+  ];
+
+  if (manifest) {
+    tags.push([
+      'imeta',
+      `dim ${dim}`,
+      `url ${manifest}`,
+      'm application/x-mpegURL',
+      `image ${poster}`,
+    ]);
+  }
+
+  const creatorPct = Math.max(0, 100 - totalPctSubmit);
+  if (lightningAddress) {
+    tags.push(['zap', lightningAddress, creatorPct.toString()]);
+  }
+  zapSplits.forEach((s) => {
+    if (s.lnaddr && s.pct > 0) {
+      tags.push(['zap', s.lnaddr, s.pct.toString()]);
+    }
+  });
+  if (nsfw) tags.push(['content-warning', 'nsfw']);
+  if (license) tags.push(['copyright', license]);
+
+  const kind = dimensions.width >= dimensions.height ? 21 : 22;
+
+  const event: EventTemplate & { pubkey: string } = {
+    kind,
+    created_at: Math.floor(Date.now() / 1000),
+    content: caption,
+    tags,
+    pubkey,
+  };
+
+  return event;
+}
+
+const media = { createVideoEvent };
+export default media;

--- a/apps/web/agents/upload.ts
+++ b/apps/web/agents/upload.ts
@@ -1,0 +1,24 @@
+import { bus } from './bus';
+
+export async function uploadVideo(formData: FormData): Promise<{
+  video: string;
+  poster: string;
+  manifest?: string;
+}> {
+  bus.emit({ type: 'upload.progress', id: 'video', pct: 0 });
+  const res = await fetch('https://nostr.media/api/upload', {
+    method: 'POST',
+    body: formData,
+  });
+  if (!res.ok) {
+    bus.emit({ type: 'nostr.error', error: 'Upload failed' });
+    throw new Error('Upload failed');
+  }
+  const data = await res.json();
+  bus.emit({ type: 'upload.progress', id: 'video', pct: 100 });
+  bus.emit({ type: 'upload.complete', id: 'video' });
+  return data;
+}
+
+const upload = { uploadVideo };
+export default upload;


### PR DESCRIPTION
## Summary
- add a lightweight event bus for cross-agent communication
- add upload, media and nostr agent functions for video posting
- refactor CreateVideoForm to use the new agent APIs

## Testing
- `pnpm test` *(fails: Vitest caught 2 unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_68983e401ae4833196c70ee90c759cd0