### PR TITLE
Handle missing LayoutProvider gracefully

### DIFF
--- a/apps/web/context/LayoutContext.tsx
+++ b/apps/web/context/LayoutContext.tsx
@@ -60,7 +60,10 @@ export function LayoutProvider({ children }: { children: ReactNode }) {
 export function useLayout(): LayoutType {
   const ctx = useContext(LayoutContext);
   if (!ctx) {
-    throw new Error('useLayout must be used within a LayoutProvider');
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('useLayout used outside LayoutProvider; defaulting to desktop layout');
+    }
+    return 'desktop';
   }
   return ctx;
 }


### PR DESCRIPTION
## Summary
- default `useLayout` to desktop and warn when provider is absent
- searched for `useLayout` usage to confirm other components

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68999e59e8e48331a9966d0c9dc0093f