### PR TITLE
feat: enlarge action bar icons on wide screens

### DIFF
--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -193,4 +193,23 @@ describe('VideoCard', () => {
     await user.click(screen.getByLabelText(/comments/i));
     expect(onComment).toHaveBeenCalled();
   });
+
+  it('renders action bar icons with responsive size classes', () => {
+    const props = {
+      videoUrl: 'video.mp4',
+      author: 'author',
+      caption: 'caption',
+      eventId: 'event',
+      pubkey: 'pk',
+      zap: <div />,
+    };
+    const { container } = render(<VideoCard {...props} />);
+    const icons = container.querySelectorAll('.action-bar-icon');
+    expect(icons).toHaveLength(3);
+    icons.forEach((icon) => {
+      const className = icon.getAttribute('class') || '';
+      expect(className).toContain('md:h-8');
+      expect(className).toContain('md:w-8');
+    });
+  });
 });

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -275,7 +275,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         </div>
       )}
 
-      <div className="absolute right-4 bottom-24 z-10 flex flex-col items-center space-y-4">
+      <div className="absolute right-4 bottom-24 z-10 flex flex-col items-center space-y-4 lg:right-6 lg:bottom-32 lg:space-y-6">
         <button
           type="button"
           className="hover:text-accent-primary"
@@ -289,7 +289,11 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           aria-label={muted ? 'Unmute' : 'Mute'}
           aria-pressed={!muted}
         >
-          {muted ? <VolumeX className="icon" /> : <Volume2 className="icon" />}
+          {muted ? (
+            <VolumeX className="icon action-bar-icon md:h-8 md:w-8" />
+          ) : (
+            <Volume2 className="icon action-bar-icon md:h-8 md:w-8" />
+          )}
         </button>
         <button
           className="relative hover:text-accent-primary disabled:opacity-50 lg:hidden"
@@ -298,7 +302,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           title={!online ? 'Offline – reconnect to interact.' : undefined}
           aria-label="Comments"
         >
-          <MessageCircle className="icon" />
+          <MessageCircle className="icon action-bar-icon md:h-8 md:w-8" />
           {commentCount > 0 && (
             <span className="absolute -right-2 -top-2 text-xs text-primary">{commentCount}</span>
           )}
@@ -312,7 +316,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
             !online ? 'Offline – reconnect to interact.' : reposted ? 'Already reposted' : undefined
           }
         >
-          <Repeat2 className="icon" />
+          <Repeat2 className="icon action-bar-icon md:h-8 md:w-8" />
         </button>
       </div>
 

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -106,6 +106,9 @@ body {
   .icon {
     @apply transition-colors duration-200 ease-in-out;
   }
+  .action-bar-icon {
+    @apply h-6 w-6 md:h-8 md:w-8;
+  }
   .feed-container {
     @apply lg:mt-4;
   }


### PR DESCRIPTION
## Summary
- scale VideoCard action bar icons up on medium screens with responsive Tailwind classes
- add `.action-bar-icon` utility for shared icon sizing
- test for presence of responsive class names on action bar icons

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689859e2a0a88331937f6347a639e3e0