### PR TITLE
feat(web): prevent feed overscroll refresh

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -7,13 +7,10 @@ export const estimateFeedItemSize = () => {
   const nav =
     typeof window === 'undefined'
       ? 0
-      :
-          parseInt(
-            getComputedStyle(document.documentElement).getPropertyValue(
-              '--bottom-nav-height',
-            ) || '0',
-            10,
-          ) || 0;
+      : parseInt(
+          getComputedStyle(document.documentElement).getPropertyValue('--bottom-nav-height') || '0',
+          10,
+        ) || 0;
   return typeof window === 'undefined' ? 0 : window.innerHeight - nav;
 };
 
@@ -34,12 +31,7 @@ interface FeedProps {
   markSeen?: (count: number) => void;
 }
 
-export const Feed: React.FC<FeedProps> = ({
-  items,
-  loading,
-  loadMore,
-  markSeen,
-}) => {
+export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore, markSeen }) => {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const setSelectedVideo = useFeedSelection((s) => s.setSelectedVideo);
   const selectedVideoId = useFeedSelection((s) => s.selectedVideoId);
@@ -127,7 +119,7 @@ export const Feed: React.FC<FeedProps> = ({
       <Virtuoso
         ref={virtuosoRef}
         totalCount={items.length}
-        className="h-screen w-full overflow-auto snap-y snap-mandatory scrollbar-none [height:calc(100dvh-var(--bottom-nav-height,0))]"
+        className="feed-container h-screen w-full overflow-auto snap-y snap-mandatory scrollbar-none [height:calc(100dvh-var(--bottom-nav-height,0))]"
         endReached={loadMore}
         rangeChanged={handleRangeChanged}
         itemContent={(index) => {
@@ -163,4 +155,3 @@ export const Feed: React.FC<FeedProps> = ({
 };
 
 export default Feed;
-

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -116,6 +116,7 @@ body {
     @apply h-6 w-6 md:h-8 md:w-8;
   }
   .feed-container {
+    overscroll-behavior: none;
     @apply lg:mt-4;
   }
   .username {


### PR DESCRIPTION
## Summary
- prevent pull-to-refresh by setting `overscroll-behavior: none` on the feed container
- ensure `Feed` component uses the `.feed-container` class to apply the overscroll rule

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ReferenceError: Cannot access 'subscribeMany' before initialization, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68993bdf6dac833191fc39de32bbaaf6