### PR TITLE
fix: set explicit height for feed virtuoso container

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -81,7 +81,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
 
   if (loading) {
     return (
-      <div className="min-h-[calc(100dvh-var(--bottom-nav-height,0))] sm:min-h-[calc(100vh-var(--bottom-nav-height,0))] w-full">
+      <div className="h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full">
         <SkeletonVideoCard />
       </div>
     );
@@ -89,7 +89,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
 
   if (items.length === 0) {
     return (
-      <div className="flex min-h-[calc(100dvh-var(--bottom-nav-height,0))] sm:min-h-[calc(100vh-var(--bottom-nav-height,0))] w-full flex-col items-center justify-center text-white">
+      <div className="flex h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full flex-col items-center justify-center text-white">
         <EmptyState />
         <Link href="/create" className="btn btn-primary mt-4" prefetch>
           Upload your first video
@@ -103,7 +103,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
       <Virtuoso
         ref={virtuosoRef}
         totalCount={items.length}
-        className="min-h-[calc(100dvh-var(--bottom-nav-height,0))] sm:min-h-[calc(100vh-var(--bottom-nav-height,0))] w-full overflow-auto snap-y snap-mandatory scrollbar-none"
+        className="h-[calc(100dvh-var(--bottom-nav-height,0))] sm:h-[calc(100vh-var(--bottom-nav-height,0))] w-full overflow-auto snap-y snap-mandatory scrollbar-none"
         endReached={loadMore}
         rangeChanged={handleRangeChanged}
         itemContent={(index) => {


### PR DESCRIPTION
## Summary
- use explicit height utilities for feed skeleton, empty, and virtuoso containers
- maintain full-height wrapping in AppShell layout

## Testing
- `pnpm test apps/web/components/Feed.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689915eab36c83319f63f484b5a02d6a