### PR TITLE
feat: enable client-side feed loading

### DIFF
--- a/apps/web/app/feed/page.test.tsx
+++ b/apps/web/app/feed/page.test.tsx
@@ -27,6 +27,6 @@ import FeedPage from './page';
 describe('FeedPage', () => {
   it('uses following authors when tab=following', () => {
     render(<FeedPage />);
-    expect(useFeedMock).toHaveBeenCalledWith('following', ['pk1', 'pk2']);
+    expect(useFeedMock).toHaveBeenCalledWith('following', ['pk1', 'pk2'], {}, true);
   });
 });

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -14,6 +14,7 @@ import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
 export default function FeedPage() {
+  const isClient = typeof window !== 'undefined';
   const { filterAuthor, setFilterAuthor } = useFeedSelection();
   const { state: auth } = useAuth();
   const { following } = useFollowing(
@@ -35,6 +36,8 @@ export default function FeedPage() {
   const { items: videos, loadMore, loading } = useFeed(
     mode,
     feedMode === 'following' && !filterAuthor ? following : [],
+    {},
+    isClient,
   );
   const me =
     auth.status === 'ready'
@@ -62,7 +65,11 @@ export default function FeedPage() {
         center={
           <div className="feed-container h-full">
             {/* tabs bar you already have can stay on top */}
-            <Feed items={videos} loadMore={loadMore} loading={loading} />
+            {isClient ? (
+              <Feed items={videos} loadMore={loadMore} loading={loading} />
+            ) : (
+              <Feed items={[]} loadMore={() => {}} loading />
+            )}
           </div>
         }
         right={<RightPanel onFilterByAuthor={filterByAuthor} />}


### PR DESCRIPTION
## Summary
- add optional `enabled` flag to `useFeed` and make query/loadMore no-ops when disabled
- only fetch feed on client side and render skeleton during SSR
- adjust feed page test for updated hook signature

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689874e4f43c83319b3f2439a04242b6