### PR TITLE
fix: register precache events at startup

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -14,17 +14,18 @@ workbox.core.setCacheNameDetails({
   suffix: CACHE_VERSION,
 });
 
+const manifest = (self.__WB_MANIFEST || []).filter(
+  (entry) => !/app-build-manifest\.json$/.test(entry.url),
+);
+try {
+  workbox.precaching.precacheAndRoute(manifest);
+  workbox.precaching.cleanupOutdatedCaches();
+} catch (err) {
+  console.warn('Precache manifest missing entries', err);
+}
+
 self.addEventListener('install', () => {
   self.skipWaiting();
-  const manifest = (self.__WB_MANIFEST || []).filter(
-    (entry) => !/app-build-manifest\.json$/.test(entry.url),
-  );
-  try {
-    workbox.precaching.precacheAndRoute(manifest);
-    workbox.precaching.cleanupOutdatedCaches();
-  } catch (err) {
-    console.warn('Precache manifest missing entries', err);
-  }
 });
 
 self.addEventListener('activate', (event) => {


### PR DESCRIPTION
## Summary
- ensure workbox precache and cleanup hooks are registered during service worker evaluation

## Testing
- `pnpm test` *(fails: vitest not found, local package.json exists but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68997faa00d883319aa4ba215672962e