### PR TITLE
Select feed item by viewport center

### DIFF
--- a/apps/web/components/Feed.test.tsx
+++ b/apps/web/components/Feed.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import Feed from './Feed';
+import Feed, { getCenteredVirtualItem } from './Feed';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { VirtualItem } from '@tanstack/react-virtual';
 
 // Ensure React is available globally for components compiled with the classic JSX runtime
 (globalThis as any).React = React;
@@ -24,5 +25,24 @@ describe('Feed', () => {
       </QueryClientProvider>,
     );
     expect(html).toContain('<svg');
+  });
+
+  describe('getCenteredVirtualItem', () => {
+    const items: VirtualItem[] = [
+      { index: 0, start: 0, end: 100, size: 100, key: 0, lane: 0 },
+      { index: 1, start: 100, end: 200, size: 100, key: 1, lane: 0 },
+      { index: 2, start: 200, end: 300, size: 100, key: 2, lane: 0 },
+    ];
+
+    it('finds item overlapping the viewport center', () => {
+      const result = getCenteredVirtualItem(items, 100, 0);
+      expect(result?.index).toBe(0);
+    });
+
+    it('ignores overscanned items during fast scrolling', () => {
+      const overscanned = items.slice(1);
+      const result = getCenteredVirtualItem(overscanned, 100, 175);
+      expect(result?.index).toBe(2);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- choose virtual item overlapping the viewport center instead of first item
- test selection logic to ensure overscanned items aren't chosen

## Testing
- `pnpm exec eslint apps/web/components/Feed.tsx apps/web/components/Feed.test.tsx` *(fails: Pages directory cannot be found)*
- `pnpm test apps/web/components/Feed.test.tsx`
- `pnpm test` *(fails: useFollowerCount test assertion)*

------
https://chatgpt.com/codex/tasks/task_e_689884d755e483318262cabfaecc24c6