### PR TITLE
Add data-index to virtualized elements

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -79,6 +79,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
             <div
               key={item.eventId ?? virtualRow.index}
               ref={rowVirtualizer.measureElement}
+              data-index={virtualRow.index}
               className="snap-start min-h-screen"
             >
               <VideoCard {...item} showMenu />

--- a/apps/web/components/ThreadedComments.tsx
+++ b/apps/web/components/ThreadedComments.tsx
@@ -51,6 +51,7 @@ export default function ThreadedComments({ noteId }: { noteId?: string }) {
               <li
                 key={events[virtualRow.index].id}
                 ref={rowVirtualizer.measureElement}
+                data-index={virtualRow.index}
                 className="absolute top-0 left-0 w-full text-sm text-gray-800 dark:text-gray-200"
                 style={{
                   transform: `translateY(${virtualRow.start}px)`,

--- a/apps/web/components/VideoFeed.tsx
+++ b/apps/web/components/VideoFeed.tsx
@@ -36,6 +36,7 @@ export default function VideoFeed({ onAuthorClick }: { onAuthorClick: (pubkey: s
           <div
             key={virtualRow.key}
             ref={rowVirtualizer.measureElement}
+            data-index={virtualRow.index}
             className="absolute top-0 left-0 w-full"
             style={{
               transform: `translateY(${virtualRow.start}px)`,


### PR DESCRIPTION
## Summary
- ensure virtualizer measure elements are tagged with data-index to satisfy tanstack virtualization requirements

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Unhandled Errors)*

------
https://chatgpt.com/codex/tasks/task_e_689841a5873c8331a2b53ac650d991cd