### PR TITLE
refine create layout height

### DIFF
--- a/apps/web/app/create/CreatePageClient.tsx
+++ b/apps/web/app/create/CreatePageClient.tsx
@@ -7,10 +7,10 @@ const CreatorWizard = dynamic(() => import('@/components/create/CreatorWizard'),
 
 export default function CreatePageClient() {
   return (
-    <div className="box-border min-h-screen h-screen">
-      <main className="mx-auto max-w-[1400px] px-4 h-full">
-        <div className="grid h-full gap-6 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[280px_minmax(0,1fr)_340px]">
-          <aside className="hidden lg:block self-start sticky top-20 space-y-4">
+    <div className="box-border min-h-screen">
+      <main className="mx-auto max-w-[1400px] px-4">
+        <div className="grid gap-6 grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[280px_minmax(0,1fr)_340px]">
+          <aside className="hidden lg:block self-start sticky top-[var(--top-nav-height,0)] space-y-4">
             <SearchBar />
             <MiniProfileCard />
           </aside>

--- a/apps/web/components/create/CreatorWizard.tsx
+++ b/apps/web/components/create/CreatorWizard.tsx
@@ -5,7 +5,7 @@ import CreateVideoForm from './CreateVideoForm';
 export default function CreatorWizard() {
   const t = useTranslations('create');
   return (
-    <div className="flex flex-col min-h-[calc(100vh-5rem)] px-4 gap-6 xl:flex-row">
+    <div className="flex flex-col min-h-[calc(100dvh-var(--top-nav-height,0))] px-4 gap-6 xl:flex-row">
       <div className="flex flex-col items-start gap-2 xl:max-w-xs flex-none">
         <h1 className="text-3xl font-bold">{t('title')}</h1>
         <p className="text-sm text-gray-600 dark:text-gray-400">{t('instructions')}</p>


### PR DESCRIPTION
## Summary
- remove fixed viewport heights in create page layout and rely on min-h-screen
- use CSS variable offset for sticky sidebar
- ensure wizard uses dynamic viewport height to avoid overflow

## Testing
- `pnpm lint apps/web` (fails: Could not find task `apps/web` in project)
- `pnpm --filter ./apps/web lint`
- `pnpm test apps/web`


------
https://chatgpt.com/codex/tasks/task_e_689898b163948331a4384a668c02e80a