### PR TITLE
feat: always show comment count badge

### DIFF
--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -88,6 +88,23 @@ describe('VideoCard', () => {
     expect(() => unmount()).not.toThrow();
   });
 
+  it('renders comment count badge and updates when count changes', () => {
+    const props = {
+      videoUrl: 'video.mp4',
+      author: 'author',
+      caption: 'caption',
+      eventId: 'event',
+      pubkey: 'pk',
+      zap: <div />,
+    };
+    const { rerender } = render(<VideoCard {...props} />);
+    const button = screen.getByRole('button', { name: 'Comments (0)' });
+    expect(button.textContent).toContain('0');
+    rerender(<VideoCard {...props} commentCount={5} />);
+    const updated = screen.getByRole('button', { name: 'Comments (5)' });
+    expect(updated.textContent).toContain('5');
+  });
+
   it('shows and hides placeholder around video load and fires onReady', async () => {
     const onReady = vi.fn();
     const props = {

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -403,12 +403,10 @@ export const VideoCard: React.FC<VideoCardProps> = ({
           onClick={() => online && onComment?.()}
           disabled={!online}
           title={!online ? 'Offline – reconnect to interact.' : undefined}
-          aria-label="Comments"
+          aria-label={`Comments (${commentCount})`}
         >
           <MessageCircle className="icon action-bar-icon md:h-8 md:w-8" />
-          {commentCount > 0 && (
-            <span className="absolute -right-2 -top-2 text-xs text-primary">{commentCount}</span>
-          )}
+          <span className="absolute -right-2 -top-2 text-xs text-primary">{commentCount}</span>
         </button>
         {zap}
         <button


### PR DESCRIPTION
## Summary
- always render comment count badge and expose count in aria-label
- add regression test for default and updated comment counts

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68989639928883319de4e86c53e9c268