### PR TITLE
chore: define id and scope in PWA manifest

### DIFF
--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -1,7 +1,9 @@
 {
   "name": "PaiDuan",
   "short_name": "PaiDuan",
+  "id": "/",
   "start_url": "/feed",
+  "scope": "/",
   "display": "standalone",
   "orientation": "portrait",
   "theme_color": "#101010",

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PaiDuan",
   "short_name": "PaiDuan",
-  "id": "/",
+  "id": "paiduan",
   "start_url": "/feed",
   "scope": "/",
   "display": "standalone",


### PR DESCRIPTION
## Summary
- add `id` and `scope` fields to PWA manifest so the app opens as a single task

## Testing
- `node -e "const m=require('./apps/web/public/manifest.json'); console.log('id:', m.id); console.log('scope:', m.scope);"`
- `pnpm test` *(fails: expected null not to be null; spy not called; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68991d4693b48331b0118a8c22d5584d