### PR TITLE
Deduplicate lnaddr datalist options in ZapSplitFields

### DIFF
--- a/apps/web/components/create/ZapSplitFields.test.tsx
+++ b/apps/web/components/create/ZapSplitFields.test.tsx
@@ -35,4 +35,27 @@ describe('ZapSplitFields', () => {
     container.querySelectorAll('button')[zapFields.length]?.click();
     expect(addSplit).toHaveBeenCalled();
   });
+
+  it('deduplicates lnaddrOptions', () => {
+    const zapFields = [] as any;
+    const register = vi.fn();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ZapSplitFields
+          zapFields={zapFields}
+          register={register as any}
+          removeSplit={vi.fn()}
+          addSplit={vi.fn()}
+          totalPct={0}
+          canAddMore={false}
+          lnaddrOptions={['a@example.com', 'b@example.com', 'a@example.com']}
+          t={t}
+        />,
+      );
+    });
+    const options = container.querySelectorAll('#lnaddr-options option');
+    expect(options.length).toBe(2);
+  });
 });

--- a/apps/web/components/create/ZapSplitFields.tsx
+++ b/apps/web/components/create/ZapSplitFields.tsx
@@ -1,4 +1,5 @@
 import { FieldArrayWithId, UseFormRegister } from 'react-hook-form';
+import { useMemo } from 'react';
 
 interface Props {
   zapFields: FieldArrayWithId<any, 'zapSplits', 'id'>[];
@@ -23,6 +24,7 @@ export default function ZapSplitFields({
   lnaddrOptions,
   t,
 }: Props) {
+  const uniqueLnaddrOptions = useMemo(() => Array.from(new Set(lnaddrOptions)), [lnaddrOptions]);
   return (
     <>
       {zapFields.map((field, i) => (
@@ -51,11 +53,9 @@ export default function ZapSplitFields({
           {t('add_collaborator')}
         </button>
       )}
-      {zapFields.length > 0 && (
-        <div className="text-sm">{t('total_pct', { pct: totalPct })}</div>
-      )}
+      {zapFields.length > 0 && <div className="text-sm">{t('total_pct', { pct: totalPct })}</div>}
       <datalist id="lnaddr-options">
-        {lnaddrOptions.map((addr) => (
+        {uniqueLnaddrOptions.map((addr) => (
           <option key={addr} value={addr}>
             {addr}
           </option>


### PR DESCRIPTION
## Summary
- avoid duplicate LN addresses in ZapSplitFields datalist by memoizing unique options
- add unit test ensuring options are deduplicated

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689872a4b6bc8331b52fae48f5719889