### PR TITLE
feat(web): track video watch via telemetry

### DIFF
--- a/apps/web/components/VideoCard.playback.test.tsx
+++ b/apps/web/components/VideoCard.playback.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@/store/feedSelection', () => ({
 }));
 vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({ picture: '', name: 'author' }) }));
 vi.mock('@/hooks/useProfiles', () => ({ prefetchProfile: () => Promise.resolve() }));
+vi.mock('@/agents/telemetry', () => ({ telemetry: { track: vi.fn() } }));
 
 import VideoCard from './VideoCard';
 

--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -88,6 +88,24 @@ describe('VideoCard', () => {
     expect(() => unmount()).not.toThrow();
   });
 
+  it('tracks a watch event on mount', async () => {
+    const props = {
+      videoUrl: 'video.mp4',
+      author: 'author',
+      caption: 'caption',
+      eventId: 'event',
+      pubkey: 'pk',
+      zap: <div />,
+    };
+    render(<VideoCard {...props} />);
+    await waitFor(() => {
+      expect(telemetryTrack).toHaveBeenCalledWith('video.watch', {
+        eventId: 'event',
+        pubkey: 'pk',
+      });
+    });
+  });
+
   it('fills the container and covers it without blank space', () => {
     const props = {
       videoUrl: 'video.mp4',

--- a/apps/web/components/VideoCard.tsx
+++ b/apps/web/components/VideoCard.tsx
@@ -122,6 +122,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
     if (inView) {
       setCurrent({ eventId, pubkey, caption, posterUrl });
       setSelectedVideo(eventId, pubkey);
+      telemetry.track('video.watch', { eventId, pubkey });
     }
   }, [inView, setCurrent, setSelectedVideo, eventId, pubkey, caption, posterUrl]);
 


### PR DESCRIPTION
## Summary
- track video watch events via telemetry
- mock telemetry in VideoCard playback tests and add watch event test

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx apps/web/components/VideoCard.playback.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6899367ebf70833193b0d2c139d5883e