### PR TITLE
feat(playback): resume video progress and cache segments

### DIFF
--- a/apps/web/agents/playback.test.ts
+++ b/apps/web/agents/playback.test.ts
@@ -1,0 +1,43 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import playback from './playback';
+
+Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+  configurable: true,
+  value: () => Promise.resolve(),
+});
+Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
+  configurable: true,
+  value: () => {},
+});
+Object.defineProperty(HTMLMediaElement.prototype, 'load', {
+  configurable: true,
+  value: () => {},
+});
+
+describe('playback progress', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('saves and restores progress', () => {
+    const v1 = document.createElement('video');
+    playback.loadSource(v1, { videoUrl: 'a.mp4', eventId: 'evt1' });
+    v1.currentTime = 12;
+    playback.pause();
+
+    const v2 = document.createElement('video');
+    playback.loadSource(v2, { videoUrl: 'a.mp4', eventId: 'evt1' });
+    v2.dispatchEvent(new Event('loadedmetadata'));
+    expect(v2.currentTime).toBeCloseTo(12);
+  });
+
+  it('clears progress on ended', () => {
+    const v = document.createElement('video');
+    playback.loadSource(v, { videoUrl: 'a.mp4', eventId: 'evt2' });
+    v.currentTime = 5;
+    playback.pause();
+    v.dispatchEvent(new Event('ended'));
+    expect(sessionStorage.getItem('lastPlaybackPosition')).toBeNull();
+  });
+});

--- a/apps/web/agents/playback.ts
+++ b/apps/web/agents/playback.ts
@@ -8,8 +8,56 @@ type ErrorListener = (message: string, data: ErrorData) => void;
 
 let video: HTMLVideoElement | null = null;
 let hls: ReturnType<typeof initHls> | null = null;
+let currentEventId: string | null = null;
 const listeners = new Set<Listener>();
 const errorListeners = new Set<ErrorListener>();
+
+const STORAGE_KEY = 'lastPlaybackPosition';
+const EXPIRY_MS = 24 * 60 * 60 * 1000; // 24h
+
+function saveProgress() {
+  if (!video || !currentEventId) return;
+  try {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        eventId: currentEventId,
+        currentTime: video.currentTime,
+        timestamp: Date.now(),
+      }),
+    );
+  } catch {
+    // ignore storage failures
+  }
+}
+
+function loadProgress(eventId: string): number | undefined {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return undefined;
+    const data = JSON.parse(raw) as {
+      eventId: string;
+      currentTime: number;
+      timestamp: number;
+    };
+    if (data.eventId !== eventId) return undefined;
+    if (Date.now() - data.timestamp > EXPIRY_MS) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return undefined;
+    }
+    return data.currentTime;
+  } catch {
+    return undefined;
+  }
+}
+
+function clearProgress() {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
 
 function emit(state: PlaybackState) {
   for (const l of listeners) l(state);
@@ -21,18 +69,29 @@ function emitError(message: string, data: ErrorData) {
 
 function loadSource(
   el: HTMLVideoElement,
-  { videoUrl, manifestUrl }: { videoUrl: string; manifestUrl?: string },
+  {
+    videoUrl,
+    manifestUrl,
+    eventId,
+  }: { videoUrl: string; manifestUrl?: string; eventId: string },
 ) {
   if (video) {
     video.removeEventListener('play', handlePlay);
     video.removeEventListener('pause', handlePause);
+    video.removeEventListener('ended', handleEnded);
+    saveProgress();
     video.pause();
     video.removeAttribute('src');
     // Force the browser to stop loading the previous source
-    video.load();
+    try {
+      video.load();
+    } catch {
+      // no-op in environments without full media support
+    }
   }
   hls?.destroy();
   video = el;
+  currentEventId = eventId;
   if (manifestUrl) {
     hls = initHls(manifestUrl, el, (data) => {
       emitError(data.error.message, data);
@@ -42,6 +101,15 @@ function loadSource(
   }
   el.addEventListener('play', handlePlay);
   el.addEventListener('pause', handlePause);
+  el.addEventListener('ended', handleEnded);
+  el.addEventListener(
+    'loadedmetadata',
+    () => {
+      const t = loadProgress(eventId);
+      if (t != null) el.currentTime = t;
+    },
+    { once: true },
+  );
 }
 
 function handlePlay() {
@@ -50,6 +118,12 @@ function handlePlay() {
 
 function handlePause() {
   emit('paused');
+  saveProgress();
+}
+
+function handleEnded() {
+  emit('paused');
+  clearProgress();
 }
 
 function play() {

--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -40,7 +40,7 @@ vi.mock('@/store/playbackPrefs', () => {
   return { usePlaybackPrefs };
 });
 let currentVideo: HTMLVideoElement | null = null;
-const loadSource = vi.fn((video: HTMLVideoElement) => {
+const loadSource = vi.fn((video: HTMLVideoElement, _opts: any) => {
   if (currentVideo && currentVideo !== video) currentVideo.pause();
   currentVideo = video;
 });

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -97,7 +97,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   useEffect(() => {
     const video = playerRef.current;
     if (!video) return;
-    playback.loadSource(video, { videoUrl, manifestUrl });
+    playback.loadSource(video, { videoUrl, manifestUrl, eventId });
     const offState = playback.onStateChange((state) => {
       setIsPlaying(state === 'playing');
     });

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -5,6 +5,7 @@ workbox.loadModule('workbox-routing');
 workbox.loadModule('workbox-strategies');
 workbox.loadModule('workbox-background-sync');
 workbox.loadModule('workbox-core');
+workbox.loadModule('workbox-expiration');
 
 const CACHE_VERSION = 'v2';
 
@@ -58,6 +59,19 @@ workbox.routing.registerRoute(
   ({ url }) => /\.(?:mp4|webm)$/.test(url.pathname),
   new workbox.strategies.CacheFirst({
     cacheName: `video-cache-${CACHE_VERSION}`,
+  }),
+);
+
+workbox.routing.registerRoute(
+  ({ url }) => /\.(?:m4s|ts)$/.test(url.pathname),
+  new workbox.strategies.CacheFirst({
+    cacheName: `segment-cache-${CACHE_VERSION}`,
+    plugins: [
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 60,
+        maxAgeSeconds: 5 * 60,
+      }),
+    ],
   }),
 );
 


### PR DESCRIPTION
## Summary
- persist video playback positions in session storage and restore on reload
- pass eventId through VideoCard and add playback progress tests
- cache HLS media segments in service worker with eviction policy

## Testing
- `pnpm vitest run apps/web/agents/playback.test.ts apps/web/components/VideoCard.test.tsx`
- `pnpm test` *(fails: Vitest caught 1 unhandled error during the test run)*

------
https://chatgpt.com/codex/tasks/task_e_68985b80ebf88331bf68de41c308ce91