### PR TITLE
fix: stop video play on username tap

### DIFF
--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -327,6 +327,11 @@ export const VideoCard: React.FC<VideoCardProps> = ({
               router.prefetch(`/p/${pubkey}`);
               prefetchProfile(pubkey);
             }}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              router.push(`/p/${pubkey}`);
+            }}
           >
             {avatar ? (
               <Image


### PR DESCRIPTION
## Summary
- stop VideoCard's global click from firing when username link is tapped
- ensure profile link uses captured pubkey via router.push

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68989db4569c8331b6bd2f4f539ed36f