### PR TITLE
Persist feed selection in local storage

### DIFF
--- a/apps/web/store/feedSelection.ts
+++ b/apps/web/store/feedSelection.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 type S = {
   selectedVideoId?: string;
@@ -7,16 +8,27 @@ type S = {
   filterAuthor?: string;
   setFilterAuthor: (pubkey?: string) => void;
 };
-export const useFeedSelection = create<S>((set) => ({
-  selectedVideoId: undefined,
-  selectedVideoAuthor: undefined,
-  setSelectedVideo: (id, authorPubkey) =>
-    set((state) => {
-      if (state.selectedVideoId === id && state.selectedVideoAuthor === authorPubkey) {
-        return state;
-      }
-      return { selectedVideoId: id, selectedVideoAuthor: authorPubkey };
+export const useFeedSelection = create<S>()(
+  persist(
+    (set) => ({
+      selectedVideoId: undefined,
+      selectedVideoAuthor: undefined,
+      setSelectedVideo: (id, authorPubkey) =>
+        set((state) => {
+          if (state.selectedVideoId === id && state.selectedVideoAuthor === authorPubkey) {
+            return state;
+          }
+          return { selectedVideoId: id, selectedVideoAuthor: authorPubkey };
+        }),
+      filterAuthor: undefined,
+      setFilterAuthor: (pubkey) => set({ filterAuthor: pubkey }),
     }),
-  filterAuthor: undefined,
-  setFilterAuthor: (pubkey) => set({ filterAuthor: pubkey }),
-}));
+    {
+      name: 'feed-selection',
+      partialize: (state) => ({
+        selectedVideoId: state.selectedVideoId,
+        selectedVideoAuthor: state.selectedVideoAuthor,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- persist feed-selection store in local storage so last watched video reloads

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68989cd70b1c833194d65bde5cad6d23