### PR TITLE
feat: supply codec init data to WebCodecs decoder

### DIFF
--- a/apps/web/utils/trimVideoWorker.test.ts
+++ b/apps/web/utils/trimVideoWorker.test.ts
@@ -1,6 +1,39 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('mp4box', () => ({
+  createFile: () => {
+    const track = {
+      id: 1,
+      timescale: 1000,
+      codec: 'avc1.4d401e',
+      avcDecoderConfigRecord: new Uint8Array([1, 2, 3, 4]).buffer,
+    };
+    const samps = [
+      { data: new Uint8Array([0]), dts: 0, is_sync: true },
+      { data: new Uint8Array([1]), dts: 1000, is_sync: false },
+    ];
+    return {
+      onReady: undefined as any,
+      onSamples: undefined as any,
+      setExtractionOptions() {},
+      start() {},
+      appendBuffer() {
+        this.onReady?.({ videoTracks: [track] });
+        this.onSamples?.(track.id, null, samps);
+      },
+      flush() {},
+    };
+  },
+}));
+
+vi.mock('jswebm', () => ({}));
 
 let detectCodec: (blobType?: string, trackCodec?: string) => string | null;
+let trim: (
+  blob: Blob,
+  options: { start: number; end?: number; width?: number; height?: number; bitrate?: number },
+  onProgress?: (p: number) => void,
+) => Promise<{ buffer: ArrayBuffer; type: string }>;
 
 beforeAll(async () => {
   (globalThis as any).self = {
@@ -9,7 +42,7 @@ beforeAll(async () => {
   };
   (globalThis as any).addEventListener = () => {};
   (globalThis as any).removeEventListener = () => {};
-  ({ detectCodec } = await import('./trimVideoWorker'));
+  ({ detectCodec, trim } = await import('./trimVideoWorker'));
 });
 
 describe('detectCodec', () => {
@@ -34,5 +67,78 @@ describe('detectCodec', () => {
 
   it('returns null for unknown codecs', () => {
     expect(detectCodec(undefined, 'unknown')).toBeNull();
+  });
+});
+
+describe('trim', () => {
+  it('trims H.264 clip without key frame error', async () => {
+    class FakeVideoFrame {
+      timestamp: number;
+      codedWidth = 640;
+      codedHeight = 480;
+      constructor(ts: number) {
+        this.timestamp = ts;
+      }
+      close() {}
+    }
+    class FakeEncodedVideoChunk {
+      type: any;
+      timestamp: number;
+      byteLength: number;
+      data: Uint8Array;
+      constructor(init: any) {
+        this.type = init.type;
+        this.timestamp = init.timestamp;
+        this.data = init.data;
+        this.byteLength = init.data.length;
+      }
+      copyTo(arr: Uint8Array) {
+        arr.set(this.data);
+      }
+    }
+    let configured: any;
+    class FakeVideoDecoder {
+      static async isConfigSupported(config: any) {
+        if (!(config.description instanceof Uint8Array)) {
+          throw new Error('missing description');
+        }
+        return { supported: true, config };
+      }
+      private output: any;
+      constructor(init: any) {
+        this.output = init.output;
+      }
+      configure(config: any) {
+        configured = config;
+      }
+      decode(chunk: any) {
+        if (!configured.description?.length) {
+          throw new Error('key frame required');
+        }
+        this.output(new FakeVideoFrame(chunk.timestamp));
+      }
+      async flush() {}
+      close() {}
+    }
+    class FakeVideoEncoder {
+      constructor(private init: any) {}
+      configure() {}
+      encode(frame: any) {
+        this.init.output({
+          byteLength: 1,
+          copyTo: (arr: Uint8Array) => arr.set([1]),
+        });
+      }
+      async flush() {}
+      close() {}
+    }
+    (self as any).EncodedVideoChunk = FakeEncodedVideoChunk;
+    (self as any).VideoDecoder = FakeVideoDecoder;
+    (self as any).VideoEncoder = FakeVideoEncoder;
+
+    const blob = new Blob([new Uint8Array([0])], { type: 'video/mp4' });
+    const result = await trim(blob, { start: 0, end: 1 }, () => {});
+    expect(result.type).toBe('video/mp4');
+    expect(result.buffer.byteLength).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- include demuxed codec config in WebCodecs decoder setup
- export trim function for testing
- add unit test ensuring H.264 trimming succeeds

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6898729240ec8331931dcebcad53fbaf