### PR TITLE
feat(feed): remeasure virtualizer on layout change

### DIFF
--- a/apps/web/components/Feed.test.tsx
+++ b/apps/web/components/Feed.test.tsx
@@ -1,8 +1,10 @@
+/* @vitest-environment jsdom */
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import Feed, { getCenteredVirtualItem } from './Feed';
+import Feed, { getCenteredVirtualItem, estimateFeedItemSize } from './Feed';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LayoutProvider } from '@/context/LayoutContext';
 import type { VirtualItem } from '@tanstack/react-virtual';
 
 // Ensure React is available globally for components compiled with the classic JSX runtime
@@ -12,7 +14,9 @@ describe('Feed', () => {
   it('renders skeleton during loading', () => {
     const html = renderToStaticMarkup(
       <QueryClientProvider client={new QueryClient()}>
-        <Feed items={[]} loading />
+        <LayoutProvider>
+          <Feed items={[]} loading />
+        </LayoutProvider>
       </QueryClientProvider>,
     );
     expect(html).toContain('bg-text-primary/10');
@@ -21,7 +25,9 @@ describe('Feed', () => {
   it('renders empty state when no items', () => {
     const html = renderToStaticMarkup(
       <QueryClientProvider client={new QueryClient()}>
-        <Feed items={[]} />
+        <LayoutProvider>
+          <Feed items={[]} />
+        </LayoutProvider>
       </QueryClientProvider>,
     );
     expect(html).toContain('<svg');
@@ -43,6 +49,25 @@ describe('Feed', () => {
       const overscanned = items.slice(1);
       const result = getCenteredVirtualItem(overscanned, 100, 175);
       expect(result?.index).toBe(2);
+    });
+  });
+
+  describe('estimateFeedItemSize', () => {
+    it('matches window height when bottom nav is absent', () => {
+      const original = window.innerHeight;
+      (window as any).innerHeight = 900;
+      document.documentElement.style.removeProperty('--bottom-nav-height');
+      expect(estimateFeedItemSize(0)).toBe(900);
+      (window as any).innerHeight = original;
+    });
+
+    it('subtracts bottom nav height when present', () => {
+      const original = window.innerHeight;
+      (window as any).innerHeight = 900;
+      document.documentElement.style.setProperty('--bottom-nav-height', '50');
+      expect(estimateFeedItemSize(0)).toBe(850);
+      document.documentElement.style.removeProperty('--bottom-nav-height');
+      (window as any).innerHeight = original;
     });
   });
 });


### PR DESCRIPTION
## Summary
- remeasure video feed virtualizer when layout changes
- ensure estimateSize adjusts to bottom nav height
- test feed item sizing for layouts without bottom nav

## Testing
- `npx eslint apps/web/components/Feed.tsx apps/web/components/Feed.test.tsx`
- `pnpm test apps/web/components/Feed.test.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6898964cb58c83318116298d98915168