### PR TITLE
feat: type-safe time series chart

### DIFF
--- a/apps/web/app/p/[pubkey]/analytics/page.tsx
+++ b/apps/web/app/p/[pubkey]/analytics/page.tsx
@@ -10,7 +10,7 @@ export default function CreatorAnalytics() {
   const downloadCsv = () => {
     if (!data) return;
     const header = ['date', 'views', 'zapsSats', 'comments', 'followerDelta', 'revenueAud'];
-    const rows = data.dailySeries.map((d: any) =>
+    const rows = data.dailySeries.map((d) =>
       [d.date, d.views, d.zapsSats, d.comments, d.followerDelta, d.revenueAud].join(',')
     );
     const csv = [header.join(','), ...rows].join('\n');

--- a/apps/web/hooks/useCreatorAnalytics.ts
+++ b/apps/web/hooks/useCreatorAnalytics.ts
@@ -1,16 +1,14 @@
 "use client";
 
 import { useEffect, useState } from 'react';
+import type {
+  AggregatedStats as BaseStats,
+  DailyEntry as BaseDailyEntry,
+} from '../lib/creatorStatsStore';
 
-export interface CreatorStats {
-  totals: {
-    views: number;
-    zapsSats: number;
-    comments: number;
-    followerDelta: number;
-    revenueAud: number;
-  };
-  dailySeries: any[];
+export type DailyStat = BaseDailyEntry & Record<string, unknown>;
+export interface CreatorStats extends BaseStats {
+  dailySeries: DailyStat[];
 }
 
 export default function useCreatorAnalytics(pubkey?: string) {
@@ -64,7 +62,7 @@ export default function useCreatorAnalytics(pubkey?: string) {
         if (!res.ok) throw new Error(String(res.status));
         return res.json();
       })
-      .then((json) => {
+      .then((json: CreatorStats) => {
         setData(json);
         if (typeof window !== 'undefined') {
           try {
@@ -83,7 +81,7 @@ export default function useCreatorAnalytics(pubkey?: string) {
     es = new EventSource(`/api/creator-stats?pubkey=${pubkey}&stream=1`);
     es.onmessage = (ev) => {
       try {
-        const json = JSON.parse(ev.data);
+        const json = JSON.parse(ev.data) as CreatorStats;
         setData(json);
         if (typeof window !== 'undefined') {
           try {

--- a/packages/ui/src/TimeSeriesChart.tsx
+++ b/packages/ui/src/TimeSeriesChart.tsx
@@ -11,19 +11,22 @@ import {
   Tooltip,
 } from 'recharts';
 
-interface LineDef {
-  dataKey: string;
+interface LineDef<T extends Record<string, unknown>> {
+  dataKey: keyof T;
   color: string;
   type?: 'line' | 'area';
   stackId?: string;
 }
 
-interface Props {
-  data: any[];
-  lines: LineDef[];
+interface Props<T extends Record<string, unknown>> {
+  data: T[];
+  lines: LineDef<T>[];
 }
 
-export function TimeSeriesChart({ data, lines }: Props) {
+export function TimeSeriesChart<T extends Record<string, unknown>>({
+  data,
+  lines,
+}: Props<T>) {
   const hasArea = lines.some((l) => l.type === 'area');
   if (hasArea) {
     return (
@@ -35,9 +38,9 @@ export function TimeSeriesChart({ data, lines }: Props) {
           <Tooltip />
           {lines.map((l) => (
             <Area
-              key={l.dataKey}
+              key={String(l.dataKey)}
               type="monotone"
-              dataKey={l.dataKey}
+              dataKey={String(l.dataKey)}
               stackId={l.stackId}
               stroke={l.color}
               fill={l.color}
@@ -55,7 +58,12 @@ export function TimeSeriesChart({ data, lines }: Props) {
         <YAxis />
         <Tooltip />
         {lines.map((l) => (
-          <Line key={l.dataKey} type="monotone" dataKey={l.dataKey} stroke={l.color} />
+          <Line
+            key={String(l.dataKey)}
+            type="monotone"
+            dataKey={String(l.dataKey)}
+            stroke={l.color}
+          />
         ))}
       </LineChart>
     </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- make `TimeSeriesChart` generic over record types
- type creator analytics hook and chart usage

## Testing
- `pnpm exec tsc --noEmit -p packages/ui/tsconfig.json`
- `pnpm exec tsc --noEmit -p apps/web/tsconfig.json` *(fails: missing qrcode types and other existing errors)*


------
https://chatgpt.com/codex/tasks/task_e_68984dc5523c83318d8140cc7eed71b5