### PR TITLE
feat(web): add session feed hook

### DIFF
--- a/apps/web/app/feed/page.test.tsx
+++ b/apps/web/app/feed/page.test.tsx
@@ -6,8 +6,10 @@ import { render } from '@testing-library/react';
 // Ensure React is available globally for components compiled with the classic JSX runtime
 (globalThis as any).React = React;
 
-const useFeedMock = vi.hoisted(() => vi.fn(() => ({ items: [], loadMore: vi.fn(), loading: false })));
-vi.mock('@/hooks/useFeed', () => ({ default: useFeedMock }));
+const useSessionFeedMock = vi.hoisted(() =>
+  vi.fn(() => ({ queue: [], fetchMore: vi.fn(), markSeen: vi.fn() })),
+);
+vi.mock('@/hooks/useSessionFeed', () => ({ default: useSessionFeedMock }));
 vi.mock('@/components/layout/AppShell', () => ({ default: ({ children }: any) => <div>{children}</div> }));
 vi.mock('@/components/layout/MainNav', () => ({ default: () => null }));
 vi.mock('@/components/feed/RightPanel', () => ({ default: () => null }));
@@ -27,6 +29,6 @@ import FeedPage from './page';
 describe('FeedPage', () => {
   it('uses following authors when tab=following', () => {
     render(<FeedPage />);
-    expect(useFeedMock).toHaveBeenCalledWith('following', ['pk1', 'pk2'], {}, true);
+    expect(useSessionFeedMock).toHaveBeenCalledWith('following', ['pk1', 'pk2']);
   });
 });

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -3,7 +3,7 @@ import AppShell from '@/components/layout/AppShell';
 import MainNav from '@/components/layout/MainNav';
 import RightPanel from '@/components/feed/RightPanel';
 import Feed from '@/components/Feed';
-import useFeed from '@/hooks/useFeed';
+import useSessionFeed from '@/hooks/useSessionFeed';
 import { useAuth } from '@/hooks/useAuth';
 import useFollowing from '@/hooks/useFollowing';
 import useFollowerCount from '@/hooks/useFollowerCount';
@@ -33,11 +33,9 @@ export default function FeedPage() {
   }, [feedMode, setFilterAuthor]);
 
   const mode = filterAuthor ? { author: filterAuthor } : feedMode;
-  const { items: videos, loadMore, loading } = useFeed(
+  const { queue: videos, fetchMore, markSeen } = useSessionFeed(
     mode,
     feedMode === 'following' && !filterAuthor ? following : [],
-    {},
-    isClient,
   );
   const me =
     auth.status === 'ready'
@@ -58,6 +56,8 @@ export default function FeedPage() {
     setFilterAuthor(pubkey);
   }
 
+  const loading = videos.length === 0;
+
   return (
     <CurrentVideoProvider>
       <AppShell
@@ -66,9 +66,14 @@ export default function FeedPage() {
           <div className="feed-container h-full">
             {/* tabs bar you already have can stay on top */}
             {isClient ? (
-              <Feed items={videos} loadMore={loadMore} loading={loading} />
+              <Feed
+                items={videos}
+                loadMore={fetchMore}
+                markSeen={markSeen}
+                loading={loading}
+              />
             ) : (
-              <Feed items={[]} loadMore={() => {}} loading />
+              <Feed items={[]} loadMore={() => {}} markSeen={() => {}} loading />
             )}
           </div>
         }

--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -31,9 +31,15 @@ interface FeedProps {
   items: VideoCardProps[];
   loading?: boolean;
   loadMore?: () => void;
+  markSeen?: (count: number) => void;
 }
 
-export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
+export const Feed: React.FC<FeedProps> = ({
+  items,
+  loading,
+  loadMore,
+  markSeen,
+}) => {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const setSelectedVideo = useFeedSelection((s) => s.setSelectedVideo);
   const selectedVideoId = useFeedSelection((s) => s.selectedVideoId);
@@ -46,10 +52,6 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
   const viewerProfile = useProfile(state.status === 'ready' ? state.pubkey : undefined);
   const hasWallet = !!viewerProfile?.wallets?.length;
   useLayout();
-
-  useEffect(() => {
-    loadMore?.();
-  }, [loadMore]);
 
   const didScrollToSelection = useRef(false);
   useEffect(() => {
@@ -95,6 +97,9 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore }) => {
     const cursor = items[items.length - 1]?.eventId;
     if (cursor) {
       setLastPosition(middleIndex, cursor);
+    }
+    if (range.startIndex > 0) {
+      markSeen?.(range.startIndex);
     }
   };
 

--- a/apps/web/hooks/useSessionFeed.test.ts
+++ b/apps/web/hooks/useSessionFeed.test.ts
@@ -1,0 +1,66 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import { render } from '@testing-library/react';
+import { JSDOM } from 'jsdom';
+
+// Ensure React is available globally
+(globalThis as any).React = React;
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const feedState: { items: any[] } = { items: [] };
+const loadMore = vi.fn();
+vi.mock('./useFeed', () => ({
+  default: () => ({ items: feedState.items, loadMore, loading: false }),
+}));
+
+import useSessionFeed from './useSessionFeed';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://example.com' });
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).navigator = dom.window.navigator;
+
+function TestComponent({ maxSize = 50 }: { maxSize?: number }) {
+  const { queue, markSeen } = useSessionFeed('all', [], { threshold: 0, maxSize });
+  (TestComponent as any).queue = queue;
+  (TestComponent as any).markSeen = markSeen;
+  return React.createElement('div', { 'data-items': queue.map((i) => i.eventId).join(',') });
+}
+
+describe('useSessionFeed', () => {
+  beforeEach(() => {
+    feedState.items = [];
+    loadMore.mockClear();
+    window.localStorage.clear();
+  });
+
+  it('persists cursor to localStorage when items are marked seen', async () => {
+    feedState.items = [
+      { eventId: 'a', pubkey: 'p', author: '', caption: '', videoUrl: '', lightningAddress: '', zapTotal: 0 },
+    ];
+    render(React.createElement(TestComponent, {}));
+    await act(async () => {
+      (TestComponent as any).markSeen(1);
+    });
+    expect(window.localStorage.getItem('sessionCursor')).toBe('a');
+  });
+
+  it('trims queue to maxSize after appending', async () => {
+    feedState.items = Array.from({ length: 5 }, (_, i) => ({
+      eventId: String(i + 1),
+      pubkey: 'p' + i,
+      author: '',
+      caption: '',
+      videoUrl: '',
+      lightningAddress: '',
+      zapTotal: 0,
+    }));
+    const { container } = render(React.createElement(TestComponent, { maxSize: 3 }));
+    await act(async () => {});
+    const rendered = container.querySelector('div')?.getAttribute('data-items');
+    expect(rendered).toBe('3,4,5');
+  });
+});
+

--- a/apps/web/hooks/useSessionFeed.ts
+++ b/apps/web/hooks/useSessionFeed.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { VideoCardProps } from '@/components/VideoCard';
+import useFeed, { type FeedMode } from './useFeed';
+
+interface Options {
+  threshold?: number;
+  maxSize?: number;
+}
+
+export default function useSessionFeed(
+  mode: FeedMode,
+  authors: string[] = [],
+  { threshold = 5, maxSize = 50 }: Options = {},
+) {
+  const [sessionCursor, setSessionCursor] = useState<string | undefined>(() => {
+    if (typeof window === 'undefined') return undefined;
+    return window.localStorage.getItem('sessionCursor') || undefined;
+  });
+  const [maxSizeState] = useState(maxSize);
+  const [queue, setQueue] = useState<VideoCardProps[]>([]);
+
+  const feed = useFeed(mode, authors, {}, typeof window !== 'undefined');
+
+  const fetchMore = useCallback(() => {
+    feed.loadMore();
+  }, [feed]);
+
+  const processedRef = useRef(0);
+  useEffect(() => {
+    const newItems = feed.items.slice(processedRef.current);
+    if (newItems.length) {
+      processedRef.current = feed.items.length;
+      setQueue((q) => {
+        const appended = [...q, ...newItems];
+        return appended.length > maxSizeState
+          ? appended.slice(appended.length - maxSizeState)
+          : appended;
+      });
+    }
+  }, [feed.items, maxSizeState]);
+
+  useEffect(() => {
+    if (queue.length < threshold && !feed.loading) {
+      fetchMore();
+    }
+  }, [queue.length, threshold, fetchMore, feed.loading]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (sessionCursor) {
+      window.localStorage.setItem('sessionCursor', sessionCursor);
+    } else {
+      window.localStorage.removeItem('sessionCursor');
+    }
+  }, [sessionCursor]);
+
+  const markSeen = useCallback((count = 1) => {
+    setQueue((q) => {
+      const seen = q.slice(0, count);
+      if (seen.length) {
+        setSessionCursor(seen[seen.length - 1].eventId);
+      }
+      return q.slice(count);
+    });
+  }, []);
+
+  return { queue, fetchMore, markSeen };
+}
+


### PR DESCRIPTION
## Summary
- add `useSessionFeed` hook to manage feed queue with session cursor persistence
- use session feed in feed page and components
- test session feed cursor storage and queue trimming

## Testing
- `pnpm test apps/web/hooks/useSessionFeed.test.ts apps/web/app/feed/page.test.tsx apps/web/components/Feed.selection.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689932482a34833197417a1b85a27670