### PR TITLE
Ensure profile images release object URLs

### DIFF
--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -1,7 +1,14 @@
 'use client';
+import { useEffect } from 'react';
 import { useProfiles } from './useProfiles';
 
 export function useProfile(pubkey?: string) {
   const profiles = useProfiles(pubkey ? [pubkey] : []);
-  return pubkey ? profiles.get(pubkey) ?? null : null;
+  const profile = pubkey ? profiles.get(pubkey) ?? null : null;
+  useEffect(() => {
+    return () => {
+      profile?.pictureRevoke?.();
+    };
+  }, [profile?.pictureRevoke]);
+  return profile;
 }

--- a/apps/web/hooks/useProfiles.ts
+++ b/apps/web/hooks/useProfiles.ts
@@ -11,6 +11,7 @@ import { cacheImage, getCachedImage } from '@/lib/imageCache';
 export type Profile = {
   name?: string;
   picture?: string;
+  pictureRevoke?: () => void;
   about?: string;
   lud16?: string;
   wallets?: { label: string; lnaddr: string; default?: boolean }[];
@@ -41,7 +42,9 @@ async function fetchProfile(pubkey: string): Promise<Profile> {
       ensureWallets(content);
       if (content.picture) {
         const cached = await getCachedImage(content.picture);
-        content.picture = cached || (await cacheImage(content.picture));
+        const img = cached || (await cacheImage(content.picture));
+        content.picture = img.url;
+        content.pictureRevoke = img.revoke;
       }
       return content;
     } catch {
@@ -60,7 +63,9 @@ async function fetchProfile(pubkey: string): Promise<Profile> {
             ensureWallets(content);
             if (content.picture) {
               const cached = await getCachedImage(content.picture);
-              content.picture = cached || (await cacheImage(content.picture));
+              const img = cached || (await cacheImage(content.picture));
+              content.picture = img.url;
+              content.pictureRevoke = img.revoke;
             }
             await saveEvent(ev);
             profile = content;

--- a/apps/web/hooks/useZapSplits.ts
+++ b/apps/web/hooks/useZapSplits.ts
@@ -24,6 +24,12 @@ export function useZapSplits(
   const { following } = useFollowing(state.status === 'ready' ? state.pubkey : undefined);
   const profiles = useProfiles(following);
 
+  useEffect(() => {
+    return () => {
+      profiles.forEach((p) => p.pictureRevoke?.());
+    };
+  }, [profiles]);
+
   const { fields, append, remove } = useFieldArray({ control, name: 'zapSplits' });
 
   const walletAddrs = Array.isArray(profile?.wallets) && profile.wallets.length > 0


### PR DESCRIPTION
## Summary
- return revokable object URLs from image cache helpers
- track profile image revoke callbacks and clean up on unmount
- clear profile image cache entries when zap split hook disposes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68985f8d15608331b644337b1cb55e82