### PR TITLE
refactor: reuse create page for i18n

### DIFF
--- a/apps/web/app/[locale]/create/page.tsx
+++ b/apps/web/app/[locale]/create/page.tsx
@@ -1,18 +1,1 @@
-import { NextIntlClientProvider, getMessages } from 'next-intl/server';
-import CreatePage from '../../create/page';
-
-export default async function LocaleCreatePage({
-  params,
-}: {
-  params: Promise<{ locale: string }>;
-}) {
-  const { locale } = await params;
-  const messages = await getMessages();
-  const createMessages = (await import(`@/locales/${locale}/create.json`)).default;
-
-  return (
-    <NextIntlClientProvider locale={locale} messages={{ ...messages, create: createMessages }}>
-      <CreatePage />
-    </NextIntlClientProvider>
-  );
-}
+export { default, metadata } from '../../create/page';

--- a/apps/web/app/create/CreatePageClient.tsx
+++ b/apps/web/app/create/CreatePageClient.tsx
@@ -1,0 +1,25 @@
+'use client';
+import dynamic from 'next/dynamic';
+import SearchBar from '@/components/SearchBar';
+import MiniProfileCard from '@/components/MiniProfileCard';
+
+const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'), { ssr: false });
+
+export default function CreatePageClient() {
+  return (
+    <div className="box-border min-h-screen h-screen">
+      <main className="mx-auto max-w-[1400px] px-4 h-full">
+        <div className="grid h-full gap-6 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[280px_minmax(0,1fr)_340px]">
+          <aside className="hidden lg:block self-start sticky top-20 space-y-4">
+            <SearchBar />
+            <MiniProfileCard />
+          </aside>
+
+          <section className="xl:col-span-2">
+            <CreatorWizard />
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/create/page.test.ts
+++ b/apps/web/app/create/page.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { metadata } from '@/app/create/page';
+import { metadata as localizedMetadata } from '@/app/[locale]/create/page';
+import { locales } from '@/utils/locales';
+
+describe('create page metadata', () => {
+  it('includes language alternates for each locale', () => {
+    const expected = Object.fromEntries(
+      locales.map((locale) => [locale, `/${locale}/create`]),
+    );
+    expect(metadata.alternates?.languages).toEqual(expected);
+  });
+
+  it('is re-exported by localized route', () => {
+    expect(localizedMetadata).toEqual(metadata);
+  });
+});

--- a/apps/web/app/create/page.tsx
+++ b/apps/web/app/create/page.tsx
@@ -1,25 +1,28 @@
-"use client";
-import dynamic from 'next/dynamic';
-import SearchBar from '@/components/SearchBar';
-import MiniProfileCard from '@/components/MiniProfileCard';
+import { NextIntlClientProvider, getMessages } from 'next-intl/server';
+import type { Metadata } from 'next';
+import { locales } from '@/utils/locales';
+import CreatePageClient from './CreatePageClient';
 
-const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'), { ssr: false });
+export const metadata: Metadata = {
+  alternates: {
+    languages: Object.fromEntries(
+      locales.map((locale) => [locale, `/${locale}/create`]),
+    ),
+  },
+};
 
-export default function CreatePage() {
+export default async function CreatePage({
+  params,
+}: {
+  params: Promise<{ locale?: string }>;
+}) {
+  const { locale = 'en' } = await params;
+  const messages = await getMessages();
+  const createMessages = (await import(`@/locales/${locale}/create.json`)).default;
+
   return (
-    <div className="box-border min-h-screen h-screen">
-      <main className="mx-auto max-w-[1400px] px-4 h-full">
-        <div className="grid h-full gap-6 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[280px_minmax(0,1fr)_340px]">
-          <aside className="hidden lg:block self-start sticky top-20 space-y-4">
-            <SearchBar />
-            <MiniProfileCard />
-          </aside>
-
-          <section className="xl:col-span-2">
-            <CreatorWizard />
-          </section>
-        </div>
-      </main>
-    </div>
+    <NextIntlClientProvider locale={locale} messages={{ ...messages, create: createMessages }}>
+      <CreatePageClient />
+    </NextIntlClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- reuse create page for locale-specific routes via re-exports
- load locale messages and language alternates for create page
- add tests for metadata on localized create routes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest caught 1 unhandled error)*

------
https://chatgpt.com/codex/tasks/task_e_68984b0f66bc8331b4cab58672c60a86