### PR TITLE
scope common translations for NextIntl

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -1,4 +1,5 @@
 import { NextIntlClientProvider } from 'next-intl';
+import { getMessages } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { locales } from '@/utils/locales';
 
@@ -19,9 +20,7 @@ export default async function LocaleLayout({
     notFound();
   }
 
-  const messages = {
-    common: (await import(`@/locales/${locale}/common.json`)).default,
-  };
+  const messages = await getMessages();
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>

--- a/apps/web/app/create/page.tsx
+++ b/apps/web/app/create/page.tsx
@@ -1,4 +1,5 @@
 import { NextIntlClientProvider } from 'next-intl';
+import { getMessages } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { locales } from '@/utils/locales';
 import CreatePageClient from './CreatePageClient';
@@ -17,13 +18,13 @@ export default async function CreatePage({
   params: Promise<{ locale?: string }>;
 }) {
   const { locale = 'en' } = await params;
+  const commonMessages = await getMessages();
   const createMessages = (await import(`@/locales/${locale}/create.json`)).default;
-  const commonMessages = (await import(`@/locales/${locale}/common.json`)).default;
 
   return (
     <NextIntlClientProvider
       locale={locale}
-      messages={{ common: commonMessages, create: createMessages }}
+      messages={{ ...commonMessages, create: createMessages }}
     >
       <CreatePageClient />
     </NextIntlClientProvider>

--- a/apps/web/i18n/request.ts
+++ b/apps/web/i18n/request.ts
@@ -5,6 +5,8 @@ export default getRequestConfig(async ({requestLocale}) => {
 
   return {
     locale,
-    messages: (await import(`../locales/${locale}/common.json`)).default
+    messages: {
+      common: (await import(`../locales/${locale}/common.json`)).default
+    }
   };
 });


### PR DESCRIPTION
## Summary
- namespace request i18n messages under `common`
- merge page-specific translations with `getMessages`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689880f3ea388331b2338477b8ce2193