### PR TITLE
Improve mobile PWA metadata and scrolling behaviour

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -16,6 +16,9 @@ export default function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="theme-color" content="#101010" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </head>
       <body suppressHydrationWarning>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -72,9 +72,15 @@
   --border-primary: 150 10% 25%;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   background: hsl(var(--background-primary));
   color: hsl(var(--text-primary));
+  min-height: 100vh;
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- add viewport and Apple web app meta tags to root layout
- ensure html/body fill viewport and body spans at least 100vh

## Testing
- `pnpm test` *(fails: 2 failed, 39 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689912fbf46c8331a99f2138e9e335d2