### PR TITLE
chore: include app build manifest in PWA build

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -60,7 +60,7 @@ const baseConfig = {
 const withPWAConfig = withPWA({
   dest: 'public',
   runtimeCaching,
-  buildExcludes: [/middleware-manifest\.json$/, /app-build-manifest\.json$/],
+  buildExcludes: [/middleware-manifest\.json$/],
   fallbacks: {
     image: '/offline.jpg',
     document: '/offline.html',


### PR DESCRIPTION
## Summary
- include app build manifest when generating PWA assets

## Testing
- `pnpm test`
- `pnpm dev` then `curl -I http://localhost:3000/en/feed`

------
https://chatgpt.com/codex/tasks/task_e_6898aa61f55c833185706002a7c9c2bc