### PR TITLE
feat: improve video fallback handling

### DIFF
--- a/apps/web/agents/telemetry.ts
+++ b/apps/web/agents/telemetry.ts
@@ -1,0 +1,9 @@
+export function track(event: string, data?: any) {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error('[telemetry]', event, data);
+  }
+}
+
+export const telemetry = { track };
+export default telemetry;

--- a/apps/web/components/VideoFallback.tsx
+++ b/apps/web/components/VideoFallback.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function VideoFallback({
+  posterUrl,
+  message = 'Video unavailable',
+}: {
+  posterUrl?: string;
+  message?: string;
+}) {
+  return (
+    <>
+      <img
+        src={posterUrl || '/offline.jpg'}
+        alt="Video unavailable"
+        className="absolute inset-0 h-full w-full object-cover"
+        onError={(e) => {
+          e.currentTarget.src = '/offline.jpg';
+        }}
+      />
+      <div className="absolute inset-0 flex items-center justify-center bg-black/70 p-4 text-center">
+        {message}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add telemetry agent stub for logging
- show dedicated fallback when video fails and try alternate source
- log playback failures and surface "Video unavailable" message

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx apps/web/components/VideoCard.playback.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68986290222c8331832fa9c17650520f