### PR TITLE
feat: add avatar image fallbacks

### DIFF
--- a/apps/web/app/p/[pubkey]/page.tsx
+++ b/apps/web/app/p/[pubkey]/page.tsx
@@ -165,12 +165,14 @@ export default function ProfilePage() {
       <div className="h-32 w-full bg-gray-700" />
       <div className="p-4 -mt-12 flex items-start space-x-4">
         <Image
-          src={picture || '/placeholder.png'}
+          src={picture || '/avatar.svg'}
           alt={name}
           width={96}
           height={96}
           className="h-24 w-24 rounded-full border-4 border-black object-cover"
           unoptimized
+          onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+          crossOrigin="anonymous"
         />
         <div className="flex-1">
           <div className="text-2xl font-semibold">

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -54,6 +54,8 @@ export default function Profile() {
                 height={96}
                 priority
                 className="h-24 w-24 rounded-full object-cover"
+                onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+                crossOrigin="anonymous"
               />
               <div className="text-lg font-semibold">{meta?.name || 'Anonymous'}</div>
             </div>

--- a/apps/web/components/MiniProfileCard.tsx
+++ b/apps/web/components/MiniProfileCard.tsx
@@ -22,6 +22,8 @@ export default function MiniProfileCard({
         height={80}
         priority
         className="mx-auto mb-2 h-20 w-20 rounded-full"
+        onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+        crossOrigin="anonymous"
       />
       <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">@{name}</div>
       {stats && (

--- a/apps/web/components/ProfileHeader.tsx
+++ b/apps/web/components/ProfileHeader.tsx
@@ -26,6 +26,8 @@ export const ProfileHeader: React.FC<ProfileHeaderProps> = ({ avatarUrl, name, l
           height={80}
           className="h-20 w-20 rounded-lg"
           unoptimized
+          onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+          crossOrigin="anonymous"
         />
       </div>
       <div className="font-semibold">{name}</div>

--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -92,6 +92,8 @@ const SearchBar: React.FC<{ showActions?: boolean }> = ({ showActions = true }) 
                     height={32}
                     className="h-8 w-8 rounded-full object-cover"
                     unoptimized
+                    onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+                    crossOrigin="anonymous"
                   />
                 ) : (
                   <div className="h-8 w-8 rounded-full bg-text-primary/20" />

--- a/apps/web/components/TopNavProfile.tsx
+++ b/apps/web/components/TopNavProfile.tsx
@@ -29,6 +29,8 @@ export default function TopNavProfile() {
         height={80}
         priority
         className="h-20 w-20 rounded-lg"
+        onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+        crossOrigin="anonymous"
       />
     </div>
   );

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -336,7 +336,8 @@ export const VideoCard: React.FC<VideoCardProps> = ({
               height={40}
               className="h-10 w-10 rounded-full object-cover"
               unoptimized
-              onError={(e) => (e.currentTarget.src = '/offline.jpg')}
+              onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+              crossOrigin="anonymous"
             />
           ) : (
             <Skeleton className="h-10 w-10 rounded-full" />

--- a/apps/web/components/VideoInfoPane.tsx
+++ b/apps/web/components/VideoInfoPane.tsx
@@ -47,6 +47,8 @@ export default function VideoInfoPane() {
           height={48}
           priority
           className="h-12 w-12 rounded-full"
+          onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+          crossOrigin="anonymous"
         />
         <div>
           <div className="font-semibold">{meta?.name || current.pubkey.slice(0, 8)}</div>

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -59,7 +59,8 @@ export default function RightPanel({
               width={48}
               height={48}
               style={{ borderRadius: '50%', objectFit: 'cover' }}
-              onError={(e) => (e.currentTarget.src = '/offline.jpg')}
+              onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+              crossOrigin="anonymous"
               unoptimized
             />
             <Box>

--- a/apps/web/components/onboarding/ProfileSetupStep.tsx
+++ b/apps/web/components/onboarding/ProfileSetupStep.tsx
@@ -184,6 +184,8 @@ export function ProfileSetupStep({ onComplete }: { onComplete: () => void }) {
               width={80}
               height={80}
               className="h-20 w-20 rounded-lg object-cover"
+              onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+              crossOrigin="anonymous"
             />
           </div>
         )}

--- a/apps/web/components/settings/ProfileCard.tsx
+++ b/apps/web/components/settings/ProfileCard.tsx
@@ -92,6 +92,8 @@ export function ProfileCard() {
               width={80}
               height={80}
               className="h-20 w-20 rounded-full object-cover"
+              onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+              crossOrigin="anonymous"
             />
           )}
           <button


### PR DESCRIPTION
## Summary
- add onError fallback and crossOrigin handling for avatar images across components
- ensure profile and search avatars fall back to default icon when image fails

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689863ca907483318ff3d4b422f34d32