### PR TITLE
feat: guard lightning alert

### DIFF
--- a/apps/web/hooks/useLightning.ts
+++ b/apps/web/hooks/useLightning.ts
@@ -114,7 +114,10 @@ export default function useLightning() {
         const signed = await state.signer.signEvent(event);
         pool.publish(getRelays(), signed);
       } catch (err: any) {
-        alert(err.message || 'Sign-in required');
+        const w = typeof window !== 'undefined' ? window : undefined;
+        if (w && typeof w.alert === 'function') {
+          w.alert(err.message || 'Sign-in required');
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- guard `alert` with safe window check in lightning hook
- add test for missing `alert`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68985e1beae08331b402bb7c3eaaa947