### PR TITLE
Pause previous video when switching playback source

### DIFF
--- a/apps/web/agents/playback.ts
+++ b/apps/web/agents/playback.ts
@@ -26,6 +26,10 @@ function loadSource(
   if (video) {
     video.removeEventListener('play', handlePlay);
     video.removeEventListener('pause', handlePause);
+    video.pause();
+    video.removeAttribute('src');
+    // Force the browser to stop loading the previous source
+    video.load();
   }
   hls?.destroy();
   video = el;

--- a/apps/web/components/VideoCard.playback.test.tsx
+++ b/apps/web/components/VideoCard.playback.test.tsx
@@ -1,0 +1,85 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+// Ensure React is available globally for components compiled with the classic JSX runtime
+;(globalThis as any).React = React;
+
+// Mock media element methods
+Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+  configurable: true,
+  value: vi.fn(() => Promise.resolve()),
+});
+Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
+  configurable: true,
+  value: vi.fn(),
+});
+Object.defineProperty(HTMLMediaElement.prototype, 'load', {
+  configurable: true,
+  value: vi.fn(),
+});
+
+vi.mock('./ReportModal', () => ({ default: () => null }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ prefetch: () => {} }) }));
+vi.mock('../hooks/useFollowing', () => ({ default: () => ({ following: [], follow: () => {} }) }));
+vi.mock('react-use', () => ({ useNetworkState: () => ({ online: true }) }));
+vi.mock('../hooks/useAdaptiveSource', () => ({ default: () => undefined }));
+vi.mock('react-intersection-observer', () => ({ useInView: () => ({ ref: () => {}, inView: true }) }));
+vi.mock('../hooks/useCurrentVideo', () => ({ useCurrentVideo: () => ({ setCurrent: () => {} }) }));
+vi.mock('@/store/feedSelection', () => ({
+  useFeedSelection: (selector: any) => selector({ setSelectedVideo: () => {} }),
+}));
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ state: { status: 'ready', pubkey: 'pk', signer: {} } }) }));
+vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({ picture: '', name: 'author' }) }));
+vi.mock('@/hooks/useProfiles', () => ({ prefetchProfile: () => Promise.resolve() }));
+
+import VideoCard from './VideoCard';
+
+describe('VideoCard playback switching', () => {
+  it('only plays the most recent video', async () => {
+    const playMock = HTMLMediaElement.prototype.play as unknown as vi.Mock;
+    const pauseMock = HTMLMediaElement.prototype.pause as unknown as vi.Mock;
+    playMock.mockClear();
+    pauseMock.mockClear();
+
+    const props1 = {
+      videoUrl: 'video1.mp4',
+      author: 'author1',
+      caption: 'caption1',
+      eventId: 'event1',
+      pubkey: 'pk1',
+      zap: <div />,
+    };
+
+    const props2 = {
+      videoUrl: 'video2.mp4',
+      author: 'author2',
+      caption: 'caption2',
+      eventId: 'event2',
+      pubkey: 'pk2',
+      zap: <div />,
+    };
+
+    const Wrapper = ({ showSecond }: { showSecond: boolean }) => (
+      <>
+        <VideoCard {...props1} />
+        {showSecond && <VideoCard {...props2} />}
+      </>
+    );
+
+    const { rerender, container } = render(<Wrapper showSecond={false} />);
+    const video1 = container.querySelector('video') as HTMLVideoElement;
+    fireEvent.loadedData(video1);
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+    expect(pauseMock).not.toHaveBeenCalled();
+
+    rerender(<Wrapper showSecond={true} />);
+    const videos = container.querySelectorAll('video');
+    const video2 = videos[1] as HTMLVideoElement;
+    fireEvent.loadedData(video2);
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- pause and clear previous video before loading a new source
- add regression test ensuring only the latest VideoCard plays

## Testing
- `pnpm lint`
- `pnpm test apps/web/components/VideoCard.playback.test.tsx`
- `pnpm test` *(fails: Vitest caught 1 unhandled error during the test run)*

------
https://chatgpt.com/codex/tasks/task_e_689852c76de08331983f705c647eebcd