### PR TITLE
fix: wrap storybook stories with layout provider

### DIFF
--- a/apps/web/.storybook/preview.ts
+++ b/apps/web/.storybook/preview.ts
@@ -1,4 +1,6 @@
+import React from 'react';
 import type { Preview } from '@storybook/react';
+import { LayoutProvider } from '@/hooks/useLayout';
 
 const preview: Preview = {
   parameters: {
@@ -10,6 +12,13 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <LayoutProvider>
+        <Story />
+      </LayoutProvider>
+    ),
+  ],
 };
 
 export default preview;


### PR DESCRIPTION
## Summary
- wrap Storybook stories in LayoutProvider to satisfy useLayout

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68999cf77ce0833189797a6cde3cd56d