### PR TITLE
chore: replace apple web app meta tag

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
     <html lang={locale} suppressHydrationWarning>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
         <meta name="theme-color" content="#101010" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </head>


### PR DESCRIPTION
## Summary
- replace `apple-mobile-web-app-capable` meta tag with standard `mobile-web-app-capable`

## Testing
- `pnpm --filter @paiduan/web lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a755f1f48331a0f68f6d3b5f198f