### PR TITLE
Expose feed limit configuration and eager prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Client-side video trimming relies on the [WebCodecs API](https://developer.mozil
 
 Override the default Nostr relays with the `NEXT_PUBLIC_RELAYS` environment variable or by editing `apps/web/relays.json`. The environment variable accepts a comma‑separated list or a JSON array. If neither is provided, the app falls back to `wss://relay.damus.io`, `wss://nos.lol` and `wss://relay.snort.social`.
 
+## Feed configuration
+
+Control how many events are requested per page by setting `NEXT_PUBLIC_FEED_LIMIT` (defaults to `20`).
+
 ## PWA features
 
 The web client ships as a Progressive Web App:

--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -44,6 +44,10 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   const hasWallet = !!viewerProfile?.wallets?.length;
   useLayout();
 
+  useEffect(() => {
+    loadMore?.();
+  }, [loadMore]);
+
   const didScrollToSelection = useRef(false);
   useEffect(() => {
     if (didScrollToSelection.current) return;
@@ -70,7 +74,7 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
 
   const handleRangeChanged = (range: ListRange) => {
     const middleIndex = Math.floor((range.startIndex + range.endIndex) / 2);
-    if (middleIndex >= items.length - 2) {
+    if (range.endIndex >= Math.floor(items.length * 0.8)) {
       loadMore?.();
     }
     const current = items[middleIndex];


### PR DESCRIPTION
## Summary
- make feed page size configurable via `NEXT_PUBLIC_FEED_LIMIT`
- prefetch additional feed items on mount and when 80% of list is viewed
- document feed limit environment variable

## Testing
- `pnpm --filter @paiduan/web lint --file hooks/useFeed.ts --file components/Feed.tsx`
- `pnpm test apps/web/components/Feed.selection.test.tsx apps/web/app/feed/page.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689918b1f8dc8331837f0c38f0f354fb