### PR TITLE
Handle null returns from image cache

### DIFF
--- a/apps/web/hooks/useProfiles.ts
+++ b/apps/web/hooks/useProfiles.ts
@@ -44,7 +44,7 @@ async function loadPicture(url: string) {
     }
   }
   const cached = await getCachedImage(target);
-  return cached || (await cacheImage(target));
+  return cached ?? (await cacheImage(target));
 }
 
 async function fetchProfile(pubkey: string): Promise<Profile> {
@@ -58,8 +58,12 @@ async function fetchProfile(pubkey: string): Promise<Profile> {
       ensureWallets(content);
       if (content.picture) {
         const img = await loadPicture(content.picture);
-        content.picture = img.url;
-        content.pictureRevoke = img.revoke;
+        if (img) {
+          content.picture = img.url;
+          content.pictureRevoke = img.revoke;
+        } else {
+          delete content.picture;
+        }
       }
       return content;
     } catch {
@@ -91,8 +95,12 @@ async function fetchProfile(pubkey: string): Promise<Profile> {
             ensureWallets(content);
             if (content.picture) {
               const img = await loadPicture(content.picture);
-              content.picture = img.url;
-              content.pictureRevoke = img.revoke;
+              if (img) {
+                content.picture = img.url;
+                content.pictureRevoke = img.revoke;
+              } else {
+                delete content.picture;
+              }
             }
             await saveEvent(ev);
             profile = content;

--- a/apps/web/lib/imageCache.ts
+++ b/apps/web/lib/imageCache.ts
@@ -21,7 +21,7 @@ function makeObjectUrl(blob: Blob): { url: string; revoke: () => void } {
 
 export async function cacheImage(
   url: string,
-): Promise<{ url: string; revoke: () => void }> {
+): Promise<{ url: string; revoke: () => void } | null> {
   const cache = await openCache();
   if (!cache) return { url, revoke: () => {} };
   try {
@@ -36,7 +36,12 @@ export async function cacheImage(
     }
 
     const res = await fetch(url, { mode: 'cors' });
-    if (!res.ok || res.type !== 'basic') return { url, revoke: () => {} };
+    if (
+      !res.ok ||
+      res.type !== 'basic' ||
+      !(res.headers.get('Content-Type') ?? '').startsWith('image/')
+    )
+      return null;
 
     const now = Date.now();
     const blob = await res.blob();


### PR DESCRIPTION
## Summary
- allow image cache to return null when the fetch result is invalid
- handle missing profile pictures by deleting bad image links

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68986a08c43083318fbc0ec13d314f31