### PR TITLE
Enforce portrait aspect ratio for video uploads

### DIFF
--- a/apps/web/hooks/useVideoProcessing.ts
+++ b/apps/web/hooks/useVideoProcessing.ts
@@ -54,6 +54,13 @@ export function useVideoProcessing(t: (key: string) => string) {
         URL.revokeObjectURL(url);
         video.remove();
 
+        // Enforce portrait orientation of at least 9:16
+        if (!height || !width || width / height > 9 / 16) {
+          setErr(t('video_must_be_portrait'));
+          setProgress(0);
+          return;
+        }
+
         let blob: Blob | null = null;
         try {
           blob = await trimVideoWebCodecs(

--- a/apps/web/locales/ar/create.json
+++ b/apps/web/locales/ar/create.json
@@ -16,6 +16,7 @@
   "webcodecs_unavailable": "WebCodecs غير متاحة في هذا المتصفح.",
   "conversion_failed": "فشل التحويل.",
   "process_video_first": "يرجى معالجة الفيديو أولاً",
+  "video_must_be_portrait": "يجب أن يكون الفيديو عموديًا (على الأقل بنسبة 9:16)",
   "caption_placeholder": "العنوان",
   "topics_placeholder": "وسوم المواضيع (مفصولة بفواصل)",
   "lightning_address": "عنوان Lightning",

--- a/apps/web/locales/en/create.json
+++ b/apps/web/locales/en/create.json
@@ -16,6 +16,7 @@
   "webcodecs_unavailable": "WebCodecs unavailable in this browser.",
   "conversion_failed": "Conversion failed.",
   "process_video_first": "Please process a video first",
+  "video_must_be_portrait": "Video must be vertical (at least 9:16)",
   "caption_placeholder": "Caption",
   "topics_placeholder": "Topic tags (comma separated)",
   "lightning_address": "Lightning address",

--- a/apps/web/locales/zh/create.json
+++ b/apps/web/locales/zh/create.json
@@ -16,6 +16,7 @@
   "webcodecs_unavailable": "此浏览器不支持 WebCodecs。",
   "conversion_failed": "转换失败。",
   "process_video_first": "请先处理视频",
+  "video_must_be_portrait": "视频必须为竖屏（至少 9:16）",
   "caption_placeholder": "标题",
   "topics_placeholder": "主题标签（用逗号分隔）",
   "lightning_address": "Lightning 地址",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   },
 
   test: {
-    exclude: [...defaultExclude, 'apps/web/components/create/CreateVideoForm*.test.tsx'],
+    exclude: [...defaultExclude],
   },
 
 });


### PR DESCRIPTION
## Summary
- ensure uploaded videos are portrait with a minimum 9:16 ratio
- add user-facing error message and translations
- re-enable CreateVideoForm tests and verify landscape video is rejected

## Testing
- `pnpm test apps/web/components/create/CreateVideoForm.test.tsx -t "rejects landscape videos"`
- `pnpm lint --filter @paiduan/web`


------
https://chatgpt.com/codex/tasks/task_e_6898a5fce0cc8331a32a35fff59cc269