### PR TITLE
fix: guard NDK connection for client

### DIFF
--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -47,12 +47,16 @@ async function connectNDK(attempt = 0): Promise<void> {
 }
 
 // establish connections eagerly so hooks/components can use it immediately
-void connectNDK();
+if (typeof window !== 'undefined') {
+  void connectNDK();
+}
 
 // update relay connections when the list changes
 bus.on('nostr.relays.changed', ({ relays }) => {
   ndk.explicitRelayUrls = relays;
-  void connectNDK();
+  if (typeof window !== 'undefined') {
+    void connectNDK();
+  }
 });
 
 const LS_KEY = 'pd.auth.v1';


### PR DESCRIPTION
## Summary
- guard NDK connections behind `window` check so WebSocket is client-only

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web build` *(fails: useSearchParams() should be wrapped in a suspense boundary at page "/feed")*


------
https://chatgpt.com/codex/tasks/task_e_68986c0013c883319428486ecb70ed10