### PR TITLE
fix: allow vertical swipes in feed

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -117,6 +117,8 @@ body {
   }
   .feed-container {
     overscroll-behavior: none;
+    touch-action: pan-y;
+    height: 100dvh;
     @apply lg:mt-4;
   }
   .username {


### PR DESCRIPTION
## Summary
- allow vertical swipes by setting `touch-action: pan-y`
- ensure feed container fills the dynamic viewport height

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 2 files, 4 tests)*

------
https://chatgpt.com/codex/tasks/task_e_689948a681b08331b99a2e03649ac1ab