### PR TITLE
Improve playback progress retention

### DIFF
--- a/apps/web/agents/playback.test.ts
+++ b/apps/web/agents/playback.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
-import { describe, it, expect, beforeEach } from 'vitest';
-import playback from './playback';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+let playback: typeof import('./playback').default;
 
 Object.defineProperty(HTMLMediaElement.prototype, 'play', {
   configurable: true,
@@ -16,8 +16,10 @@ Object.defineProperty(HTMLMediaElement.prototype, 'load', {
 });
 
 describe('playback progress', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     sessionStorage.clear();
+    vi.resetModules();
+    playback = (await import('./playback')).default;
   });
 
   it('saves and restores progress', () => {
@@ -39,5 +41,41 @@ describe('playback progress', () => {
     playback.pause();
     v.dispatchEvent(new Event('ended'));
     expect(sessionStorage.getItem('lastPlaybackPosition')).toBeNull();
+  });
+
+  it('restores progress when switching between videos', () => {
+    const first = document.createElement('video');
+    playback.loadSource(first, { videoUrl: 'a.mp4', eventId: 'evt1' });
+    first.currentTime = 10;
+    first.dispatchEvent(new Event('pause'));
+
+    const second = document.createElement('video');
+    playback.loadSource(second, { videoUrl: 'b.mp4', eventId: 'evt2' });
+    second.currentTime = 20;
+    second.dispatchEvent(new Event('pause'));
+
+    const firstAgain = document.createElement('video');
+    playback.loadSource(firstAgain, { videoUrl: 'a.mp4', eventId: 'evt1' });
+    firstAgain.dispatchEvent(new Event('loadedmetadata'));
+    expect(firstAgain.currentTime).toBeCloseTo(10);
+  });
+
+  it('prunes expired entries', async () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    const v = document.createElement('video');
+    playback.loadSource(v, { videoUrl: 'a.mp4', eventId: 'evt3' });
+    v.currentTime = 5;
+    v.dispatchEvent(new Event('pause'));
+
+    vi.setSystemTime(start + 24 * 60 * 60 * 1000 + 1);
+    vi.resetModules();
+    playback = (await import('./playback')).default;
+    const v2 = document.createElement('video');
+    playback.loadSource(v2, { videoUrl: 'a.mp4', eventId: 'evt3' });
+    v2.dispatchEvent(new Event('loadedmetadata'));
+    expect(v2.currentTime).toBe(0);
+    expect(sessionStorage.getItem('lastPlaybackPosition')).toBeNull();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- track playback positions for multiple videos and clear expired entries
- test cross-video progress restoration and pruning logic

## Testing
- `pnpm test apps/web/agents/playback.test.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68988c0324288331bf1e792f5d85bea1