### PR TITLE
Preload selected videos and auto-play when visible

### DIFF
--- a/apps/web/components/VideoCard.playback.test.tsx
+++ b/apps/web/components/VideoCard.playback.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { useFollowingStore } from '@/store/following';
 
 // Ensure React is available globally for components compiled with the classic JSX runtime
@@ -25,16 +25,43 @@ vi.mock('./ReportModal', () => ({ default: () => null }));
 vi.mock('next/navigation', () => ({ useRouter: () => ({ prefetch: () => {} }) }));
 vi.mock('react-use', () => ({ useNetworkState: () => ({ online: true }) }));
 vi.mock('../hooks/useAdaptiveSource', () => ({ default: () => undefined }));
-vi.mock('react-intersection-observer', () => ({ useInView: () => ({ ref: () => {}, inView: true }) }));
+let mockInView = true;
+vi.mock('react-intersection-observer', () => ({
+  useInView: () => ({ ref: () => {}, inView: mockInView }),
+}));
 vi.mock('../hooks/useCurrentVideo', () => ({ useCurrentVideo: () => ({ setCurrent: () => {} }) }));
+const feedSelectionState = { selectedVideoId: undefined as string | undefined, setSelectedVideo: () => {} };
 vi.mock('@/store/feedSelection', () => ({
-  useFeedSelection: (selector: any) => selector({ setSelectedVideo: () => {} }),
+  useFeedSelection: (selector: any) => selector(feedSelectionState),
 }));
 vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({ picture: '', name: 'author' }) }));
 vi.mock('@/hooks/useProfiles', () => ({ prefetchProfile: () => Promise.resolve() }));
 vi.mock('@/agents/telemetry', () => ({ telemetry: { track: vi.fn() } }));
+const currentRef = { video: null as HTMLVideoElement | null };
+const { loadSource, play, playbackPause, onStateChange, onError } = vi.hoisted(() => ({
+  loadSource: vi.fn((video: HTMLVideoElement) => {
+    if (currentRef.video && currentRef.video !== video) currentRef.video.pause();
+    currentRef.video = video;
+  }),
+  play: vi.fn(() => Promise.resolve()),
+  playbackPause: vi.fn(),
+  onStateChange: vi.fn(() => () => {}),
+  onError: vi.fn(() => () => {}),
+}));
+vi.mock('@/agents/playback', () => ({
+  playback: { loadSource, play, pause: playbackPause, onStateChange, onError },
+}));
 
 import VideoCard from './VideoCard';
+
+afterEach(() => {
+  mockInView = true;
+  feedSelectionState.selectedVideoId = undefined;
+  loadSource.mockClear();
+  play.mockClear();
+  playbackPause.mockClear();
+  currentRef.video = null;
+});
 
 describe('VideoCard playback switching', () => {
   it('only plays the most recent video', async () => {
@@ -81,6 +108,30 @@ describe('VideoCard playback switching', () => {
     fireEvent.loadedData(video2);
     await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
     expect(pauseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preloads selected video when out of view and plays on enter', async () => {
+    useFollowingStore.setState({ following: [] });
+    mockInView = false;
+    feedSelectionState.selectedVideoId = 'event1';
+    const props = {
+      videoUrl: 'video1.mp4',
+      author: 'author1',
+      caption: 'caption1',
+      eventId: 'event1',
+      pubkey: 'pk1',
+      zap: <div />,
+    };
+    const { rerender, container } = render(<VideoCard {...props} />);
+    await waitFor(() => expect(loadSource).toHaveBeenCalledTimes(1));
+    expect(play).not.toHaveBeenCalled();
+    const video = container.querySelector('video') as HTMLVideoElement;
+    fireEvent.loadedData(video);
+    expect(play).not.toHaveBeenCalled();
+    mockInView = true;
+    rerender(<VideoCard {...props} />);
+    await waitFor(() => expect(play).toHaveBeenCalledTimes(1));
+    expect(loadSource).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/components/VideoCard.test.tsx
+++ b/apps/web/components/VideoCard.test.tsx
@@ -26,8 +26,9 @@ vi.mock('react-intersection-observer', () => ({
   useInView: () => ({ ref: () => {}, inView: true }),
 }));
 vi.mock('../hooks/useCurrentVideo', () => ({ useCurrentVideo: () => ({ setCurrent: () => {} }) }));
+const feedSelectionState = { selectedVideoId: undefined as string | undefined, setSelectedVideo: () => {} };
 vi.mock('@/store/feedSelection', () => ({
-  useFeedSelection: (selector: any) => selector({ setSelectedVideo: () => {} }),
+  useFeedSelection: (selector: any) => selector(feedSelectionState),
 }));
 vi.mock('@/hooks/useProfile', () => ({ useProfile: () => ({ picture: '', name: 'author' }) }));
 vi.mock('@/hooks/useProfiles', () => ({ prefetchProfile: () => Promise.resolve() }));
@@ -71,6 +72,7 @@ afterEach(() => {
   play.mockClear();
   playbackPause.mockClear();
   telemetryTrack.mockClear();
+  feedSelectionState.selectedVideoId = undefined;
 });
 
 describe('VideoCard', () => {
@@ -306,6 +308,8 @@ describe('VideoCard', () => {
     const { container } = render(<VideoCard {...props} />);
     const video = container.querySelector('video') as HTMLVideoElement;
     fireEvent.loadedData(video);
+    play.mockClear();
+    playbackPause.mockClear();
     const card = container.firstChild as HTMLElement;
     card.getBoundingClientRect = () => ({
       left: 0,
@@ -336,6 +340,8 @@ describe('VideoCard', () => {
     const { container } = render(<VideoCard {...props} />);
     const video = container.querySelector('video') as HTMLVideoElement;
     fireEvent.loadedData(video);
+    play.mockClear();
+    playbackPause.mockClear();
     const card = container.firstChild as HTMLElement;
     card.getBoundingClientRect = () => ({
       left: 0,


### PR DESCRIPTION
## Summary
- Reduce video in-view threshold to start loading earlier
- Preload initially selected video and start playback once visible
- Add tests for preloading and viewport-driven playback

## Testing
- `pnpm test apps/web/components/VideoCard.test.tsx apps/web/components/VideoCard.playback.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6899bb3e20848331b1c0dd098a9fcd56