### PR TITLE
fix infinite render loop in session feed hook

### DIFF
--- a/apps/web/hooks/useSessionFeed.ts
+++ b/apps/web/hooks/useSessionFeed.ts
@@ -55,12 +55,14 @@ export default function useSessionFeed(
     }
   }, [feed.items, maxSizeState]);
 
+  const { loadMore, loading } = feed;
+
   useEffect(() => {
-    if ((queue.length < threshold || shouldFetch) && !feed.loading) {
-      feed.loadMore();
+    if ((queue.length < threshold || shouldFetch) && !loading) {
+      loadMore();
       setShouldFetch(false);
     }
-  }, [queue.length, threshold, shouldFetch, feed]);
+  }, [queue.length, threshold, shouldFetch, loadMore, loading]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;


### PR DESCRIPTION
## Summary
- prevent redundant `loadMore` calls in `useSessionFeed` by using stable dependencies

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68994e11ac08833195fabb8136a2a755