### PR TITLE
fix: cache feed route with network-first strategy

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -81,6 +81,19 @@ workbox.routing.registerRoute(
 );
 
 workbox.routing.registerRoute(
+  ({ url }) => url.pathname.endsWith('/feed'),
+  new workbox.strategies.NetworkFirst({
+    cacheName: `feed-cache-${CACHE_VERSION}`,
+    plugins: [
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 10,
+        maxAgeSeconds: 5 * 60,
+      }),
+    ],
+  }),
+);
+
+workbox.routing.registerRoute(
   ({ url }) => /\.(?:mp4|webm)$/.test(url.pathname),
   new workbox.strategies.CacheFirst({
     cacheName: `video-cache-${CACHE_VERSION}`,


### PR DESCRIPTION
## Summary
- cache /feed with network-first strategy for offline support

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899634863fc833184aaf607393c6576