### PR TITLE
fix(web): size feed items to viewport

### DIFF
--- a/apps/web/components/Feed.test.tsx
+++ b/apps/web/components/Feed.test.tsx
@@ -70,15 +70,13 @@ describe('Feed', () => {
       (window as any).innerHeight = original;
     });
 
-    it('caps height by width on narrow viewports', () => {
-      const originalHeight = window.innerHeight;
-      const originalWidth = window.innerWidth;
-      (window as any).innerHeight = 900;
-      (window as any).innerWidth = 300;
-      document.documentElement.style.removeProperty('--bottom-nav-height');
-      expect(estimateFeedItemSize()).toBeCloseTo((300 * 16) / 9);
-      (window as any).innerHeight = originalHeight;
-      (window as any).innerWidth = originalWidth;
+    it('returns 0 when window is undefined', () => {
+      const originalWindow = (globalThis as any).window;
+      // @ts-ignore simulate server environment
+      delete (globalThis as any).window;
+      expect(estimateFeedItemSize()).toBe(0);
+      (globalThis as any).window = originalWindow;
     });
+
   });
 });

--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -12,13 +12,17 @@ export function getCenteredVirtualItem(
   return virtualItems.find((item) => item.start <= center && item.end >= center);
 }
 export const estimateFeedItemSize = () => {
-  if (typeof window === 'undefined') return 0;
   const nav =
-    parseInt(
-      getComputedStyle(document.documentElement).getPropertyValue('--bottom-nav-height') || '0',
-      10,
-    ) || 0;
-  return Math.min(window.innerHeight - nav, (window.innerWidth * 16) / 9);
+    typeof window === 'undefined'
+      ? 0
+      :
+          parseInt(
+            getComputedStyle(document.documentElement).getPropertyValue(
+              '--bottom-nav-height',
+            ) || '0',
+            10,
+          ) || 0;
+  return typeof window === 'undefined' ? 0 : window.innerHeight - nav;
 };
 import { VideoCard, VideoCardProps } from './VideoCard';
 import EmptyState from './EmptyState';


### PR DESCRIPTION
## Summary
- ensure feed item sizing uses viewport height minus bottom nav
- drop 16:9 ratio fallback and handle SSR gracefully
- align unit tests with new sizing logic

## Testing
- `pnpm test apps/web/components/Feed.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689904b4459c8331aaa045391be55828