### PR TITLE
refactor: move VideoCard user info overlay to top

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -313,35 +313,77 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         </button>
       )}
 
-      {errorMessage && <VideoFallback posterUrl={posterUrl} message={errorMessage} />}
+        {errorMessage && <VideoFallback posterUrl={posterUrl} message={errorMessage} />}
 
-      {showMenu && (
-        <div className="absolute right-4 top-4">
-          <button onClick={() => setMenuOpen((o) => !o)} className="hover:text-accent-primary">
-            <MoreVertical className="icon" />
-          </button>
-          {menuOpen && (
-            <div className="absolute right-0 mt-2 w-24 rounded bg-background-primary p-1 shadow">
+        <div className="absolute top-0 left-0 right-0 p-4 flex items-start justify-between">
+          <div className="flex-1 min-w-0">
+            <Link
+              href={`/p/${pubkey}`}
+              className="flex items-center space-x-3"
+              prefetch={false}
+              onMouseEnter={() => {
+                router.prefetch(`/p/${pubkey}`);
+                prefetchProfile(pubkey);
+              }}
+            >
+              {avatar ? (
+                <Image
+                  src={avatar}
+                  alt={displayName}
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-full object-cover"
+                  unoptimized
+                  onError={(e) => (e.currentTarget.src = '/avatar.svg')}
+                  crossOrigin="anonymous"
+                />
+              ) : (
+                <Skeleton className="h-10 w-10 rounded-full" />
+              )}
+              <div className="username">@{displayName}</div>
+            </Link>
+            {!isFollowing && (
               <button
-                className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
-                onClick={() => {
-                  setMenuOpen(false);
-                  ReportModal({ targetId: eventId, targetKind: 'video' });
-                }}
+                onClick={() => follow(pubkey)}
+                className="mt-2 rounded bg-accent-primary px-2 py-1 text-sm text-white"
               >
-                Report
+                Follow
               </button>
+            )}
+            <div className="meta-info mt-1">{caption}</div>
+          </div>
+          {showMenu && (
+            <div className="relative ml-2">
+              <button
+                onClick={() => setMenuOpen((o) => !o)}
+                className="hover:text-accent-primary"
+                aria-label="More options"
+              >
+                <MoreVertical className="icon" />
+              </button>
+              {menuOpen && (
+                <div className="absolute right-0 mt-2 w-24 rounded bg-background-primary p-1 shadow">
+                  <button
+                    className="block w-full rounded px-2 py-1 text-left text-sm hover:bg-text-primary/10"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      ReportModal({ targetId: eventId, targetKind: 'video' });
+                    }}
+                  >
+                    Report
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </div>
-      )}
 
-      <div className="absolute right-4 bottom-24 z-10 flex flex-col items-center space-y-4 lg:right-6 lg:bottom-32 lg:space-y-6">
-        <button
-          type="button"
-          className="hover:text-accent-primary"
-          onClick={() => {
-            const next = !muted;
+        <div className="absolute right-4 bottom-24 z-10 flex flex-col items-center space-y-4 lg:right-6 lg:bottom-32 lg:space-y-6">
+          <button
+            type="button"
+            className="hover:text-accent-primary"
+            onClick={() => {
+              const next = !muted;
             setMuted(next);
             const player = getPlayer();
             if (player) player.muted = next;
@@ -381,42 +423,6 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         </button>
       </div>
 
-      <div className="absolute bottom-0 left-0 w-full p-4">
-        <Link
-          href={`/p/${pubkey}`}
-          className="flex items-center space-x-3"
-          prefetch={false}
-          onMouseEnter={() => {
-            router.prefetch(`/p/${pubkey}`);
-            prefetchProfile(pubkey);
-          }}
-        >
-          {avatar ? (
-            <Image
-              src={avatar}
-              alt={displayName}
-              width={40}
-              height={40}
-              className="h-10 w-10 rounded-full object-cover"
-              unoptimized
-              onError={(e) => (e.currentTarget.src = '/avatar.svg')}
-              crossOrigin="anonymous"
-            />
-          ) : (
-            <Skeleton className="h-10 w-10 rounded-full" />
-          )}
-          <div className="username">@{displayName}</div>
-        </Link>
-        {!isFollowing && (
-          <button
-            onClick={() => follow(pubkey)}
-            className="mt-2 rounded bg-accent-primary px-2 py-1 text-sm text-white"
-          >
-            Follow
-          </button>
-        )}
-        <div className="meta-info mt-1">{caption}</div>
-      </div>
 
       <animated.div
         style={{ opacity }}

--- a/apps/web/components/ui/SkeletonVideoCard.tsx
+++ b/apps/web/components/ui/SkeletonVideoCard.tsx
@@ -5,12 +5,15 @@ export function SkeletonVideoCard() {
   return (
     <div className="relative mx-auto h-[calc(100dvh-var(--bottom-nav-height,0))] w-auto max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:h-[calc(100vh-var(--bottom-nav-height,0))] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-text-primary/10">
       <Skeleton className="h-full w-full" />
-      <div className="absolute bottom-0 left-0 w-full p-4">
-        <div className="flex items-center space-x-3">
-          <Skeleton className="h-10 w-10 rounded-full" />
-          <Skeleton className="h-4 w-32" />
+      <div className="absolute top-0 left-0 right-0 p-4 flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-3">
+            <Skeleton className="h-10 w-10 rounded-full" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+          <Skeleton className="mt-2 h-4 w-3/4" />
         </div>
-        <Skeleton className="mt-2 h-4 w-3/4" />
+        <Skeleton className="h-6 w-6" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- reposition VideoCard author info, follow button, and caption into a unified top overlay with the menu
- update SkeletonVideoCard to mirror the new top overlay layout

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx apps/web/components/VideoCard.playback.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689893cf0b3883318f51e8768c1017ad