### PR TITLE
fix: align VideoCard containers to top

### DIFF
--- a/apps/web/app/p/[pubkey]/page.tsx
+++ b/apps/web/app/p/[pubkey]/page.tsx
@@ -262,8 +262,8 @@ export default function ProfilePage() {
       </div>
 
       {selected && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90">
-          <div className="flex h-[calc(100dvh-var(--top-nav-height,0)-var(--bottom-nav-height,0))] w-full items-center justify-center relative">
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/90 lg:items-center">
+          <div className="flex h-[calc(100dvh-var(--top-nav-height,0)-var(--bottom-nav-height,0))] w-full items-start justify-center relative lg:items-center">
             <VideoCard
               {...selected}
               showMenu

--- a/apps/web/app/v/[eventId]/page.tsx
+++ b/apps/web/app/v/[eventId]/page.tsx
@@ -51,7 +51,7 @@ export default function VideoPage() {
     return <div className="flex min-h-screen items-center justify-center bg-black text-white">Loading...</div>;
   return (
     <>
-      <div className="flex h-[calc(100dvh-var(--top-nav-height,0)-var(--bottom-nav-height,0))] items-center justify-center">
+      <div className="flex h-[calc(100dvh-var(--top-nav-height,0)-var(--bottom-nav-height,0))] items-start justify-center lg:items-center">
         <VideoCard
           {...video}
           showMenu

--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -92,7 +92,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
               <div
                 key={item.eventId ?? index}
                 data-index={index}
-                className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full snap-start snap-always items-center justify-center"
+                className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full snap-start snap-always items-start justify-center lg:items-center"
                 ref={(el) => {
                   rowRefs.current[index] = el;
                   if (el) rowVirtualizer.measureElement(el);


### PR DESCRIPTION
## Summary
- anchor VideoCard to top on small screens in video page overlay
- top-align videos in feed items with responsive centering on larger screens
- ensure profile video overlay uses top alignment with responsive centering

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68988110424483319111716c22ba1efd