### PR TITLE
Prevent AppShell main grid from scrolling

### DIFF
--- a/apps/web/components/layout/AppShell.tsx
+++ b/apps/web/components/layout/AppShell.tsx
@@ -90,7 +90,7 @@ export default function AppShell({
           as="main"
           h="100vh"
           style={{ height: 'calc(100dvh - var(--bottom-nav-height, 0))' }}
-          overflowY="auto"
+          overflow="hidden"
         >
           <Box maxW="2xl" mx="auto" h="full" px={4}>
             {center}


### PR DESCRIPTION
## Summary
- Ensure AppShell's main column doesn't scroll so Virtuoso controls feed scrolling

## Testing
- `pnpm test` *(fails: Cannot set property navigator of #<Object> which has only a getter in useFollowerCount.test.tsx and useFollowing.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68995f6935ec8331911b5f733b67cd53