### PR TITLE
feat(web): cache nostr comments

### DIFF
--- a/apps/web/agents/nostr.comments.test.ts
+++ b/apps/web/agents/nostr.comments.test.ts
@@ -3,8 +3,13 @@ import type { EventTemplate } from 'nostr-tools/pure';
 import type { Signer } from '@/lib/signers/types';
 import { subscribe, sendComment } from './nostr.comments';
 import pool from '@/lib/relayPool';
+import { getCommentsByVideoId, saveComment } from '@/lib/db';
 
 vi.mock('@/lib/nostr', () => ({ getRelays: () => ['wss://example.com'] }));
+vi.mock('@/lib/db', () => ({
+  getCommentsByVideoId: vi.fn().mockResolvedValue([]),
+  saveComment: vi.fn(),
+}));
 
 const close = vi.fn();
 let handlers: any;
@@ -32,10 +37,34 @@ describe('nostr.comments', () => {
     const signer: Signer = {
       type: 'local',
       getPublicKey: vi.fn().mockResolvedValue('pub'),
-      signEvent: vi.fn(async (evt: any) => ({ ...evt, id: 'id', sig: 'sig', pubkey: evt.pubkey || 'pub' })),
+      signEvent: vi.fn(async (evt: any) => ({
+        ...evt,
+        id: 'id',
+        sig: 'sig',
+        pubkey: evt.pubkey || 'pub',
+      })),
     };
     await sendComment('video123', 'hello', signer);
     const arg = (signer.signEvent as any).mock.calls[0][0];
     expectTypeOf(arg).toMatchTypeOf<EventTemplate & { pubkey: string }>();
+  });
+
+  it('reads cache before subscribing and saves incoming events', async () => {
+    const cached: any = {
+      id: 'cached',
+      pubkey: 'pub',
+      created_at: 1,
+      kind: 1,
+      tags: [],
+      content: 'hello',
+    };
+    (getCommentsByVideoId as any).mockResolvedValueOnce([cached]);
+    const onEvent = vi.fn();
+    subscribe('video123', onEvent);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onEvent).toHaveBeenCalled();
+    expect(onEvent.mock.calls[0][0]).toEqual(cached);
+    handlers.onevent(cached);
+    expect(saveComment).toHaveBeenCalledWith('video123', cached);
   });
 });

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -6,19 +6,43 @@ interface StoredEvent {
   event: any;
 }
 
+interface StoredComment {
+  videoId: string;
+  id: string;
+  event: any;
+  created_at: number;
+}
+
 class NostrCacheDB extends Dexie {
   events!: Table<StoredEvent, [string, string]>;
+  comments!: Table<StoredComment, [string, string]>;
 
   constructor() {
     super('nostr-cache');
     this.version(1).stores({
       events: '[pubkey+id]',
     });
+    this.version(2).stores({
+      events: '[pubkey+id]',
+      comments: '[videoId+id], created_at',
+    });
   }
 }
 
-export const db =
-  typeof indexedDB === 'undefined' ? null : new NostrCacheDB();
+export const db = typeof indexedDB === 'undefined' ? null : new NostrCacheDB();
+
+const COMMENT_TTL_SECONDS = 60 * 60 * 24;
+
+export async function cleanupOldComments(): Promise<void> {
+  if (!db) return;
+  const cutoff = Math.floor(Date.now() / 1000) - COMMENT_TTL_SECONDS;
+  await db.comments.where('created_at').below(cutoff).delete();
+}
+
+if (db) {
+  void cleanupOldComments();
+  setInterval(cleanupOldComments, COMMENT_TTL_SECONDS * 1000);
+}
 
 export async function saveEvent(event: any): Promise<void> {
   if (!db) return;
@@ -44,3 +68,25 @@ export async function getAllEvents(): Promise<any[]> {
   return rows.map((r) => r.event);
 }
 
+export async function saveComment(videoId: string, event: any): Promise<void> {
+  if (!db) return;
+  try {
+    await db.comments.add({
+      videoId,
+      id: event.id,
+      event,
+      created_at: event.created_at,
+    });
+  } catch (err: any) {
+    if (err?.name !== 'ConstraintError') throw err;
+  }
+}
+
+export async function getCommentsByVideoId(videoId: string): Promise<any[]> {
+  if (!db) return [];
+  const rows = await db.comments
+    .where('[videoId+id]')
+    .between([videoId, Dexie.minKey], [videoId, Dexie.maxKey])
+    .toArray();
+  return rows.map((r) => r.event);
+}


### PR DESCRIPTION
## Summary
- add IndexedDB comments cache with daily cleanup
- use cached comments before subscribing to nostr relays
- hydrate comment hook from cache and avoid unnecessary network fetches

## Testing
- `pnpm test apps/web/agents/nostr.comments.test.ts`
- `pnpm test` *(fails: Vitest reported an unhandled error after all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_6898569fb6f483319408fd92e0a0e657