### PR TITLE
fix: avoid infinite scroll re-render

### DIFF
--- a/apps/web/components/VideoFeed.tsx
+++ b/apps/web/components/VideoFeed.tsx
@@ -20,12 +20,12 @@ export default function VideoFeed({
 
     const handleScroll = () => {
       const next = Math.round(scroller.scrollTop / scroller.clientHeight);
-      if (next !== index) setIndex(next);
+      setIndex((prev) => (next !== prev ? next : prev));
     };
 
     scroller.addEventListener("scroll", handleScroll, { passive: true });
     return () => scroller.removeEventListener("scroll", handleScroll);
-  }, [index]);
+  }, []);
 
   useEffect(() => {
     const scroller = scrollerRef.current;


### PR DESCRIPTION
## Summary
- prevent VideoFeed scroll handler from re-attaching on every index update

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689963312b688331a31538fa9b3dc4f0