### PR TITLE
docs: explain feed resume queue and freshness limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Override the default Nostr relays with the `NEXT_PUBLIC_RELAYS` environment vari
 
 Control how many events are requested per page by setting `NEXT_PUBLIC_FEED_LIMIT` (defaults to `20`).
 
+## Feed resume & session queue
+
+When `enableFeedResume` is enabled in **Settings**, the feed buffers items in a session‑scoped queue and stores a cursor for the last seen video. The cursor keeps the event id and timestamp in `localStorage` so a refresh scrolls back to the same position. A one‑week freshness rule drops entries older than seven days and drives `since` timestamps on feed requests. If the stored cursor points to a pruned or stale video, the feed starts from the top instead of resuming.
+
+### Developer testing
+
+1. Enable **Feed Resume** in the app settings.
+2. Scroll a few videos down the feed.
+3. Refresh the page – the feed should restore to the same video if the cursor is still within the one‑week window.
+4. Clear `localStorage` or disable the flag to reset the cursor.
+5. If the feed fails to resume, older videos may have been pruned; load newer items and try again.
+
 ## PWA features
 
 The web client ships as a Progressive Web App:
@@ -49,7 +61,7 @@ Open the app and choose **Install** (or **Add to Home Screen**) to install it.
 Static assets in `apps/web/public` are served with long-lived caching headers. When deploying:
 
 - **Vercel** respects `Cache-Control` by default, so no extra setup is required.
-- **Cloudflare** should be set to *Respect Existing Headers* or *Origin Cache Control* so the `Cache-Control: public, max-age=31536000, immutable` header is honored.
+- **Cloudflare** should be set to _Respect Existing Headers_ or _Origin Cache Control_ so the `Cache-Control: public, max-age=31536000, immutable` header is honored.
 
 Verify locally by running `pnpm --filter @paiduan/web dev` and inspecting network responses in your browser's developer tools to confirm the `Cache-Control` value.
 

--- a/project_spec.md
+++ b/project_spec.md
@@ -13,7 +13,7 @@ Replace “Enter Feed” with standard Nostr login flow, support new/imported ke
 | 3   | Key generation       | Use `nostr-tools` `generateSecretKey()` (not deprecated `generatePrivateKey()`), derive pubkey; store keys.                                                   |
 | 4   | Remote signer        | Implement NIP-46 connect flow; persist pubkey, no privkey stored.                                                                                             |
 | 5   | Post-auth onboarding | After successful import/generate/login, route to `/onboarding/profile`.                                                                                       |
-| 6   | Enable notifications | Prompt user to grant browser notification permission and register push subscription.            |
+| 6   | Enable notifications | Prompt user to grant browser notification permission and register push subscription.                                                                          |
 | 7   | Profile onboarding   | If imported key has existing kind 0 profile, prefill name, picture, about; else show empty form.                                                              |
 | 8   | Profile UI           | Avatar upload (browser file → Blob URL or upload to media API), name, bio; publish kind 0 metadata to relays.                                                 |
 | 9   | Profile page         | `/p/[pubkey]` shows banner, avatar, name, bio, zaps, follow; edit button if own profile.                                                                      |
@@ -41,18 +41,19 @@ Modernise Creator Wizard UI, fix tool loading/trim bugs, and ensure WebM (9:16) 
 
 ### Tasks
 
-| #   | Area               | Work required                                                                                                                                                                      |
-| --- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 12  | CreatorWizard UI   | Replace current 3-step flow with wizard that first asks “What do you want to do?” — options: **Upload existing** or **Import from URL**.                           |
-| 13  | Dynamic components | Load relevant step component depending on option (e.g., `UploadStep.tsx`).                                                                                |
-| 14  | Upload             | Existing file input flow; enforce ≤3 minutes; immediately transcode if not WebM.                                                                                |
-| 15  | Transcoding        | Use the WebCodecs API with a polyfill; default to WebM VP9, 9:16 crop. |
-| 16  | Trim tool          | Ensure trim UI loads only after video metadata loaded; fix “pressing Next throws trim error” by validating clip bounds.                                                            |
-| 17  | Poster capture     | Frame capture via `<canvas>`; store as JPEG/WebP; attach to upload payload.                                                                                |
-| 18  | Upload flow        | POST video + poster to `nostr.media/api/upload`; show progress; capture `video`, `poster` & `manifest` URLs and publish kind‑30023 event with `v`, `image`, `vman`, optional `zap` and one `t` tag per topic.                                                            |
-| 19  | Error handling     | Toasts for FFmpeg load failure, file type issues, upload errors.                                                                                |
-| 20  | Responsive design  | Wizard lets steps manage their own widths; metadata step displays preview and fields side-by-side on large (`lg`) screens. |
-| 21  | Event publishing   | CreatorWizard publishes a signed kind-30023 event containing video URL, poster, manifest, zap address, and topic tags. |
+| #   | Area               | Work required                                                                                                                                                                                                 |
+| --- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 12  | CreatorWizard UI   | Replace current 3-step flow with wizard that first asks “What do you want to do?” — options: **Upload existing** or **Import from URL**.                                                                      |
+| 13  | Dynamic components | Load relevant step component depending on option (e.g., `UploadStep.tsx`).                                                                                                                                    |
+| 14  | Upload             | Existing file input flow; enforce ≤3 minutes; immediately transcode if not WebM.                                                                                                                              |
+| 15  | Transcoding        | Use the WebCodecs API with a polyfill; default to WebM VP9, 9:16 crop.                                                                                                                                        |
+| 16  | Trim tool          | Ensure trim UI loads only after video metadata loaded; fix “pressing Next throws trim error” by validating clip bounds.                                                                                       |
+| 17  | Poster capture     | Frame capture via `<canvas>`; store as JPEG/WebP; attach to upload payload.                                                                                                                                   |
+| 18  | Upload flow        | POST video + poster to `nostr.media/api/upload`; show progress; capture `video`, `poster` & `manifest` URLs and publish kind‑30023 event with `v`, `image`, `vman`, optional `zap` and one `t` tag per topic. |
+| 19  | Error handling     | Toasts for FFmpeg load failure, file type issues, upload errors.                                                                                                                                              |
+| 20  | Responsive design  | Wizard lets steps manage their own widths; metadata step displays preview and fields side-by-side on large (`lg`) screens.                                                                                    |
+| 21  | Event publishing   | CreatorWizard publishes a signed kind-30023 event containing video URL, poster, manifest, zap address, and topic tags.                                                                                        |
+
 ### Acceptance Criteria
 
 - CreatorWizard first screen is option chooser.
@@ -70,6 +71,18 @@ Modernise Creator Wizard UI, fix tool loading/trim bugs, and ensure WebM (9:16) 
 - Zap / comment buttons disable while offline.
 - Clear cached videos via **Settings → Storage**.
 
+## Feed session queue & resume
+
+- The feed agent maintains a session-scoped queue and persists `lastIndex`, `lastCursor` and `lastCursorTime` so users return to the same position after a refresh.
+- Items older than seven days are pruned and `since` timestamps in subsequent requests keep the feed fresh.
+- Resuming relies on the stored cursor's timestamp; if the referenced video has been pruned or is older than a week, the feed falls back to the top.
+
+### Developer testing
+
+- Toggle `enableFeedResume` in Settings.
+- Scroll a few videos, refresh the page and confirm the same item is selected.
+- Clear `localStorage` or disable the flag to reset; stale cursors beyond a week will not restore.
+
 ## UI/UX Improvement Tasks for Codex
 
 - **Typography:** Adopt a consistent font stack with clearly defined heading, body, and caption sizes.
@@ -78,4 +91,3 @@ Modernise Creator Wizard UI, fix tool loading/trim bugs, and ensure WebM (9:16) 
 - **Component Styling:** Buttons, inputs and cards share consistent radius, shadows and hover/active states.
 - **Comments:** Comments display avatar, name, timestamp, and support nested replies with clear indentation.
 - **Profile Area:** Profile pages show banner, avatar, bio and stats, with edit controls for the owner.
-


### PR DESCRIPTION
## Summary
- document feed resume queue and cursor storage rules
- highlight one-week freshness window and failure cases when cursor is stale
- add developer notes for testing feed resume

## Testing
- `pnpm test` *(fails: apps/web/hooks/useFollowerCount.test.tsx > resets count and closes previous subscription on pubkey change)*

------
https://chatgpt.com/codex/tasks/task_e_68994ce7035c8331be41b60d753584f0