### PR TITLE
fix: include common messages for create page

### DIFF
--- a/apps/web/app/create/page.tsx
+++ b/apps/web/app/create/page.tsx
@@ -1,5 +1,4 @@
 import { NextIntlClientProvider } from 'next-intl';
-import { getMessages } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { locales } from '@/utils/locales';
 import CreatePageClient from './CreatePageClient';
@@ -18,11 +17,14 @@ export default async function CreatePage({
   params: Promise<{ locale?: string }>;
 }) {
   const { locale = 'en' } = await params;
-  const messages = await getMessages();
   const createMessages = (await import(`@/locales/${locale}/create.json`)).default;
+  const commonMessages = (await import(`@/locales/${locale}/common.json`)).default;
 
   return (
-    <NextIntlClientProvider locale={locale} messages={{ ...messages, create: createMessages }}>
+    <NextIntlClientProvider
+      locale={locale}
+      messages={{ common: commonMessages, create: createMessages }}
+    >
       <CreatePageClient />
     </NextIntlClientProvider>
   );


### PR DESCRIPTION
## Summary
- load common i18n messages in create page
- merge common and create messages into `NextIntlClientProvider`

## Testing
- `pnpm test apps/web/app/create/page.test.ts`
- `pnpm --filter @paiduan/web lint`

------
https://chatgpt.com/codex/tasks/task_e_68987ef4e63083318885199c324ba948