### PR TITLE
fix: guard feed selection hydration

### DIFF
--- a/apps/web/hooks/useSessionFeed.ts
+++ b/apps/web/hooks/useSessionFeed.ts
@@ -23,10 +23,14 @@ export default function useSessionFeed(
   const [queue, setQueue] = useState<VideoCardProps[]>([]);
   const [shouldFetch, setShouldFetch] = useState(false);
 
-  const [hydrated, setHydrated] = useState(useFeedSelection.persist.hasHydrated());
+  const [hydrated, setHydrated] = useState(
+    useFeedSelection.persist?.hasHydrated?.() ?? true,
+  );
   useEffect(() => {
-    const unsub = useFeedSelection.persist.onFinishHydration(() => setHydrated(true));
-    return () => unsub();
+    const unsub = useFeedSelection.persist?.onFinishHydration?.(() => setHydrated(true));
+    return () => {
+      unsub?.();
+    };
   }, []);
   const lastCursorTime = useFeedSelection((s) => s.lastCursorTime);
 


### PR DESCRIPTION
## Summary
- avoid calling `persist` APIs when feed selection store is not persisted

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68994d886ddc833192905cb271734920