### PR TITLE
feat(web): allow disabling cross-origin isolation

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,8 +4,6 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const isProd = process.env.NODE_ENV === 'production';
 
-const enableIsolation = process.env.ENABLE_ISOLATION !== 'false';
-
 const baseConfig = {
   experimental: { esmExternals: 'loose' },
   reactStrictMode: true,
@@ -16,6 +14,15 @@ const baseConfig = {
   },
   async headers() {
     const headers = [];
+
+    // Enable cross-origin isolation only when explicitly allowed.
+    // In development, isolation stays off unless ENABLE_ISOLATION=true.
+    // In production, it is on by default but can be disabled via
+    // ENABLE_ISOLATION=false.
+    const enableIsolation =
+      process.env.NODE_ENV === 'production'
+        ? process.env.ENABLE_ISOLATION !== 'false'
+        : process.env.ENABLE_ISOLATION === 'true';
 
     if (enableIsolation) {
       headers.push({


### PR DESCRIPTION
## Summary
- respect `ENABLE_ISOLATION` to disable cross-origin isolation in development unless explicitly enabled
- document isolation header handling in `next.config.mjs`

## Testing
- `pnpm test` *(fails: Vitest caught 1 unhandled error during the test run)*
- `ENABLE_ISOLATION=false pnpm --filter web dev & curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_68984025a66c8331a53a97a51eba6d95