### PR TITLE
fix: require LayoutProvider for layout hook

### DIFF
--- a/apps/web/context/LayoutContext.tsx
+++ b/apps/web/context/LayoutContext.tsx
@@ -59,11 +59,8 @@ export function LayoutProvider({ children }: { children: ReactNode }) {
 
 export function useLayout(): LayoutType {
   const ctx = useContext(LayoutContext);
-  if (!ctx) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn('useLayout used outside LayoutProvider; defaulting to desktop layout');
-    }
-    return 'desktop';
+  if (ctx === undefined) {
+    throw new Error('useLayout must be used within a LayoutProvider');
   }
   return ctx;
 }


### PR DESCRIPTION
## Summary
- throw error when `useLayout` is called outside `LayoutProvider`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a006020483319ef888e2d975431f