### PR TITLE
chore: skip locale redirect for service workers

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -16,7 +16,13 @@ function getLocale(req: NextRequest): string {
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
-  if (PUBLIC_FILE.test(pathname) || pathname.startsWith('/_next') || pathname.startsWith('/api')) {
+  if (
+    pathname === '/sw.js' ||
+    pathname === '/workbox-sw.js' ||
+    PUBLIC_FILE.test(pathname) ||
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/api')
+  ) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary
- ensure `sw.js` and `workbox-sw.js` skip locale redirection in middleware

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test` *(fails: 2 unhandled errors)*
- `curl -i http://localhost:3000/workbox-sw.js`

------
https://chatgpt.com/codex/tasks/task_e_689857a77f288331a89798efa9f837fe