### PR TITLE
feat(web): enforce portrait orientation

### DIFF
--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -3,6 +3,7 @@
   "short_name": "PaiDuan",
   "start_url": "/feed",
   "display": "standalone",
+  "orientation": "portrait",
   "theme_color": "#101010",
   "background_color": "#000000",
   "icons": [


### PR DESCRIPTION
## Summary
- enforce portrait orientation in web manifest

## Testing
- `pnpm test`
- `pnpm --filter @paiduan/web build` *(fails: useSearchParams should be wrapped in a suspense boundary at page "/feed". Export encountered an error on /feed/page: /feed)*

------
https://chatgpt.com/codex/tasks/task_e_68987a165cec833192a12f12321c1037