### PR TITLE
fix: default layout when provider missing

### DIFF
--- a/apps/web/context/LayoutContext.tsx
+++ b/apps/web/context/LayoutContext.tsx
@@ -59,8 +59,12 @@ export function LayoutProvider({ children }: { children: ReactNode }) {
 
 export function useLayout(): LayoutType {
   const ctx = useContext(LayoutContext);
-  if (ctx === undefined) {
-    throw new Error('useLayout must be used within a LayoutProvider');
+  if (ctx !== undefined) return ctx;
+
+  // Fallback for environments without LayoutProvider (e.g. Storybook, tests)
+  if (typeof window !== 'undefined' && 'matchMedia' in window) {
+    if (window.matchMedia('(min-width: 1280px)').matches) return 'desktop';
+    if (window.matchMedia('(min-width: 1024px)').matches) return 'tablet';
   }
-  return ctx;
+  return 'mobile';
 }


### PR DESCRIPTION
## Summary
- default to window width when LayoutProvider is absent

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a484c108833188d877983aa517b1