### PR TITLE
fix: await params in avatar API route

### DIFF
--- a/apps/web/app/api/avatar/[pubkey]/route.ts
+++ b/apps/web/app/api/avatar/[pubkey]/route.ts
@@ -24,9 +24,10 @@ function generateIdenticon(pubkey: string): string {
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { pubkey: string } },
+  { params }: { params: Promise<{ pubkey: string }> },
 ) {
-  const svg = generateIdenticon(params.pubkey);
+  const { pubkey } = await params;
+  const svg = generateIdenticon(pubkey);
   return new NextResponse(svg, {
     headers: {
       'Content-Type': 'image/svg+xml',
@@ -37,7 +38,7 @@ export async function GET(
 
 export async function HEAD(
   req: NextRequest,
-  ctx: { params: { pubkey: string } },
+  ctx: { params: Promise<{ pubkey: string }> },
 ) {
   const res = await GET(req, ctx);
   return new NextResponse(null, { status: res.status, headers: res.headers });


### PR DESCRIPTION
## Summary
- await dynamic `params` in avatar identicon endpoint

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899386df1b083318a8631521c8e5bd0