### PR TITLE
Lock body scroll while feed is active

### DIFF
--- a/apps/web/components/Feed.tsx
+++ b/apps/web/components/Feed.tsx
@@ -48,6 +48,14 @@ export const Feed: React.FC<FeedProps> = ({ items, loading, loadMore, markSeen }
   const hasWallet = !!viewerProfile?.wallets?.length;
   useLayout();
 
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+
   const didScrollToSelection = useRef(false);
   useEffect(() => {
     if (didScrollToSelection.current) return;

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -83,6 +83,10 @@ body {
   min-height: 100vh;
 }
 
+body.no-scroll {
+  overflow: hidden;
+}
+
 @layer utilities {
   .text-primary {
     color: hsl(var(--text-primary));


### PR DESCRIPTION
## Summary
- hide body overflow when Feed mounts and restore on unmount
- add global utility `.no-scroll` for body overflow management

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68994ce23abc833196ed99bc7b8634f6