### PR TITLE
Use query params to switch between feed tabs

### DIFF
--- a/apps/web/app/feed/page.test.tsx
+++ b/apps/web/app/feed/page.test.tsx
@@ -1,0 +1,32 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+// Ensure React is available globally for components compiled with the classic JSX runtime
+(globalThis as any).React = React;
+
+const useFeedMock = vi.hoisted(() => vi.fn(() => ({ items: [], loadMore: vi.fn(), loading: false })));
+vi.mock('@/hooks/useFeed', () => ({ default: useFeedMock }));
+vi.mock('@/components/layout/AppShell', () => ({ default: ({ children }: any) => <div>{children}</div> }));
+vi.mock('@/components/layout/MainNav', () => ({ default: () => null }));
+vi.mock('@/components/feed/RightPanel', () => ({ default: () => null }));
+vi.mock('@/components/Feed', () => ({ default: () => null }));
+vi.mock('@/hooks/useCurrentVideo', () => ({ CurrentVideoProvider: ({ children }: any) => <>{children}</> }));
+
+const setFilterAuthor = vi.fn();
+vi.mock('@/store/feedSelection', () => ({ useFeedSelection: () => ({ filterAuthor: undefined, setFilterAuthor }) }));
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ state: { status: 'ready', pubkey: 'me' } }) }));
+vi.mock('@/hooks/useFollowing', () => ({ default: () => ({ following: ['pk1', 'pk2'] }) }));
+vi.mock('@/hooks/useFollowerCount', () => ({ default: () => 0 }));
+vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({}) }));
+vi.mock('next/navigation', () => ({ useSearchParams: () => ({ get: (k: string) => (k === 'tab' ? 'following' : null) }) }));
+
+import FeedPage from './page';
+
+describe('FeedPage', () => {
+  it('uses following authors when tab=following', () => {
+    render(<FeedPage />);
+    expect(useFeedMock).toHaveBeenCalledWith('following', ['pk1', 'pk2']);
+  });
+});

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -10,13 +10,11 @@ import useFollowerCount from '@/hooks/useFollowerCount';
 import { useProfile } from '@/hooks/useProfile';
 import { useFeedSelection } from '@/store/feedSelection';
 import { CurrentVideoProvider } from '@/hooks/useCurrentVideo';
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 export default function FeedPage() {
   const { filterAuthor, setFilterAuthor } = useFeedSelection();
-  const { items: videos, loadMore, loading } = useFeed(
-    filterAuthor ? { author: filterAuthor } : 'all',
-  );
-
   const { state: auth } = useAuth();
   const { following } = useFollowing(
     auth.status === 'ready' ? auth.pubkey : undefined,
@@ -25,6 +23,19 @@ export default function FeedPage() {
     auth.status === 'ready' ? auth.pubkey : undefined,
   );
   const meProfile = useProfile(auth.status === 'ready' ? auth.pubkey : undefined);
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab');
+  const feedMode = tab === 'following' ? 'following' : 'all';
+
+  useEffect(() => {
+    setFilterAuthor(undefined);
+  }, [feedMode, setFilterAuthor]);
+
+  const mode = filterAuthor ? { author: filterAuthor } : feedMode;
+  const { items: videos, loadMore, loading } = useFeed(
+    mode,
+    feedMode === 'following' && !filterAuthor ? following : [],
+  );
   const me =
     auth.status === 'ready'
       ? {


### PR DESCRIPTION
## Summary
- Read the `tab` query using Next.js `useSearchParams` to switch between All and Following feeds
- Clear author filters on tab change and pass following authors when fetching the feed
- Add a regression test ensuring the Following tab filters by followed authors

## Testing
- `pnpm test apps/web/app/feed/page.test.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689861c2bae083318581c66d1d37516b