### PR TITLE
refactor: replace inline gradients with theme tokens

### DIFF
--- a/apps/web/components/ProfileHeader.tsx
+++ b/apps/web/components/ProfileHeader.tsx
@@ -15,10 +15,7 @@ export const ProfileHeader: React.FC<ProfileHeaderProps> = ({ avatarUrl, name, l
   const { online } = useNetworkState();
   return (
     <div className="flex flex-col items-center space-y-3 p-4 text-center">
-      <div
-        className="rounded-lg p-[2px]"
-        style={{ background: 'linear-gradient(145deg, #2a2a2a, #1c1c1c)' }}
-      >
+      <div className="rounded-lg bg-surface p-[2px]">
         <Image
           src={avatarUrl}
           alt={name}

--- a/apps/web/components/TopNavProfile.tsx
+++ b/apps/web/components/TopNavProfile.tsx
@@ -19,8 +19,7 @@ export default function TopNavProfile() {
   return (
     <div
       onClick={handleClick}
-      className="cursor-pointer rounded-lg p-[2px]"
-      style={{ background: 'linear-gradient(145deg, #2a2a2a, #1c1c1c)' }}
+      className="cursor-pointer rounded-lg bg-surface p-[2px]"
     >
       <Image
         src={profile?.picture || '/avatar.svg'}


### PR DESCRIPTION
## Summary
- replace inline gradient styles in ProfileHeader and TopNavProfile
- use Tailwind surface background token so colors follow theme

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6898873bc1b48331a8717d2759c46998