### PR TITLE
fix: cover video and use full-width container

### DIFF
--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -88,6 +88,24 @@ describe('VideoCard', () => {
     expect(() => unmount()).not.toThrow();
   });
 
+  it('fills the container and covers it without blank space', () => {
+    const props = {
+      videoUrl: 'video.mp4',
+      author: 'author',
+      caption: 'caption',
+      eventId: 'event',
+      pubkey: 'pk',
+      zap: <div />,
+    };
+    const { container } = render(<VideoCard {...props} />);
+    const video = container.querySelector('video') as HTMLVideoElement;
+    expect(video.className).toContain('object-cover');
+    const wrapper = container.firstChild as HTMLElement;
+    const className = wrapper.getAttribute('class') || '';
+    expect(className).toContain('w-full');
+    expect(className).not.toContain('w-auto');
+  });
+
   it('renders comment count badge and updates when count changes', () => {
     const props = {
       videoUrl: 'video.mp4',

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -247,7 +247,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="relative mx-auto h-[calc(100dvh-var(--bottom-nav-height,0))] w-auto max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:h-[calc(100vh-var(--bottom-nav-height,0))] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-card text-white shadow-card"
+      className="relative mx-auto h-[calc(100dvh-var(--bottom-nav-height,0))] w-full max-w-[calc((100dvh-var(--bottom-nav-height,0))*9/16)] sm:h-[calc(100vh-var(--bottom-nav-height,0))] sm:max-w-[calc((100vh-var(--bottom-nav-height,0))*9/16)] aspect-[9/16] overflow-hidden rounded-2xl bg-card text-white shadow-card"
       onClick={handleTogglePlay}
       onPointerDown={handleSpeedPointerDown}
       onPointerUp={handleSpeedPointerUp}
@@ -260,7 +260,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
       {!errorMessage && (
         <video
           ref={playerRef}
-          className={`pointer-events-none absolute inset-0 h-full w-full object-contain ${loaded ? '' : 'hidden'}`}
+          className={`pointer-events-none absolute inset-0 h-full w-full object-cover ${loaded ? '' : 'hidden'}`}
           loop
           muted={muted}
           playsInline


### PR DESCRIPTION
## Summary
- ensure VideoCard video uses `object-cover`
- expand VideoCard container to `w-full`
- test VideoCard renders full-width video

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689897ddba788331920027cab2bd0c9f