### PR TITLE
Prototype react-virtuoso for feed virtualization

### DIFF
--- a/apps/web/components/Feed.selection.test.tsx
+++ b/apps/web/components/Feed.selection.test.tsx
@@ -7,15 +7,14 @@ import { render, waitFor } from '@testing-library/react';
 (globalThis as any).React = React;
 
 const scrollToIndex = vi.fn();
-vi.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: () => ({
-    getVirtualItems: () => [],
-    scrollToIndex,
-    measure: vi.fn(),
-    getTotalSize: vi.fn(() => 0),
-    scrollRect: {},
-    scrollOffset: 0,
-    measureElement: vi.fn(),
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: React.forwardRef((props: any, ref: any) => {
+    if (typeof ref === 'function') {
+      ref({ scrollToIndex });
+    } else if (ref) {
+      ref.current = { scrollToIndex };
+    }
+    return <div {...props} />;
   }),
 }));
 
@@ -54,7 +53,7 @@ describe('Feed selection persistence', () => {
 
     render(<Feed items={items} />);
     await waitFor(() => {
-      expect(scrollToIndex).toHaveBeenCalledWith(1);
+      expect(scrollToIndex).toHaveBeenCalledWith({ index: 1 });
     });
   });
 });

--- a/apps/web/components/Feed.test.tsx
+++ b/apps/web/components/Feed.test.tsx
@@ -2,10 +2,9 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import Feed, { getCenteredVirtualItem, estimateFeedItemSize } from './Feed';
+import Feed, { estimateFeedItemSize } from './Feed';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LayoutProvider } from '@/context/LayoutContext';
-import type { VirtualItem } from '@tanstack/react-virtual';
 
 // Ensure React is available globally for components compiled with the classic JSX runtime
 (globalThis as any).React = React;
@@ -31,25 +30,6 @@ describe('Feed', () => {
       </QueryClientProvider>,
     );
     expect(html).toContain('<svg');
-  });
-
-  describe('getCenteredVirtualItem', () => {
-    const items: VirtualItem[] = [
-      { index: 0, start: 0, end: 100, size: 100, key: 0, lane: 0 },
-      { index: 1, start: 100, end: 200, size: 100, key: 1, lane: 0 },
-      { index: 2, start: 200, end: 300, size: 100, key: 2, lane: 0 },
-    ];
-
-    it('finds item overlapping the viewport center', () => {
-      const result = getCenteredVirtualItem(items, 100, 0);
-      expect(result?.index).toBe(0);
-    });
-
-    it('ignores overscanned items during fast scrolling', () => {
-      const overscanned = items.slice(1);
-      const result = getCenteredVirtualItem(overscanned, 100, 175);
-      expect(result?.index).toBe(2);
-    });
   });
 
   describe('estimateFeedItemSize', () => {

--- a/apps/web/components/ThreadedComments.tsx
+++ b/apps/web/components/ThreadedComments.tsx
@@ -1,21 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import React, { useEffect, useState } from 'react';
+import { Virtuoso } from 'react-virtuoso';
 import type { Event } from 'nostr-tools/pure';
 import { getRelays } from '@/lib/nostr';
 import pool from '@/lib/relayPool';
 
 export default function ThreadedComments({ noteId }: { noteId?: string }) {
   const [events, setEvents] = useState<Event[]>([]);
-  const parentRef = useRef<HTMLUListElement>(null);
-
-  const rowVirtualizer = useVirtualizer({
-    count: events.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => 80,
-    overscan: 5,
-  });
 
   useEffect(() => {
     if (!noteId) return;
@@ -39,30 +31,25 @@ export default function ThreadedComments({ noteId }: { noteId?: string }) {
       {events.length === 0 ? (
         <p className="text-xs text-gray-600 dark:text-gray-400">Thread will render here.</p>
       ) : (
-        <ul ref={parentRef} className="max-h-96 overflow-auto relative">
-          <div
-            style={{
-              height: rowVirtualizer.getTotalSize(),
-              width: '100%',
-              position: 'relative',
-            }}
-          >
-            {rowVirtualizer.getVirtualItems().map((virtualRow) => (
-              <li
-                key={events[virtualRow.index].id}
-                ref={rowVirtualizer.measureElement}
-                data-index={virtualRow.index}
-                className="absolute top-0 left-0 w-full text-sm text-gray-800 dark:text-gray-200"
-                style={{
-                  transform: `translateY(${virtualRow.start}px)`,
-                  height: `${virtualRow.size}px`,
-                }}
-              >
-                {events[virtualRow.index].content}
-              </li>
-            ))}
-          </div>
-        </ul>
+        <Virtuoso
+          data={events}
+          className="max-h-96 overflow-auto"
+          components={{
+            List: React.forwardRef<HTMLUListElement, React.HTMLAttributes<HTMLUListElement>>(
+              (props, ref) => <ul {...props} ref={ref} />,
+            ),
+            Item: React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIElement>>(
+              (props, ref) => (
+                <li
+                  {...props}
+                  ref={ref}
+                  className="text-sm text-gray-800 dark:text-gray-200"
+                />
+              ),
+            ),
+          }}
+          itemContent={(index, event) => <>{event.content}</>}
+        />
       )}
     </div>
   );

--- a/apps/web/components/VideoFeed.tsx
+++ b/apps/web/components/VideoFeed.tsx
@@ -1,17 +1,9 @@
 'use client';
-import { useRef } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { Virtuoso } from 'react-virtuoso';
 import PlaceholderVideo from './PlaceholderVideo';
 
 export default function VideoFeed({ onAuthorClick }: { onAuthorClick: (pubkey: string) => void }) {
   const videos: unknown[] = [];
-  const parentRef = useRef<HTMLDivElement>(null);
-  const rowVirtualizer = useVirtualizer({
-    count: videos.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => (typeof window === 'undefined' ? 0 : window.innerHeight),
-    overscan: 1,
-  });
 
   if (videos.length === 0) {
     return (
@@ -24,29 +16,12 @@ export default function VideoFeed({ onAuthorClick }: { onAuthorClick: (pubkey: s
   }
 
   return (
-    <div ref={parentRef} className="relative h-full w-full overflow-auto">
-      <div
-        style={{
-          height: rowVirtualizer.getTotalSize(),
-          width: '100%',
-          position: 'relative',
-        }}
-      >
-        {rowVirtualizer.getVirtualItems().map((virtualRow) => (
-          <div
-            key={virtualRow.key}
-            ref={rowVirtualizer.measureElement}
-            data-index={virtualRow.index}
-            className="absolute top-0 left-0 w-full"
-            style={{
-              transform: `translateY(${virtualRow.start}px)`,
-              height: `${virtualRow.size}px`,
-            }}
-          >
-            <PlaceholderVideo className="h-full w-full" message="Loading video…" />
-          </div>
-        ))}
-      </div>
-    </div>
+    <Virtuoso
+      data={videos}
+      className="relative h-full w-full overflow-auto"
+      itemContent={() => (
+        <PlaceholderVideo className="h-full w-full" message="Loading video…" />
+      )}
+    />
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "@react-spring/web": "^9.7.2",
     "@sentry/nextjs": "^10.3.0",
     "@tanstack/react-query": "^5.84.2",
-    "@tanstack/react-virtual": "3.13.12",
+    "react-virtuoso": "^4.14.0",
     "clsx": "^2.1.1",
     "comlink": "^4.4.2",
     "dexie": "^4.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.84.2
         version: 5.84.2(react@19.1.1)
-      '@tanstack/react-virtual':
-        specifier: 3.13.12
-        version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -195,6 +192,9 @@ importers:
       react-use-gesture:
         specifier: ^9.1.3
         version: 9.1.3(react@19.1.1)
+      react-virtuoso:
+        specifier: ^4.14.0
+        version: 4.14.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       recharts:
         specifier: ^2.8.0
         version: 2.15.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -247,6 +247,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.9)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.21(postcss@8.5.6)
@@ -2511,6 +2514,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
 
   '@typescript-eslint/eslint-plugin@8.39.0':
     resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
@@ -5407,6 +5413,12 @@ packages:
     peerDependencies:
       react: '*'
       react-dom: '*'
+
+  react-virtuoso@4.14.0:
+    resolution: {integrity: sha512-fR+eiCvirSNIRvvCD7ueJPRsacGQvUbjkwgWzBZXVq+yWypoH7mRUvWJzGHIdoRaCZCT+6mMMMwIG2S1BW3uwA==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
@@ -9027,6 +9039,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 20.19.9
+
   '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -12231,6 +12247,11 @@ snapshots:
       throttle-debounce: 3.0.1
       ts-easing: 0.2.0
       tslib: 2.8.1
+
+  react-virtuoso@4.14.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   react@19.1.1: {}
 


### PR DESCRIPTION
## Summary
- replace @tanstack/react-virtual with react-virtuoso in feed, comment list, and placeholder feed components
- wrap feed items in `snap-y snap-mandatory` container to keep snap scrolling
- drop direct dependency on @tanstack/react-virtual and adjust tests
- compare bundle sizes: react-virtual ≈18 KB vs react-virtuoso ≈199 KB

## Testing
- `pnpm test` *(fails: CreateVideoForm and CreateVideoForm.profiles suites)*

------
https://chatgpt.com/codex/tasks/task_e_689907ed1fe883319637ea0cba8b1606