### PR TITLE
feat: configure upload endpoint and use toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ curl -F "file=@video.mp4" -F "poster=@poster.jpg" https://nostr.media/api/upload
 
 The response returns `video`, `poster` and `manifest` URLs that can be referenced from an `imeta` tag when constructing a kind 21/22 event.
 
+Set the `NEXT_PUBLIC_UPLOAD_URL` environment variable to point the app at a different upload server.
+
 ### NIP‑71 video events
 
 PaiDuan uses [NIP‑71](https://github.com/nostr-protocol/nips/blob/master/71.md) for publishing video posts. Clients should:

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_UPLOAD_URL=https://nostr.media/api/upload

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,6 +4,10 @@
 
 The upload page at `pages/create.tsx` (and locale variants in `[locale]/create.tsx`) renders the `CreateVideoForm` component from `components/create/CreateVideoForm.tsx`. This form keeps file selection, metadata entry and publishing on a single screen.
 
+### Configuration
+
+Set `NEXT_PUBLIC_UPLOAD_URL` to change the upload API endpoint. It defaults to `https://nostr.media/api/upload`.
+
 ### Requirements
 
 - Accepted formats: mp4 and webm

--- a/apps/web/agents/bus.ts
+++ b/apps/web/agents/bus.ts
@@ -1,6 +1,7 @@
 export type AppEvent =
   | { type: 'upload.progress'; id: string; pct: number }
   | { type: 'upload.complete'; id: string }
+  | { type: 'upload.error'; id: string; error: string }
   | { type: 'nostr.published'; id?: string }
   | { type: 'nostr.error'; error: string };
 

--- a/apps/web/components/create/CreateVideoForm.test.tsx
+++ b/apps/web/components/create/CreateVideoForm.test.tsx
@@ -30,6 +30,8 @@ const mockPublish = vi.fn();
 vi.mock('../../lib/relayPool', () => ({ default: { publish: mockPublish } }));
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({ back: vi.fn() }) }));
+const mockToast = { success: vi.fn(), error: vi.fn() };
+vi.mock('react-hot-toast', () => ({ toast: mockToast }));
 let origCreateElement: any;
 
 describe('CreateVideoForm', () => {
@@ -37,6 +39,8 @@ describe('CreateVideoForm', () => {
     mockTrim.mockReset();
     mockSignEvent.mockReset();
     mockPublish.mockReset();
+    mockToast.success.mockReset();
+    mockToast.error.mockReset();
     (URL as any).revokeObjectURL = vi.fn();
     (HTMLMediaElement.prototype as any).load = vi.fn();
     (HTMLMediaElement.prototype as any).play = vi.fn(() => Promise.resolve());
@@ -56,6 +60,7 @@ describe('CreateVideoForm', () => {
     });
     profileMock = {};
     queryClient.clear();
+    delete process.env.NEXT_PUBLIC_UPLOAD_URL;
   });
 
   it('prefills lightning address from profile', async () => {
@@ -254,7 +259,7 @@ describe('CreateVideoForm', () => {
       }),
     );
     (globalThis as any).fetch = mockFetch;
-    (globalThis as any).alert = vi.fn();
+    process.env.NEXT_PUBLIC_UPLOAD_URL = 'https://nostr.media/api/upload';
 
     const container = document.createElement('div');
     const root = createRoot(container);
@@ -307,7 +312,10 @@ describe('CreateVideoForm', () => {
       publishBtn.click();
     });
 
-    expect(mockFetch).toHaveBeenCalledWith('https://nostr.media/api/upload', expect.any(Object));
+    expect(mockFetch).toHaveBeenCalledWith(
+      process.env.NEXT_PUBLIC_UPLOAD_URL,
+      expect.any(Object),
+    );
     const tags = mockSignEvent.mock.calls[0][0].tags;
     expect(tags).toContainEqual(['zap', 'addr', '100']);
     expect(tags).toContainEqual(['copyright', 'CC BY']);
@@ -327,7 +335,6 @@ describe('CreateVideoForm', () => {
       }),
     );
     (globalThis as any).fetch = mockFetch;
-    (globalThis as any).alert = vi.fn();
 
     const container = document.createElement('div');
     const root = createRoot(container);
@@ -406,7 +413,6 @@ describe('CreateVideoForm', () => {
       }),
     );
     (globalThis as any).fetch = mockFetch;
-    (globalThis as any).alert = vi.fn();
 
     const container = document.createElement('div');
     const root = createRoot(container);


### PR DESCRIPTION
## Summary
- configure upload API via `NEXT_PUBLIC_UPLOAD_URL`
- replace alerts and confirms with toast notifications and modal
- surface upload/nostr status via event bus

## Testing
- `pnpm test` *(fails: Vitest caught 1 unhandled error)*

------
https://chatgpt.com/codex/tasks/task_e_689840a1366483318bec33048729421c