### PR TITLE
fix feed remeasurement after video load

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -17,6 +17,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   const parentRef = useRef<HTMLDivElement>(null);
   const setSelectedVideo = useFeedSelection((s) => s.setSelectedVideo);
   const selectedVideoId = useFeedSelection((s) => s.selectedVideoId);
+  const rowRefs = useRef<(HTMLElement | null)[]>([]);
 
   const rowVirtualizer = useVirtualizer({
     count: items.length,
@@ -68,12 +69,17 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
         className="w-full"
       >
         {virtualItems.map((virtualRow) => {
-          const item = items[virtualRow.index];
+          const index = virtualRow.index;
+          const item = items[index];
           return (
             <div
-              key={item.eventId ?? virtualRow.index}
-              data-index={virtualRow.index}
+              key={item.eventId ?? index}
+              data-index={index}
               className="h-screen w-full snap-start snap-always"
+              ref={(el) => {
+                rowRefs.current[index] = el;
+                if (el) rowVirtualizer.measureElement(el);
+              }}
               style={{
                 position: 'absolute',
                 top: 0,
@@ -81,7 +87,14 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
                 transform: `translateY(${virtualRow.start}px)`,
               }}
             >
-              <VideoCard {...item} showMenu />
+              <VideoCard
+                {...item}
+                showMenu
+                onReady={() => {
+                  const el = rowRefs.current[index];
+                  if (el) rowVirtualizer.measureElement(el);
+                }}
+              />
             </div>
           );
         })}

--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -61,7 +61,8 @@ describe('VideoCard', () => {
     expect(() => unmount()).not.toThrow();
   });
 
-  it('shows and hides placeholder around video load', async () => {
+  it('shows and hides placeholder around video load and fires onReady', async () => {
+    const onReady = vi.fn();
     const props = {
       videoUrl: 'video.mp4',
       author: 'author',
@@ -69,6 +70,7 @@ describe('VideoCard', () => {
       eventId: 'event',
       pubkey: 'pk',
       zap: <div />,
+      onReady,
     };
     const { container } = render(<VideoCard {...props} />);
     await screen.findByText('Loading video…');
@@ -76,6 +78,7 @@ describe('VideoCard', () => {
     fireEvent.loadedData(video);
     await waitFor(() => {
       expect(screen.queryByText('Loading video…')).toBeNull();
+      expect(onReady).toHaveBeenCalled();
     });
   });
 

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -34,6 +34,11 @@ export interface VideoCardProps {
   onComment?: () => void;
   onRepost?: () => Promise<void> | void;
   zap?: React.ReactNode;
+  /**
+   * Fired when the underlying video element has loaded enough data to play.
+   * Useful for triggering measurements or other side effects once the video is ready.
+   */
+  onReady?: () => void;
 }
 
 export const VideoCard: React.FC<VideoCardProps> = ({
@@ -51,6 +56,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   onComment,
   onRepost,
   zap,
+  onReady,
 }) => {
   const router = useRouter();
   const playerRef = useRef<HTMLVideoElement>(null);
@@ -180,7 +186,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="relative w-full h-full max-h-full overflow-hidden rounded-2xl bg-card text-white shadow-card"
+      className="relative w-full h-screen overflow-hidden rounded-2xl bg-card text-white shadow-card"
       onClick={() => setSelectedVideo(eventId, pubkey)}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
@@ -212,6 +218,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
                   setIsPlaying(false);
                 });
             }
+            onReady?.();
           }}
           onError={() => setErrorMessage('Video playback error')}
         />


### PR DESCRIPTION
## Summary
- fix `VideoCard` wrapper to a screen height and expose `onReady` callback
- remeasure virtualized rows in `Feed` when a video finishes loading
- test that `VideoCard` fires `onReady`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Unhandled Errors during test run)*

------
https://chatgpt.com/codex/tasks/task_e_68984fb131bc83319cf85ae973d36d5b