### PR TITLE
feat: adjust video layout for top nav

### DIFF
--- a/apps/web/app/p/[pubkey]/page.tsx
+++ b/apps/web/app/p/[pubkey]/page.tsx
@@ -160,7 +160,7 @@ export default function ProfilePage() {
   };
 
   return (
-    <div className="min-h-screen bg-black text-white pt-12">
+    <div className="min-h-screen bg-black text-white pt-[var(--top-nav-height,0)]">
       <SearchBar />
       <div className="h-32 w-full bg-gray-700" />
       <div className="p-4 -mt-12 flex items-start space-x-4">
@@ -260,7 +260,7 @@ export default function ProfilePage() {
 
       {selected && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90">
-          <div className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] w-full items-center justify-center relative">
+          <div className="flex h-[calc(100dvh-var(--top-nav-height,0)-var(--bottom-nav-height,0))] w-full items-center justify-center relative">
             <VideoCard
               {...selected}
               showMenu

--- a/apps/web/app/v/[eventId]/page.tsx
+++ b/apps/web/app/v/[eventId]/page.tsx
@@ -51,7 +51,7 @@ export default function VideoPage() {
     return <div className="flex min-h-screen items-center justify-center bg-black text-white">Loading...</div>;
   return (
     <>
-      <div className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] items-center justify-center">
+      <div className="flex h-[calc(100dvh-var(--top-nav-height,0)-var(--bottom-nav-height,0))] items-center justify-center">
         <VideoCard
           {...video}
           showMenu

--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { X, Sun, Moon } from 'lucide-react';
@@ -6,6 +6,7 @@ import useSearch from '../hooks/useSearch';
 import NotificationBell from './NotificationBell';
 import { useTheme } from 'next-themes';
 import useT from '../hooks/useT';
+import { useLayout } from '@/context/LayoutContext';
 
 const SearchBar: React.FC<{ showActions?: boolean }> = ({ showActions = true }) => {
   const [value, setValue] = useState('');
@@ -16,11 +17,25 @@ const SearchBar: React.FC<{ showActions?: boolean }> = ({ showActions = true }) 
   const isDark = resolvedTheme === 'dark';
   const toggleMode = () => setTheme(isDark ? 'light' : 'dark');
   const t = useT();
+  const layout = useLayout();
+  const barRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handler = setTimeout(() => setQuery(value.trim()), 300);
     return () => clearTimeout(handler);
   }, [value]);
+
+  useEffect(() => {
+    if (!barRef.current || layout === 'desktop') {
+      document.documentElement.style.removeProperty('--top-nav-height');
+      return;
+    }
+    const height = barRef.current.getBoundingClientRect().height;
+    document.documentElement.style.setProperty('--top-nav-height', `${height}px`);
+    return () => {
+      document.documentElement.style.removeProperty('--top-nav-height');
+    };
+  }, [layout]);
 
   const clear = () => {
     setValue('');
@@ -41,7 +56,10 @@ const SearchBar: React.FC<{ showActions?: boolean }> = ({ showActions = true }) 
 
   return (
     <>
-      <div className="fixed inset-x-0 top-0 z-20 flex h-12 items-center space-x-2 bg-background-primary/80 p-2 text-primary lg:static lg:max-w-[1400px] lg:mx-auto">
+      <div
+        ref={barRef}
+        className="fixed inset-x-0 top-0 z-20 flex h-12 items-center space-x-2 bg-background-primary/80 p-2 text-primary lg:static lg:max-w-[1400px] lg:mx-auto"
+      >
         <input
           value={value}
           onChange={(e) => setValue(e.target.value)}


### PR DESCRIPTION
## Summary
- add `--top-nav-height` CSS variable via SearchBar layout
- account for top navigation height in video pages

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68987a7154e88331bffd02f318d267a9