### PR TITLE
feat(feed): restore scroll to persisted selection

### DIFF
--- a/apps/web/components/Feed.selection.test.tsx
+++ b/apps/web/components/Feed.selection.test.tsx
@@ -1,0 +1,60 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+// Ensure React is available globally for components compiled with the classic JSX runtime
+(globalThis as any).React = React;
+
+const scrollToIndex = vi.fn();
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: () => ({
+    getVirtualItems: () => [],
+    scrollToIndex,
+    measure: vi.fn(),
+    getTotalSize: vi.fn(() => 0),
+    scrollRect: {},
+    scrollOffset: 0,
+    measureElement: vi.fn(),
+  }),
+}));
+
+vi.mock('./VideoCard', () => ({
+  VideoCard: (props: any) => <div data-video={props.eventId} />, // simple stub
+  default: (props: any) => <div data-video={props.eventId} />,
+}));
+vi.mock('./EmptyState', () => ({ default: () => null }));
+vi.mock('./ui/SkeletonVideoCard', () => ({ SkeletonVideoCard: () => null }));
+vi.mock('next/link', () => ({ default: (props: any) => <a {...props} /> }));
+vi.mock('./CommentDrawer', () => ({ default: () => null }));
+vi.mock('./ZapButton', () => ({ default: () => null }));
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ state: { status: 'ready', pubkey: 'pk' } }) }));
+vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({ wallets: [] }) }));
+vi.mock('@/context/LayoutContext', () => ({
+  useLayout: () => 'mobile',
+  LayoutProvider: ({ children }: any) => <div>{children}</div>,
+}));
+
+import Feed from './Feed';
+import { useFeedSelection } from '@/store/feedSelection';
+
+describe('Feed selection persistence', () => {
+  it('scrolls to persisted selected video on mount', async () => {
+    localStorage.clear();
+    useFeedSelection.getState().setSelectedVideo('vid2', 'pk2');
+    expect(
+      JSON.parse(localStorage.getItem('feed-selection') as string).state,
+    ).toMatchObject({ selectedVideoId: 'vid2', selectedVideoAuthor: 'pk2' });
+
+    const items = [
+      { eventId: 'vid1', pubkey: 'pk1', author: 'a1', caption: '', videoUrl: '', lightningAddress: '', zapTotal: 0 },
+      { eventId: 'vid2', pubkey: 'pk2', author: 'a2', caption: '', videoUrl: '', lightningAddress: '', zapTotal: 0 },
+      { eventId: 'vid3', pubkey: 'pk3', author: 'a3', caption: '', videoUrl: '', lightningAddress: '', zapTotal: 0 },
+    ];
+
+    render(<Feed items={items} />);
+    await waitFor(() => {
+      expect(scrollToIndex).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -54,6 +54,17 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
     overscan: 1,
   });
 
+  const didScrollToSelection = useRef(false);
+  useEffect(() => {
+    if (didScrollToSelection.current) return;
+    if (!selectedVideoId) return;
+    const index = items.findIndex((i) => i.eventId === selectedVideoId);
+    if (index >= 0) {
+      rowVirtualizer.scrollToIndex(index);
+      didScrollToSelection.current = true;
+    }
+  }, [selectedVideoId, items, rowVirtualizer]);
+
   useEffect(() => {
     rowVirtualizer.measure();
   }, [layout, rowVirtualizer]);


### PR DESCRIPTION
## Summary
- ensure Feed scrolls to previously selected video
- add test verifying virtualizer scrolls to persisted selection

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68989fa670308331bdb24dc23e347319