### PR TITLE
fix: mark overlay as client component and expand overlay tests

### DIFF
--- a/apps/web/components/ui/Overlay.tsx
+++ b/apps/web/components/ui/Overlay.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, ReactNode } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useLayout } from '@/hooks/useLayout';


### PR DESCRIPTION
## Summary
- mark Overlay component as client component so useLayout context works
- test Overlay open/close across desktop/tablet/mobile layouts

## Testing
- `pnpm test apps/web/components/ui/Overlay.test.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a769a1e483318824b7e7ecc7d7ad