### PR TITLE
feat: add recommendation feed service and queue

### DIFF
--- a/apps/web/components/Feed.selection.test.tsx
+++ b/apps/web/components/Feed.selection.test.tsx
@@ -7,16 +7,16 @@ import { render, waitFor } from '@testing-library/react';
 (globalThis as any).React = React;
 
 const scrollToIndex = vi.fn();
-vi.mock('react-virtuoso', () => ({
-  Virtuoso: React.forwardRef((props: any, ref: any) => {
-    if (typeof ref === 'function') {
-      ref({ scrollToIndex });
-    } else if (ref) {
-      ref.current = { scrollToIndex };
-    }
-    return <div {...props} />;
-  }),
-}));
+const MockVirtuoso = React.forwardRef((props: any, ref: any) => {
+  if (typeof ref === 'function') {
+    ref({ scrollToIndex });
+  } else if (ref) {
+    ref.current = { scrollToIndex };
+  }
+  return <div {...props} />;
+});
+MockVirtuoso.displayName = 'Virtuoso';
+vi.mock('react-virtuoso', () => ({ Virtuoso: MockVirtuoso }));
 
 vi.mock('./VideoCard', () => ({
   VideoCard: (props: any) => <div data-video={props.eventId} />, // simple stub

--- a/apps/web/components/ThreadedComments.tsx
+++ b/apps/web/components/ThreadedComments.tsx
@@ -6,6 +6,22 @@ import type { Event } from 'nostr-tools/pure';
 import { getRelays } from '@/lib/nostr';
 import pool from '@/lib/relayPool';
 
+const List = React.forwardRef<HTMLUListElement, React.HTMLAttributes<HTMLUListElement>>(
+  (props, ref) => <ul {...props} ref={ref} />,
+);
+List.displayName = 'VirtuosoList';
+
+const Item = React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIElement>>(
+  (props, ref) => (
+    <li
+      {...props}
+      ref={ref}
+      className="text-sm text-gray-800 dark:text-gray-200"
+    />
+  ),
+);
+Item.displayName = 'VirtuosoItem';
+
 export default function ThreadedComments({ noteId }: { noteId?: string }) {
   const [events, setEvents] = useState<Event[]>([]);
 
@@ -34,20 +50,7 @@ export default function ThreadedComments({ noteId }: { noteId?: string }) {
         <Virtuoso
           data={events}
           className="max-h-96 overflow-auto"
-          components={{
-            List: React.forwardRef<HTMLUListElement, React.HTMLAttributes<HTMLUListElement>>(
-              (props, ref) => <ul {...props} ref={ref} />,
-            ),
-            Item: React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIElement>>(
-              (props, ref) => (
-                <li
-                  {...props}
-                  ref={ref}
-                  className="text-sm text-gray-800 dark:text-gray-200"
-                />
-              ),
-            ),
-          }}
+          components={{ List, Item }}
           itemContent={(index, event) => <>{event.content}</>}
         />
       )}

--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/re
 import userEvent from '@testing-library/user-event';
 import { usePlaybackPrefs } from '@/store/playbackPrefs';
 import { useFollowingStore } from '@/store/following';
+vi.mock('@/lib/feed-service', () => ({ feedService: { logInteraction: vi.fn() } }));
 
 // Ensure React is available globally for components compiled with the classic JSX runtime
 (globalThis as any).React = React;
@@ -207,9 +208,7 @@ describe('VideoCard', () => {
     await user.click(await screen.findByRole('button', { name: /unmute/i }));
     await screen.findByRole('button', { name: /mute/i });
     rerender(<Wrapper showSecond={true} />);
-    expect(
-      HTMLMediaElement.prototype.pause as unknown as vi.Mock
-    ).toHaveBeenCalledTimes(1);
+    expect(HTMLMediaElement.prototype.pause as unknown as vi.Mock).toHaveBeenCalledTimes(1);
     const videos = container.querySelectorAll('video');
     const video2 = videos[1] as HTMLVideoElement;
     fireEvent.loadedData(video2);
@@ -268,7 +267,7 @@ describe('VideoCard', () => {
     };
     const { container } = render(<VideoCard {...props} />);
     const icons = container.querySelectorAll('.action-bar-icon');
-    expect(icons).toHaveLength(3);
+    expect(icons).toHaveLength(4);
     icons.forEach((icon) => {
       const className = icon.getAttribute('class') || '';
       expect(className).toContain('md:h-8');

--- a/apps/web/hooks/useRecommendationQueue.test.ts
+++ b/apps/web/hooks/useRecommendationQueue.test.ts
@@ -1,0 +1,30 @@
+/* @vitest-environment jsdom */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import useRecommendationQueue from './useRecommendationQueue';
+import { feedService } from '@/lib/feed-service';
+
+vi.mock('@/lib/feed-service', () => ({
+  feedService: {
+    fetchRecommendations: vi.fn(),
+  },
+}));
+
+describe('useRecommendationQueue', () => {
+  it('fetches more when below threshold', async () => {
+    const item = { videoUrl: '', author: 'a', caption: '', eventId: '1', pubkey: 'p' };
+    const mockFetch = feedService.fetchRecommendations as unknown as vi.Mock;
+    mockFetch
+      .mockResolvedValueOnce({ items: [item], nextCursor: 'c2' })
+      .mockResolvedValueOnce({ items: [item], nextCursor: undefined });
+
+    const { result } = renderHook(() => useRecommendationQueue(2));
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    act(() => result.current.markSeen());
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.queue.length).toBe(1));
+  });
+});

--- a/apps/web/hooks/useRecommendationQueue.ts
+++ b/apps/web/hooks/useRecommendationQueue.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react';
+import { feedService } from '@/lib/feed-service';
+import type { VideoCardProps } from '@/components/VideoCard';
+
+export function useRecommendationQueue(threshold = 5) {
+  const [queue, setQueue] = useState<VideoCardProps[]>([]);
+  const [cursor, setCursor] = useState<string | undefined>();
+  const [hasMore, setHasMore] = useState(true);
+  const loading = useRef(false);
+
+  const fetchMore = async () => {
+    if (loading.current || !hasMore) return;
+    loading.current = true;
+    try {
+      const { items, nextCursor } = await feedService.fetchRecommendations(cursor);
+      setQueue((q) => [...q, ...items]);
+      setCursor(nextCursor);
+      setHasMore(!!nextCursor);
+    } finally {
+      loading.current = false;
+    }
+  };
+
+  useEffect(() => {
+    fetchMore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (queue.length < threshold && hasMore) {
+      fetchMore();
+    }
+  }, [queue.length, threshold, hasMore]);
+
+  const markSeen = (count = 1) => {
+    setQueue((q) => q.slice(count));
+  };
+
+  return { queue, markSeen, fetchMore };
+}
+
+export default useRecommendationQueue;

--- a/apps/web/lib/feed-service.ts
+++ b/apps/web/lib/feed-service.ts
@@ -1,0 +1,33 @@
+import { VideoCardProps } from '@/components/VideoCard';
+import { telemetry } from '@/agents/telemetry';
+
+export interface RecommendationResponse {
+  items: VideoCardProps[];
+  nextCursor?: string;
+}
+
+export async function fetchRecommendations(cursor?: string): Promise<RecommendationResponse> {
+  const url = cursor
+    ? `/api/recommendations?cursor=${encodeURIComponent(cursor)}`
+    : '/api/recommendations';
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch recommendations');
+  const data: RecommendationResponse = await res.json();
+  telemetry.track('feed.fetch', { cursor, count: data.items.length });
+  return data;
+}
+
+export async function logInteraction(
+  itemId: string,
+  data: { watchTime?: number; liked?: boolean },
+): Promise<void> {
+  telemetry.track('feed.interaction', { itemId, ...data });
+  await fetch('/api/recommendations/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ itemId, ...data }),
+  });
+}
+
+export const feedService = { fetchRecommendations, logInteraction };
+export default feedService;


### PR DESCRIPTION
## Summary
- add feed service for cursor-based recommendations and interaction logging
- maintain client-side queue that prefetches when low
- record watch time and likes to improve personalization
- fix lint errors by adding display names to mocked components

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68991d1b4ff083318932be72ef2d22f9