### PR TITLE
feat(web): unify theming with CSS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ notifications and follow data. Preferences are saved in `localStorage` and
 applied across all pages. A sun/moon icon in the toolbar also toggles light and
 dark modes without leaving the feed.
 
+Theming is driven by CSS variables declared in `apps/web/styles/globals.css`.
+`next-themes` manages the `data-theme` attribute and the Theme Agent's
+`useThemeAgent()` hook keeps DOM attributes in sync. Chakra UI and Tailwind map
+their colour tokens to these variables, making CSS variables plus
+`next-themes` the single source of truth.
+
 ## Internationalisation
 
 The web app uses [`next-intl`](https://next-intl-docs.vercel.app/) with explicit

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -3,7 +3,7 @@
 import { ChakraProvider, useColorMode } from '@chakra-ui/react';
 import theme from '../styles/theme';
 import { ThemeProvider, useTheme } from 'next-themes';
-import { themes } from '@/agents/theme';
+import { themes, useThemeAgent } from '@/agents/theme';
 import { ModqueueProvider } from '@/context/modqueueContext';
 import { GestureProvider } from '@paiduan/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -25,10 +25,16 @@ function ColorModeSync() {
   return null;
 }
 
+function ThemeAgentSync() {
+  useThemeAgent();
+  return null;
+}
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ChakraProvider theme={theme}>
       <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem themes={themes}>
+        <ThemeAgentSync />
         <ColorModeSync />
         <GestureProvider>
           <ModqueueProvider>

--- a/apps/web/styles/theme-config.ts
+++ b/apps/web/styles/theme-config.ts
@@ -2,7 +2,6 @@ import type { ThemeConfig } from '@chakra-ui/react';
 
 const themeConfig: ThemeConfig = {
   initialColorMode: 'light',
-  useSystemColorMode: true,
 };
 
 export default themeConfig;

--- a/apps/web/styles/theme.ts
+++ b/apps/web/styles/theme.ts
@@ -3,7 +3,36 @@
 import { extendTheme } from '@chakra-ui/react';
 import themeConfig from './theme-config';
 
-const theme = extendTheme({ config: themeConfig });
+const theme = extendTheme({
+  config: themeConfig,
+  colors: {
+    background: {
+      primary: 'hsl(var(--background-primary))',
+      secondary: 'hsl(var(--background-secondary))',
+    },
+    text: {
+      primary: 'hsl(var(--text-primary))',
+    },
+    card: 'hsl(var(--card))',
+    surface: 'hsl(var(--surface))',
+    accent: {
+      primary: 'hsl(var(--accent-primary))',
+      hover: 'hsl(var(--accent-hover))',
+      active: 'hsl(var(--accent-active))',
+    },
+    border: {
+      primary: 'hsl(var(--border-primary))',
+    },
+  },
+  styles: {
+    global: {
+      body: {
+        bg: 'background.primary',
+        color: 'text.primary',
+      },
+    },
+  },
+});
 
 export default theme;
 


### PR DESCRIPTION
## Summary
- bind Theme Agent to next-themes in app providers
- map Chakra tokens to CSS variables and drop redundant color-mode config
- document CSS variables + next-themes as theming source of truth

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689888c9995083319dd2448127fc56ed