### PR TITLE
fix: constrain video card height

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -218,7 +218,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="relative mx-auto w-full max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-card text-white shadow-card"
+      className="relative mx-auto w-full max-h-[calc(100dvh-var(--bottom-nav-height,0))] sm:max-h-[calc(100vh-var(--bottom-nav-height,0))] max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-card text-white shadow-card"
       onClick={() => setSelectedVideo(eventId, pubkey)}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}

--- a/apps/web/components/ui/SkeletonVideoCard.tsx
+++ b/apps/web/components/ui/SkeletonVideoCard.tsx
@@ -3,7 +3,7 @@ import Skeleton from './Skeleton';
 
 export function SkeletonVideoCard() {
   return (
-    <div className="relative mx-auto w-full max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-text-primary/10">
+    <div className="relative mx-auto w-full max-h-[calc(100dvh-var(--bottom-nav-height,0))] sm:max-h-[calc(100vh-var(--bottom-nav-height,0))] max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-text-primary/10">
       <Skeleton className="h-full w-full" />
       <div className="absolute bottom-0 left-0 w-full p-4">
         <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- ensure video card respects viewport height on large screens
- apply same viewport height constraint to skeleton placeholder

## Testing
- `pnpm test` *(fails: TypeError: Cannot set property navigator of #<Object> which has only a getter in useFollowerCount.test.tsx and useFollowing.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68986ef6534083319ec28b592ce5dafa