### PR TITLE
chore: force runtime rendering for profile page

### DIFF
--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,4 +1,7 @@
 "use client";
+
+export const dynamic = 'force-dynamic';
+
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { useAuth } from '@/hooks/useAuth';


### PR DESCRIPTION
## Summary
- force runtime rendering for profile page

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web build` (fails: useSearchParams() should be wrapped in a suspense boundary at page "/feed")

------
https://chatgpt.com/codex/tasks/task_e_68986c14db58833197e96e5cd5978e82