### PR TITLE
fix: adjust AppShell height for bottom nav

### DIFF
--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -59,7 +59,7 @@ export default function AppShell({
   const borderColor = useColorModeValue('gray.200', 'gray.700');
 
   return (
-    <Box minH="100vh" bg={bg}>
+    <Box minH="calc(100dvh - var(--bottom-nav-height, 0))" bg={bg}>
       <Grid
         mx="auto"
         w="full"
@@ -76,7 +76,7 @@ export default function AppShell({
             borderColor={borderColor}
             position="sticky"
             top={0}
-            h="100vh"
+            h="calc(100dvh - var(--bottom-nav-height, 0))"
             overflowY="auto"
             p={4}
           >
@@ -85,7 +85,11 @@ export default function AppShell({
         )}
 
         {/* Middle column: main feed */}
-        <GridItem as="main" h="100vh" overflow="hidden">
+        <GridItem
+          as="main"
+          h="calc(100dvh - var(--bottom-nav-height, 0))"
+          overflow="hidden"
+        >
           <Box maxW="2xl" mx="auto" h="full" px={4}>
             {center}
           </Box>
@@ -99,7 +103,7 @@ export default function AppShell({
             borderColor={borderColor}
             position="sticky"
             top={0}
-            h="100vh"
+            h="calc(100dvh - var(--bottom-nav-height, 0))"
             overflowY="auto"
           >
             {React.isValidElement(right)


### PR DESCRIPTION
## Summary
- use `calc(100dvh - var(--bottom-nav-height, 0))` for AppShell layout to account for mobile bottom navigation

## Testing
- `pnpm lint --filter=@paiduan/web`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68989a9f98bc833191d2bd8910b3888a