### PR TITLE
feat: proxy external images

### DIFF
--- a/apps/web/app/api/image-proxy.ts
+++ b/apps/web/app/api/image-proxy.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { url } = req.query;
+  if (typeof url !== 'string') {
+    res.status(400).end('missing url');
+    return;
+  }
+  try {
+    const r = await fetch(url);
+    if (!r.ok) {
+      res.status(502).end('bad response');
+      return;
+    }
+    const contentType = r.headers.get('content-type') || 'application/octet-stream';
+    const buffer = Buffer.from(await r.arrayBuffer());
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Content-Type', contentType);
+    res.status(200).send(buffer);
+  } catch {
+    res.status(500).end('failed to fetch');
+  }
+}

--- a/apps/web/hooks/useProfiles.ts
+++ b/apps/web/hooks/useProfiles.ts
@@ -40,8 +40,17 @@ async function fetchProfile(pubkey: string): Promise<Profile> {
       const content = JSON.parse(latest.content);
       ensureWallets(content);
       if (content.picture) {
-        const cached = await getCachedImage(content.picture);
-        content.picture = cached || (await cacheImage(content.picture));
+        let pic = content.picture;
+        try {
+          const picUrl = new URL(pic, location.origin);
+          if (picUrl.origin !== location.origin) {
+            pic = `/api/image-proxy?url=${encodeURIComponent(pic)}`;
+          }
+        } catch {
+          /* ignore */
+        }
+        const cached = await getCachedImage(pic);
+        content.picture = cached || (await cacheImage(pic));
       }
       return content;
     } catch {
@@ -59,8 +68,17 @@ async function fetchProfile(pubkey: string): Promise<Profile> {
             const content = JSON.parse(ev.content);
             ensureWallets(content);
             if (content.picture) {
-              const cached = await getCachedImage(content.picture);
-              content.picture = cached || (await cacheImage(content.picture));
+              let pic = content.picture;
+              try {
+                const picUrl = new URL(pic, location.origin);
+                if (picUrl.origin !== location.origin) {
+                  pic = `/api/image-proxy?url=${encodeURIComponent(pic)}`;
+                }
+              } catch {
+                /* ignore */
+              }
+              const cached = await getCachedImage(pic);
+              content.picture = cached || (await cacheImage(pic));
             }
             await saveEvent(ev);
             profile = content;


### PR DESCRIPTION
## Summary
- route foreign image URLs through `/api/image-proxy` before caching to avoid cross-origin failures
- add an image proxy endpoint that forwards remote images with proper CORS headers
- update profile hook to proxy external avatars prior to caching

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68985fdc3e4483318998682cc09e350d