### PR TITLE
fix: mark SearchBar as client component

### DIFF
--- a/apps/web/components/SearchBar.tsx
+++ b/apps/web/components/SearchBar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';


### PR DESCRIPTION
## Summary
- ensure SearchBar is treated as client component
- verify parents that import SearchBar remain client components

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6899a77c3d248331a3198905ef5f0fff