### PR TITLE
feat: cap feed item size by width

### DIFF
--- a/apps/web/components/Feed.test.tsx
+++ b/apps/web/components/Feed.test.tsx
@@ -57,7 +57,7 @@ describe('Feed', () => {
       const original = window.innerHeight;
       (window as any).innerHeight = 900;
       document.documentElement.style.removeProperty('--bottom-nav-height');
-      expect(estimateFeedItemSize(0)).toBe(900);
+      expect(estimateFeedItemSize()).toBe(900);
       (window as any).innerHeight = original;
     });
 
@@ -65,9 +65,20 @@ describe('Feed', () => {
       const original = window.innerHeight;
       (window as any).innerHeight = 900;
       document.documentElement.style.setProperty('--bottom-nav-height', '50');
-      expect(estimateFeedItemSize(0)).toBe(850);
+      expect(estimateFeedItemSize()).toBe(850);
       document.documentElement.style.removeProperty('--bottom-nav-height');
       (window as any).innerHeight = original;
+    });
+
+    it('caps height by width on narrow viewports', () => {
+      const originalHeight = window.innerHeight;
+      const originalWidth = window.innerWidth;
+      (window as any).innerHeight = 900;
+      (window as any).innerWidth = 300;
+      document.documentElement.style.removeProperty('--bottom-nav-height');
+      expect(estimateFeedItemSize()).toBeCloseTo((300 * 16) / 9);
+      (window as any).innerHeight = originalHeight;
+      (window as any).innerWidth = originalWidth;
     });
   });
 });

--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -18,7 +18,7 @@ export const estimateFeedItemSize = () => {
       getComputedStyle(document.documentElement).getPropertyValue('--bottom-nav-height') || '0',
       10,
     ) || 0;
-  return window.innerHeight - nav;
+  return Math.min(window.innerHeight - nav, (window.innerWidth * 16) / 9);
 };
 import { VideoCard, VideoCardProps } from './VideoCard';
 import EmptyState from './EmptyState';
@@ -83,7 +83,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
 
   if (loading) {
     return (
-      <div className="h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full">
+      <div className="min-h-[calc(100dvh-var(--bottom-nav-height,0))] sm:min-h-[calc(100vh-var(--bottom-nav-height,0))] w-full">
         <SkeletonVideoCard />
       </div>
     );
@@ -91,7 +91,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
 
   if (items.length === 0) {
     return (
-      <div className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full flex-col items-center justify-center text-white">
+      <div className="flex min-h-[calc(100dvh-var(--bottom-nav-height,0))] sm:min-h-[calc(100vh-var(--bottom-nav-height,0))] w-full flex-col items-center justify-center text-white">
         <EmptyState />
         <Link href="/create" className="btn btn-primary mt-4" prefetch>
           Upload your first video
@@ -104,7 +104,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
     <>
       <div
         ref={parentRef}
-        className="h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full overflow-auto snap-y snap-mandatory scrollbar-none"
+        className="min-h-[calc(100dvh-var(--bottom-nav-height,0))] sm:min-h-[calc(100vh-var(--bottom-nav-height,0))] w-full overflow-auto snap-y snap-mandatory scrollbar-none"
       >
         <div
           style={{ height: rowVirtualizer.getTotalSize(), position: 'relative' }}


### PR DESCRIPTION
## Summary
- Cap feed item size by viewport width, respecting 16:9 ratio
- Use min-height utilities for loading, empty, and scroll containers
- Extend feed tests for width-based sizing

## Testing
- `pnpm test apps/web/components/Feed.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68989e274c9c83318a9d0ac024b9e29a