### PR TITLE
fix: await params in create page

### DIFF
--- a/apps/web/app/create/page.tsx
+++ b/apps/web/app/create/page.tsx
@@ -15,9 +15,9 @@ export const metadata: Metadata = {
 export default async function CreatePage({
   params,
 }: {
-  params: { locale?: string };
+  params: Promise<{ locale?: string }>;
 }) {
-  const { locale = 'en' } = params;
+  const { locale = 'en' } = await params;
   const messages = await getMessages();
   const createMessages = (await import(`@/locales/${locale}/create.json`)).default;
 


### PR DESCRIPTION
## Summary
- await `params` in create page

## Testing
- `pnpm test`
- `curl -I http://localhost:3000/en/create`


------
https://chatgpt.com/codex/tasks/task_e_68985fbde9e88331937a26c38769937d