### PR TITLE
chore(web): copy workbox-sw during install

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -32,3 +32,7 @@ The **Publish** button remains disabled until a trimmed video is available and r
 By default, the application sends `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on all routes. These headers enable cross-origin isolation for features like WebCodecs.
 
 Set `ENABLE_ISOLATION=false` to disable these headers and allow loading third-party resources that do not provide COEP/CORP.
+
+## Service worker
+
+The app expects `public/workbox-sw.js` to be present so requests to `/workbox-sw.js` succeed. This file is copied from `node_modules/workbox-sw/build/workbox-sw.js` during `postinstall`. Run `pnpm run copy-workbox` if you need to regenerate it manually.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "postinstall": "pnpm run copy-workbox",
     "prebuild:pwa": "pnpm run copy-workbox",
     "build:pwa": "next build && next-pwa",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Summary
- copy Workbox runtime into `public` during `postinstall` so `/workbox-sw.js` is always present
- document Workbox requirement for future web app maintainers

## Testing
- `pnpm --filter @paiduan/web postinstall`
- `pnpm --filter @paiduan/web build` *(fails: useSearchParams() should be wrapped in a suspense boundary at page "/profile")*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689897b423bc8331b5a7a14255cf4177