### PR TITLE
feat: persist feed position

### DIFF
--- a/apps/web/store/feedSelection.ts
+++ b/apps/web/store/feedSelection.ts
@@ -7,6 +7,9 @@ type S = {
   setSelectedVideo: (id?: string, authorPubkey?: string) => void;
   filterAuthor?: string;
   setFilterAuthor: (pubkey?: string) => void;
+  lastIndex?: number;
+  lastCursor?: string;
+  setLastPosition: (index: number, cursor: string) => void;
 };
 export const useFeedSelection = create<S>()(
   persist(
@@ -22,12 +25,17 @@ export const useFeedSelection = create<S>()(
         }),
       filterAuthor: undefined,
       setFilterAuthor: (pubkey) => set({ filterAuthor: pubkey }),
+      lastIndex: undefined,
+      lastCursor: undefined,
+      setLastPosition: (index, cursor) => set({ lastIndex: index, lastCursor: cursor }),
     }),
     {
       name: 'feed-selection',
       partialize: (state) => ({
         selectedVideoId: state.selectedVideoId,
         selectedVideoAuthor: state.selectedVideoAuthor,
+        lastIndex: state.lastIndex,
+        lastCursor: state.lastCursor,
       }),
     },
   ),


### PR DESCRIPTION
## Summary
- persist feed index and cursor in feed selection store
- restore feed scroll from persisted position and load more until cursor

## Testing
- `pnpm test apps/web/components/Feed.test.tsx apps/web/components/Feed.selection.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68991afdec1883319cc3b172b0fb80cb