### PR TITLE
Proxy external avatar images to avoid CORS caching errors

### DIFF
--- a/apps/web/app/api/image-proxy.ts
+++ b/apps/web/app/api/image-proxy.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const url = (req.query.url as string) || '';
+  if (!url) {
+    res.status(400).send('Missing url');
+    return;
+  }
+  try {
+    const upstream = await fetch(url);
+    const contentType = upstream.headers.get('content-type') || 'application/octet-stream';
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Content-Type', contentType);
+    const arrayBuffer = await upstream.arrayBuffer();
+    res.status(upstream.status).send(Buffer.from(arrayBuffer));
+  } catch {
+    res.status(502).send('Bad Gateway');
+  }
+}

--- a/apps/web/lib/imageCache.ts
+++ b/apps/web/lib/imageCache.ts
@@ -25,9 +25,15 @@ export async function cacheImage(
   const cache = await openCache();
   if (!cache) return { url, revoke: () => {} };
   try {
-    const { hostname } = new URL(url);
-    if (TRUSTED_HOSTS.length && !TRUSTED_HOSTS.includes(hostname))
+    const base = typeof location !== 'undefined' ? location.href : undefined;
+    const { hostname, origin } = new URL(url, base);
+    if (
+      typeof location !== 'undefined' &&
+      origin !== location.origin &&
+      !TRUSTED_HOSTS.includes(hostname)
+    ) {
       return { url, revoke: () => {} };
+    }
 
     const res = await fetch(url, { mode: 'cors' });
     if (!res.ok || res.type !== 'basic') return { url, revoke: () => {} };


### PR DESCRIPTION
## Summary
- Skip caching for foreign-origin image URLs to avoid CORS failures
- Add `/api/image-proxy` endpoint to fetch remote images with permissive CORS headers
- Route external avatar URLs through the proxy before caching in `useProfiles`

## Testing
- `pnpm test apps/web/hooks/useProfiles.test.ts`
- `pnpm test`
- `pnpm --filter @paiduan/web lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_6898619719848331a422ea62eb8ec5c6