### PR TITLE
Add ZapButton to video cards

### DIFF
--- a/apps/web/app/p/[pubkey]/page.tsx
+++ b/apps/web/app/p/[pubkey]/page.tsx
@@ -13,10 +13,14 @@ import SearchBar from '@/components/SearchBar';
 import { useAuth } from '@/hooks/useAuth';
 import { getRelays } from '@/lib/nostr';
 import CommentDrawer from '@/components/CommentDrawer';
+import ZapButton from '@/components/ZapButton';
+import { useProfile } from '@/hooks/useProfile';
 
 export default function ProfilePage() {
   const { pubkey } = useParams<{ pubkey?: string }>();
   const { state } = useAuth();
+  const viewerProfile = useProfile(state.status === 'ready' ? state.pubkey : undefined);
+  const hasWallet = !!viewerProfile?.wallets?.length;
   const [name, setName] = useState('');
   const [picture, setPicture] = useState('');
   const [bio, setBio] = useState('');
@@ -259,6 +263,16 @@ export default function ProfilePage() {
               {...selected}
               showMenu
               onComment={() => setCommentVideoId(selected.eventId)}
+              zap={
+                <ZapButton
+                  lightningAddress={selected.lightningAddress}
+                  pubkey={selected.pubkey}
+                  eventId={selected.eventId}
+                  total={selected.zapTotal}
+                  disabled={!hasWallet}
+                  title={!hasWallet ? 'Add a wallet to zap' : undefined}
+                />
+              }
             />
             <button
               className="absolute right-4 top-4 text-white"

--- a/apps/web/app/v/[eventId]/page.tsx
+++ b/apps/web/app/v/[eventId]/page.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from 'react';
 import pool from '@/lib/relayPool';
 import type { Event as NostrEvent } from 'nostr-tools/pure';
 import VideoCard, { VideoCardProps } from '@/components/VideoCard';
+import ZapButton from '@/components/ZapButton';
+import { useAuth } from '@/hooks/useAuth';
+import { useProfile } from '@/hooks/useProfile';
 import { getRelays } from '@/lib/nostr';
 import CommentDrawer from '@/components/CommentDrawer';
 
@@ -11,6 +14,9 @@ export default function VideoPage() {
   const { eventId } = useParams<{ eventId?: string }>();
   const [video, setVideo] = useState<VideoCardProps | null>(null);
   const [commentVideoId, setCommentVideoId] = useState<string | null>(null);
+  const { state } = useAuth();
+  const profile = useProfile(state.status === 'ready' ? state.pubkey : undefined);
+  const hasWallet = !!profile?.wallets?.length;
 
   useEffect(() => {
     if (!eventId) return;
@@ -50,6 +56,16 @@ export default function VideoPage() {
           {...video}
           showMenu
           onComment={() => setCommentVideoId(video.eventId)}
+          zap={
+            <ZapButton
+              lightningAddress={video.lightningAddress}
+              pubkey={video.pubkey}
+              eventId={video.eventId}
+              total={video.zapTotal}
+              disabled={!hasWallet}
+              title={!hasWallet ? 'Add a wallet to zap' : undefined}
+            />
+          }
         />
       </div>
       <CommentDrawer

--- a/apps/web/components/Feed.test.tsx
+++ b/apps/web/components/Feed.test.tsx
@@ -2,18 +2,27 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Feed from './Feed';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Ensure React is available globally for components compiled with the classic JSX runtime
 (globalThis as any).React = React;
 
 describe('Feed', () => {
   it('renders skeleton during loading', () => {
-    const html = renderToStaticMarkup(<Feed items={[]} loading />);
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <Feed items={[]} loading />
+      </QueryClientProvider>,
+    );
     expect(html).toContain('bg-text-primary/10');
   });
 
   it('renders empty state when no items', () => {
-    const html = renderToStaticMarkup(<Feed items={[]} />);
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <Feed items={[]} />
+      </QueryClientProvider>,
+    );
     expect(html).toContain('<svg');
   });
 });

--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -7,6 +7,9 @@ import { SkeletonVideoCard } from './ui/SkeletonVideoCard';
 import Link from 'next/link';
 import { useFeedSelection } from '@/store/feedSelection';
 import CommentDrawer from './CommentDrawer';
+import ZapButton from './ZapButton';
+import { useAuth } from '@/hooks/useAuth';
+import { useProfile } from '@/hooks/useProfile';
 
 interface FeedProps {
   items: VideoCardProps[];
@@ -20,6 +23,9 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   const selectedVideoId = useFeedSelection((s) => s.selectedVideoId);
   const rowRefs = useRef<(HTMLElement | null)[]>([]);
   const [commentVideoId, setCommentVideoId] = useState<string | null>(null);
+  const { state } = useAuth();
+  const viewerProfile = useProfile(state.status === 'ready' ? state.pubkey : undefined);
+  const hasWallet = !!viewerProfile?.wallets?.length;
 
   const rowVirtualizer = useVirtualizer({
     count: items.length,
@@ -106,6 +112,16 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
                     const el = rowRefs.current[index];
                     if (el) rowVirtualizer.measureElement(el);
                   }}
+                  zap={
+                    <ZapButton
+                      lightningAddress={item.lightningAddress}
+                      pubkey={item.pubkey}
+                      eventId={item.eventId}
+                      total={item.zapTotal}
+                      disabled={!hasWallet}
+                      title={!hasWallet ? 'Add a wallet to zap' : undefined}
+                    />
+                  }
                 />
               </div>
             );


### PR DESCRIPTION
## Summary
- render ZapButton on feed and video detail cards
- disable zaps when viewer has no wallet
- update Feed tests to wrap component in QueryClientProvider

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68986017bb24833185f541c1ab87455a