### PR TITLE
Improve tablet feed layout and orientation handling

### DIFF
--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -66,19 +66,16 @@ export default function FeedPage() {
       <AppShell
         left={<MainNav me={me} />}
         center={
-          <div className="feed-container h-full">
-            {/* tabs bar you already have can stay on top */}
-            {isClient ? (
-              <Feed
-                items={videos}
-                loadMore={fetchMore}
-                markSeen={markSeen}
-                loading={loading}
-              />
-            ) : (
-              <Feed items={[]} loadMore={() => {}} markSeen={() => {}} loading />
-            )}
-          </div>
+          isClient ? (
+            <Feed
+              items={videos}
+              loadMore={fetchMore}
+              markSeen={markSeen}
+              loading={loading}
+            />
+          ) : (
+            <Feed items={[]} loadMore={() => {}} markSeen={() => {}} loading />
+          )
         }
         right={<RightPanel onFilterByAuthor={filterByAuthor} />}
       />

--- a/apps/web/components/AutoSizer.tsx
+++ b/apps/web/components/AutoSizer.tsx
@@ -36,10 +36,18 @@ export default function AutoSizer({ className, children }: AutoSizerProps) {
     if (typeof ResizeObserver !== 'undefined') {
       const observer = new ResizeObserver(measure);
       observer.observe(el);
-      return () => observer.disconnect();
+      window.addEventListener('orientationchange', measure);
+      return () => {
+        observer.disconnect();
+        window.removeEventListener('orientationchange', measure);
+      };
     } else {
       window.addEventListener('resize', measure);
-      return () => window.removeEventListener('resize', measure);
+      window.addEventListener('orientationchange', measure);
+      return () => {
+        window.removeEventListener('resize', measure);
+        window.removeEventListener('orientationchange', measure);
+      };
     }
   }, []);
 

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -139,8 +139,9 @@ body.no-scroll {
   }
   .feed-container {
     overscroll-behavior: none;
-    touch-action: pan-y;
-    @apply h-screen h-safe-screen lg:mt-4;
+    touch-action: auto;
+    height: 100dvh;
+    @apply h-safe-screen lg:mt-4;
   }
   .username {
     @apply text-lg font-semibold;


### PR DESCRIPTION
## Summary
- Remove extra feed wrapper so Virtuoso owns feed layout
- Use dynamic viewport height and allow native scrolling
- Recompute AutoSizer dimensions on orientation changes

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68996150b1848331aa16d0466b95bae9