### PR TITLE
feat: replace key prompt with form

### DIFF
--- a/apps/web/components/onboarding/KeySetupStep.tsx
+++ b/apps/web/components/onboarding/KeySetupStep.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useState } from 'react';
 import * as nip19 from 'nostr-tools/nip19';
 import { generateSecretKey } from 'nostr-tools/pure';
 import { bytesToHex } from '@noble/hashes/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@paiduan/ui';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
 
 function privHexFrom(input: string): string {
   const s = input.trim();
@@ -20,7 +22,51 @@ function privHexFrom(input: string): string {
 
 export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
   const { signInWithLocal, signInWithNip07, signInWithNip46 } = useAuth();
-  const [uri, setUri] = useState('');
+
+  const uriSchema = z.object({
+    uri: z
+      .string()
+      .min(1, 'Remote signer URI is required')
+      .url('Invalid URI')
+      .refine((val) => val.startsWith('nostrconnect:'), {
+        message: 'Must start with nostrconnect:',
+      }),
+  });
+  type UriForm = z.infer<typeof uriSchema>;
+  const {
+    register: registerUri,
+    handleSubmit: handleSubmitUri,
+    formState: { errors: uriErrors, isValid: uriValid },
+  } = useForm<UriForm>({
+    resolver: zodResolver(uriSchema),
+    mode: 'onChange',
+    defaultValues: { uri: '' },
+  });
+
+  const privSchema = z.object({
+    privkey: z
+      .string()
+      .min(1, 'Private key is required')
+      .refine((val) => {
+        try {
+          privHexFrom(val);
+          return true;
+        } catch {
+          return false;
+        }
+      }, 'Invalid nsec or hex private key')
+      .transform((val) => privHexFrom(val)),
+  });
+  type PrivForm = z.infer<typeof privSchema>;
+  const {
+    register: registerPriv,
+    handleSubmit: handleSubmitPriv,
+    formState: { errors: privErrors, isValid: privValid },
+  } = useForm<PrivForm>({
+    resolver: zodResolver(privSchema),
+    mode: 'onChange',
+    defaultValues: { privkey: '' },
+  });
 
   function saveLocalKey(priv: string) {
     try {
@@ -31,30 +77,23 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
     }
   }
 
-  const importKey = async () => {
-    const input = prompt('Paste nsec or hex private key');
-    if (!input) return;
-    try {
-      const priv = privHexFrom(input);
-      saveLocalKey(priv);
-    } catch (e: any) {
-      alert(e.message || 'Invalid key');
-    }
-  };
+  const onImport = handleSubmitPriv(({ privkey }) => {
+    saveLocalKey(privkey);
+  });
 
-  const generateKey = async () => {
+  const generateKey = () => {
     const priv = bytesToHex(generateSecretKey());
     saveLocalKey(priv);
   };
 
-  const connectRemote = async () => {
+  const onConnectRemote = handleSubmitUri(async ({ uri }) => {
     try {
       await signInWithNip46(uri);
       onComplete();
     } catch (e: any) {
       alert(e.message || 'Failed to connect');
     }
-  };
+  });
 
   const connectExtension = () => {
     try {
@@ -75,23 +114,27 @@ export function KeySetupStep({ onComplete }: { onComplete: () => void }) {
         Continue with Nostr Extension
       </Button>
 
-      <div className="space-y-2 rounded-xl border p-4">
+      <form onSubmit={onConnectRemote} className="space-y-2 rounded-xl border p-4">
         <label className="text-sm font-medium">Remote signer (NIP‑46)</label>
-        <input
-          value={uri}
-          onChange={(e) => setUri(e.target.value)}
-          placeholder="nostrconnect:..."
-          className="input w-full"
-        />
-        <Button className="btn-outline w-full" onClick={connectRemote}>
+        <input {...registerUri('uri')} placeholder="nostrconnect:..." className="input w-full" />
+        {uriErrors.uri && <span className="text-sm text-red-500">{uriErrors.uri.message}</span>}
+        <Button type="submit" className="btn-outline w-full" disabled={!uriValid}>
           Connect remote signer
         </Button>
-      </div>
+      </form>
 
-      <Button className="btn-outline w-full" onClick={importKey}>
-        Import nsec / hex
-      </Button>
-      <Button className="btn-outline w-full" onClick={generateKey}>
+      <form onSubmit={onImport} className="space-y-2 rounded-xl border p-4">
+        <label className="text-sm font-medium">Import nsec / hex</label>
+        <input {...registerPriv('privkey')} placeholder="nsec1..." className="input w-full" />
+        {privErrors.privkey && (
+          <span className="text-sm text-red-500">{privErrors.privkey.message}</span>
+        )}
+        <Button type="submit" className="btn-outline w-full" disabled={!privValid}>
+          Import key
+        </Button>
+      </form>
+
+      <Button className="btn-outline w-full" type="button" onClick={generateKey}>
         Generate new key
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- replace key import prompt with controlled form using react-hook-form and zod
- validate nostrconnect URI and private key with friendly errors
- keep generate-key and extension flows intact

## Testing
- `pnpm lint --filter @paiduan/web`
- `pnpm test apps/web` *(fails: useFollowerCount.test.tsx expected '2' to be '0')*

------
https://chatgpt.com/codex/tasks/task_e_689869df4854833188a43ed7f498945c