### PR TITLE
feat(playback): retain progress per video

### DIFF
--- a/apps/web/agents/playback.test.ts
+++ b/apps/web/agents/playback.test.ts
@@ -20,24 +20,43 @@ describe('playback progress', () => {
     sessionStorage.clear();
   });
 
-  it('saves and restores progress', () => {
+  it('saves and restores progress for multiple videos', () => {
     const v1 = document.createElement('video');
     playback.loadSource(v1, { videoUrl: 'a.mp4', eventId: 'evt1' });
     v1.currentTime = 12;
     playback.pause();
 
     const v2 = document.createElement('video');
-    playback.loadSource(v2, { videoUrl: 'a.mp4', eventId: 'evt1' });
-    v2.dispatchEvent(new Event('loadedmetadata'));
-    expect(v2.currentTime).toBeCloseTo(12);
+    playback.loadSource(v2, { videoUrl: 'b.mp4', eventId: 'evt2' });
+    v2.currentTime = 34;
+    playback.pause();
+
+    const v1b = document.createElement('video');
+    playback.loadSource(v1b, { videoUrl: 'a.mp4', eventId: 'evt1' });
+    v1b.dispatchEvent(new Event('loadedmetadata'));
+    expect(v1b.currentTime).toBeCloseTo(12);
+
+    const v2b = document.createElement('video');
+    playback.loadSource(v2b, { videoUrl: 'b.mp4', eventId: 'evt2' });
+    v2b.dispatchEvent(new Event('loadedmetadata'));
+    expect(v2b.currentTime).toBeCloseTo(34);
   });
 
-  it('clears progress on ended', () => {
-    const v = document.createElement('video');
-    playback.loadSource(v, { videoUrl: 'a.mp4', eventId: 'evt2' });
-    v.currentTime = 5;
+  it('clears only the ended video progress', () => {
+    const v1 = document.createElement('video');
+    playback.loadSource(v1, { videoUrl: 'a.mp4', eventId: 'evt1' });
+    v1.currentTime = 5;
     playback.pause();
-    v.dispatchEvent(new Event('ended'));
-    expect(sessionStorage.getItem('lastPlaybackPosition')).toBeNull();
+
+    const v2 = document.createElement('video');
+    playback.loadSource(v2, { videoUrl: 'b.mp4', eventId: 'evt2' });
+    v2.currentTime = 7;
+    playback.pause();
+
+    v2.dispatchEvent(new Event('ended'));
+
+    const stored = JSON.parse(sessionStorage.getItem('lastPlaybackPosition')!);
+    expect(stored).toHaveProperty('evt1');
+    expect(stored).not.toHaveProperty('evt2');
   });
 });


### PR DESCRIPTION
## Summary
- track playback progress per `eventId` so multiple videos retain position
- prune expired entries and delete progress only for completed videos
- test multi-video progress saving and selective clearing

## Testing
- `pnpm test apps/web/agents/playback.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68988bfdb7448331babf7d45b1b4bbbb