### PR TITLE
chore: dedupe following subscriptions

### DIFF
--- a/apps/web/hooks/useFollowing.ts
+++ b/apps/web/hooks/useFollowing.ts
@@ -7,6 +7,9 @@ import pool from '@/lib/relayPool';
 import { useFollowingStore, setFollowing } from '@/store/following';
 import { useAuth } from './useAuth';
 
+// Track active subscriptions per pubkey to avoid duplicate network traffic.
+const activeSubs = new Map<string, { sub: { close: () => void }; refs: number }>();
+
 export function useFollowing(pubkey?: string) {
   const { state } = useAuth();
   const actualPubkey = pubkey ?? (state.status === 'ready' ? state.pubkey : undefined);
@@ -14,7 +17,21 @@ export function useFollowing(pubkey?: string) {
 
   useEffect(() => {
     if (!actualPubkey) return;
-    const sub = pool.subscribeMany(
+
+    const entry = activeSubs.get(actualPubkey);
+    if (entry) {
+      entry.refs++;
+      return () => {
+        const e = activeSubs.get(actualPubkey);
+        if (e && --e.refs === 0) {
+          e.sub.close();
+          activeSubs.delete(actualPubkey);
+        }
+      };
+    }
+
+    let sub: { close: () => void };
+    sub = pool.subscribeMany(
       getRelays(),
       [{ kinds: [nostrKinds.Contacts], authors: [actualPubkey] } as Filter],
       {
@@ -24,10 +41,21 @@ export function useFollowing(pubkey?: string) {
             .map((t: any) => t[1]);
           setFollowing(Array.from(new Set(contacts)));
         },
-        oneose: () => sub.close(),
+        oneose: () => {
+          sub.close();
+          activeSubs.delete(actualPubkey);
+        },
       },
     );
-    return () => sub.close();
+    activeSubs.set(actualPubkey, { sub, refs: 1 });
+
+    return () => {
+      const e = activeSubs.get(actualPubkey);
+      if (e && --e.refs === 0) {
+        e.sub.close();
+        activeSubs.delete(actualPubkey);
+      }
+    };
   }, [actualPubkey]);
 
   return store;


### PR DESCRIPTION
## Summary
- prevent duplicate Nostr follow-list subscriptions by tracking active subs per pubkey
- test useFollowing to ensure subscription deduplication

## Testing
- `pnpm test apps/web/hooks/useFollowing.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689859f9519c83318436e15b3c7a62d9