### PR TITLE
feat: focus existing client on notification click

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -98,5 +98,16 @@ self.addEventListener('notificationclick', (event) => {
   event.notification.close();
   const url =
     event.notification.data && event.notification.data.url ? event.notification.data.url : '/';
-  event.waitUntil(clients.openWindow(url));
+  event.waitUntil(
+    clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((windowClients) => {
+        for (const client of windowClients) {
+          if (client.url === url || client.url.startsWith(url)) {
+            return client.focus();
+          }
+        }
+        return clients.openWindow(url);
+      })
+  );
 });


### PR DESCRIPTION
## Summary
- reuse open clients if a notification target URL is already open
- open new window only when no matching client exists

## Testing
- `pnpm --filter @paiduan/web run lint` *(fails: Component definition is missing display name)*
- `pnpm test` *(fails: 2 failed test files, 4 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68991c43282c83318b8997f50f2231c3