### PR TITLE
feat: add avatar placeholder route

### DIFF
--- a/apps/web/app/api/avatar/[pubkey]/route.ts
+++ b/apps/web/app/api/avatar/[pubkey]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createHash } from 'crypto';
+
+function generateIdenticon(pubkey: string): string {
+  const hash = createHash('sha256').update(pubkey).digest('hex');
+  const color = `#${hash.slice(0, 6)}`;
+  const size = 5;
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 ${size} ${size}" shape-rendering="crispEdges">`;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < Math.ceil(size / 2); x++) {
+      const i = x + y * Math.ceil(size / 2);
+      const fill = parseInt(hash[i], 16) % 2 === 0;
+      if (fill) {
+        svg += `<rect x="${x}" y="${y}" width="1" height="1" fill="${color}"/>`;
+        if (x !== size - 1 - x) {
+          svg += `<rect x="${size - 1 - x}" y="${y}" width="1" height="1" fill="${color}"/>`;
+        }
+      }
+    }
+  }
+  svg += '</svg>';
+  return svg;
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { pubkey: string } },
+) {
+  const svg = generateIdenticon(params.pubkey);
+  return new NextResponse(svg, {
+    headers: {
+      'Content-Type': 'image/svg+xml',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
+}
+
+export async function HEAD(
+  req: NextRequest,
+  ctx: { params: { pubkey: string } },
+) {
+  const res = await GET(req, ctx);
+  return new NextResponse(null, { status: res.status, headers: res.headers });
+}

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/hooks/useAuth';
 import useFollowing from '@/hooks/useFollowing';
 import useFollowerCount from '@/hooks/useFollowerCount';
 import { useProfile } from '@/hooks/useProfile';
+import { useAvatar } from '@/hooks/useAvatar';
 import { useFeedSelection } from '@/store/feedSelection';
 import { CurrentVideoProvider } from '@/hooks/useCurrentVideo';
 import { useSearchParams } from 'next/navigation';
@@ -37,16 +38,18 @@ export default function FeedPage() {
     mode,
     feedMode === 'following' && !filterAuthor ? following : [],
   );
+  const mePubkey = auth.status === 'ready' ? auth.pubkey : 'me';
+  const meAvatar = useAvatar(meProfile?.picture ? undefined : mePubkey);
   const me =
     auth.status === 'ready'
       ? {
-          avatar: meProfile?.picture || `/api/avatar/${auth.pubkey}`,
+          avatar: meProfile?.picture || meAvatar,
           name: meProfile?.name || auth.pubkey.slice(0, 8),
           username: meProfile?.name || auth.pubkey.slice(0, 8),
           stats: { followers: myFollowerCount, following: following.length },
         }
       : {
-          avatar: '/api/avatar/me',
+          avatar: meAvatar,
           name: 'You',
           username: 'me',
           stats: { followers: 0, following: 0 },

--- a/apps/web/components/feed/RightPanel.tsx
+++ b/apps/web/components/feed/RightPanel.tsx
@@ -8,6 +8,7 @@ import { useFeedSelection } from '@/store/feedSelection';
 import { useLayout } from '@/context/LayoutContext';
 import { useProfile } from '@/hooks/useProfile';
 import useFollowerCount from '@/hooks/useFollowerCount';
+import { useAvatar } from '@/hooks/useAvatar';
 import {
   Box,
   Stack,
@@ -35,10 +36,15 @@ export default function RightPanel({
   const shouldLoad = isDesktop || isOpen;
   const profile = useProfile(shouldLoad ? selectedVideoAuthor : undefined);
   const followers = useFollowerCount(shouldLoad ? selectedVideoAuthor : undefined);
+  const avatarUrl = useAvatar(
+    shouldLoad && selectedVideoAuthor && !profile?.picture
+      ? selectedVideoAuthor
+      : undefined,
+  );
   const author =
     selectedVideoAuthor && profile
       ? {
-          avatar: profile.picture || `/api/avatar/${selectedVideoAuthor}`,
+          avatar: profile.picture || avatarUrl,
           name: profile.name || selectedVideoAuthor.slice(0, 8),
           username: profile.name || selectedVideoAuthor.slice(0, 8),
           pubkey: selectedVideoAuthor,
@@ -59,7 +65,6 @@ export default function RightPanel({
               width={48}
               height={48}
               style={{ borderRadius: '50%', objectFit: 'cover' }}
-              onError={(e) => (e.currentTarget.src = '/avatar.svg')}
               crossOrigin="anonymous"
               unoptimized
             />

--- a/apps/web/hooks/useAvatar.ts
+++ b/apps/web/hooks/useAvatar.ts
@@ -1,0 +1,33 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+const cache = new Map<string, string>();
+
+export function useAvatar(pubkey?: string) {
+  const [url, setUrl] = useState('/avatar.svg');
+
+  useEffect(() => {
+    if (!pubkey) return;
+    if (cache.has(pubkey)) {
+      setUrl(cache.get(pubkey)!);
+      return;
+    }
+    const apiUrl = `/api/avatar/${pubkey}`;
+    let cancelled = false;
+    fetch(apiUrl)
+      .then((res) => {
+        const finalUrl = res.ok ? apiUrl : '/avatar.svg';
+        cache.set(pubkey, finalUrl);
+        if (!cancelled) setUrl(finalUrl);
+      })
+      .catch(() => {
+        cache.set(pubkey, '/avatar.svg');
+        if (!cancelled) setUrl('/avatar.svg');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pubkey]);
+
+  return url;
+}


### PR DESCRIPTION
## Summary
- add `/api/avatar/[pubkey]` route generating deterministic SVG identicon
- add `useAvatar` hook to cache avatar lookups and fall back to `/avatar.svg` only on error
- update feed and right panel components to use cached avatar URLs

## Testing
- `pnpm test` *(fails: The current testing environment is not configured to support act(...), see logs)*

------
https://chatgpt.com/codex/tasks/task_e_689935ce89448331a6f31b57dccaf33a