### PR TITLE
Use viewport units for desktop video layout

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -58,7 +58,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
 
   if (loading) {
     return (
-      <div className="h-[calc(100dvh-var(--bottom-nav-height,0))] w-full">
+      <div className="h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full">
         <SkeletonVideoCard />
       </div>
     );
@@ -66,7 +66,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
 
   if (items.length === 0) {
     return (
-      <div className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] w-full flex-col items-center justify-center text-white">
+      <div className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full flex-col items-center justify-center text-white">
         <EmptyState />
         <Link href="/create" className="btn btn-primary mt-4" prefetch>
           Upload your first video
@@ -79,7 +79,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
     <>
       <div
         ref={parentRef}
-        className="h-[calc(100dvh-var(--bottom-nav-height,0))] w-full overflow-auto snap-y snap-mandatory scrollbar-none"
+        className="h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full overflow-auto snap-y snap-mandatory scrollbar-none"
       >
         <div
           style={{ height: rowVirtualizer.getTotalSize(), position: 'relative' }}
@@ -92,7 +92,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
               <div
                 key={item.eventId ?? index}
                 data-index={index}
-                className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] w-full snap-start snap-always items-center justify-center"
+                className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full snap-start snap-always items-center justify-center"
                 ref={(el) => {
                   rowRefs.current[index] = el;
                   if (el) rowVirtualizer.measureElement(el);

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -218,7 +218,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="relative mx-auto w-full max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-card text-white shadow-card"
+      className="relative mx-auto w-full max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-card text-white shadow-card"
       onClick={() => setSelectedVideo(eventId, pubkey)}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}

--- a/apps/web/components/ui/SkeletonVideoCard.tsx
+++ b/apps/web/components/ui/SkeletonVideoCard.tsx
@@ -3,7 +3,7 @@ import Skeleton from './Skeleton';
 
 export function SkeletonVideoCard() {
   return (
-    <div className="relative mx-auto w-full max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-text-primary/10">
+    <div className="relative mx-auto w-full max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-text-primary/10">
       <Skeleton className="h-full w-full" />
       <div className="absolute bottom-0 left-0 w-full p-4">
         <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- ensure Feed and its children use 100vh on larger screens and keep 100dvh only on mobile
- align VideoCard and SkeletonVideoCard width calculations with 100vh on desktop

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6898642ba9fc8331a53712f8462743ac