### PR TITLE
fix: maintain image aspect ratio

### DIFF
--- a/apps/web/app/p/[pubkey]/page.tsx
+++ b/apps/web/app/p/[pubkey]/page.tsx
@@ -236,6 +236,7 @@ export default function ProfilePage() {
               width={1920}
               height={1080}
               className="w-full aspect-video object-cover cursor-pointer"
+              style={{ height: 'auto' }}
               onClick={() => setSelected(v)}
               unoptimized
             />


### PR DESCRIPTION
## Summary
- ensure profile video thumbnails maintain aspect ratio by using height: auto when overriding width

## Testing
- `pnpm test` *(fails: Vitest caught 1 unhandled error)*

------
https://chatgpt.com/codex/tasks/task_e_68984bbb2b348331bdbd259cfc4b17b1