### PR TITLE
chore: log telemetry warnings

### DIFF
--- a/apps/web/agents/telemetry.ts
+++ b/apps/web/agents/telemetry.ts
@@ -1,7 +1,11 @@
+import analytics from '@/utils/analytics';
+
 export function track(event: string, data?: any) {
+  analytics.trackEvent(event, data ? { props: data } : undefined);
+
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line no-console
-    console.error('[telemetry]', event, data);
+    console.warn('[telemetry]', event, data);
   }
 }
 


### PR DESCRIPTION
## Summary
- warn in dev telemetry logs instead of error
- forward telemetry events to Plausible when available

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68986e978b8883319b76d87d60496f36