### PR TITLE
Disable pull-to-refresh and contain scroll

### DIFF
--- a/apps/web/components/CommentDrawer.tsx
+++ b/apps/web/components/CommentDrawer.tsx
@@ -102,7 +102,7 @@ function CommentDrawerContent({ videoId, onClose, onCountChange }: CommentDrawer
           <X />
         </button>
       </div>
-      <div className="h-[calc(50vh-88px)] overflow-y-auto p-4 space-y-4">
+      <div className="h-[calc(50vh-88px)] overflow-y-auto overscroll-contain p-4 space-y-4">
         {visibleTop.map((c) => (
           <div key={c.id}>
             <div className="flex items-start space-x-2">

--- a/apps/web/components/NotificationDrawer.tsx
+++ b/apps/web/components/NotificationDrawer.tsx
@@ -24,7 +24,7 @@ const NotificationDrawer: React.FC = () => {
       role="dialog"
       aria-modal="true"
       aria-label="Notifications"
-      className={`fixed top-12 left-0 right-0 z-30 max-h-1/2 transform overflow-y-auto bg-background-primary text-primary transition-transform duration-300 ${
+      className={`fixed top-12 left-0 right-0 z-30 max-h-1/2 transform overflow-y-auto overscroll-contain bg-background-primary text-primary transition-transform duration-300 ${
         open ? 'translate-y-0' : '-translate-y-full'
       }`}
     >

--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -94,7 +94,7 @@ const SearchBar: React.FC<{ showActions?: boolean }> = ({ showActions = true }) 
         )}
       </div>
       <div
-        className={`fixed inset-x-0 bottom-0 z-20 max-h-1/2 overflow-y-auto bg-background-primary text-primary transition-transform duration-300 lg:absolute lg:inset-x-auto lg:right-0 ${
+        className={`fixed inset-x-0 bottom-0 z-20 max-h-1/2 overflow-y-auto overscroll-contain bg-background-primary text-primary transition-transform duration-300 lg:absolute lg:inset-x-auto lg:right-0 ${
           showDrawer ? 'translate-y-0' : 'translate-y-full'
         }`}
       >

--- a/apps/web/components/ThreadedComments.tsx
+++ b/apps/web/components/ThreadedComments.tsx
@@ -49,7 +49,7 @@ export default function ThreadedComments({ noteId }: { noteId?: string }) {
       ) : (
         <Virtuoso
           data={events}
-          className="max-h-96 overflow-auto"
+          className="max-h-96 overflow-auto overscroll-contain"
           components={{ List, Item }}
           itemContent={(index, event) => <>{event.content}</>}
         />

--- a/apps/web/components/VideoFeed.tsx
+++ b/apps/web/components/VideoFeed.tsx
@@ -18,7 +18,7 @@ export default function VideoFeed({ onAuthorClick }: { onAuthorClick: (pubkey: s
   return (
     <Virtuoso
       data={videos}
-      className="relative h-screen w-full overflow-auto [height:calc(100dvh-var(--bottom-nav-height,0))]"
+      className="relative h-screen w-full overflow-auto overscroll-contain [height:calc(100dvh-var(--bottom-nav-height,0))]"
       itemContent={() => (
         <PlaceholderVideo className="h-full w-full" message="Loading video…" />
       )}

--- a/apps/web/components/VideoInfoPane.tsx
+++ b/apps/web/components/VideoInfoPane.tsx
@@ -38,7 +38,7 @@ export default function VideoInfoPane() {
   const isFollow = following.includes(current.pubkey);
 
   return (
-    <aside className="hidden lg:block lg:w-64 lg:fixed lg:right-0 lg:inset-y-0 lg:pr-4 lg:pt-6 overflow-y-auto space-y-6 text-white">
+    <aside className="hidden lg:block lg:w-64 lg:fixed lg:right-0 lg:inset-y-0 lg:pr-4 lg:pt-6 overflow-y-auto overscroll-contain space-y-6 text-white">
       <div className="flex items-center space-x-3">
         <Image
           src={meta?.picture || '/avatar.svg'}

--- a/apps/web/components/settings/KeysCard.tsx
+++ b/apps/web/components/settings/KeysCard.tsx
@@ -57,7 +57,7 @@ function Field({ label, value }: { label: string; value: string }) {
   return (
     <div>
       <div className="mb-1 text-sm text-muted">{label}</div>
-      <pre className="bg-black/20 rounded-lg p-3 text-xs overflow-auto">{value}</pre>
+      <pre className="bg-black/20 rounded-lg p-3 text-xs overflow-auto overscroll-contain">{value}</pre>
     </div>
   );
 }

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -75,6 +75,7 @@
 html,
 body {
   height: 100%;
+  overscroll-behavior-y: none;
 }
 
 body {


### PR DESCRIPTION
## Summary
- prevent global pull-to-refresh by disabling vertical overscroll on `html, body`
- contain overscroll on drawers, feeds and other scrollable components

## Testing
- `pnpm test` *(fails: useFollowerCount resets count)*
- `pnpm --filter @paiduan/web exec tsc --noEmit app/get-started/page.tsx` *(missing Next.js type modules)*

------
https://chatgpt.com/codex/tasks/task_e_68994fc0c03083319828a0644573b919