### PR TITLE
feat: prototype ReactPlayer video card

### DIFF
--- a/apps/web/components/VideoCardReactPlayer.tsx
+++ b/apps/web/components/VideoCardReactPlayer.tsx
@@ -1,0 +1,159 @@
+'use client';
+import React, { useEffect, useRef, useState } from 'react';
+import ReactPlayer, { ReactPlayerProps } from 'react-player';
+import { useInView } from 'react-intersection-observer';
+import PlaceholderVideo from './PlaceholderVideo';
+import VideoFallback from './VideoFallback';
+import { usePlaybackPrefs } from '@/store/playbackPrefs';
+import { useFeedSelection } from '@/store/feedSelection';
+
+export interface VideoCardReactPlayerProps {
+  videoUrl: string;
+  manifestUrl?: string;
+  posterUrl?: string;
+  eventId: string;
+  onReady?: () => void;
+}
+
+const STORAGE_KEY = 'lastPlaybackPosition';
+const EXPIRY_MS = 24 * 60 * 60 * 1000; // 24h
+
+type ProgressEntry = { currentTime: number; timestamp: number };
+type ProgressMap = Record<string, ProgressEntry>;
+
+function loadStore(): ProgressMap {
+  if (typeof sessionStorage === 'undefined') return {};
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as ProgressMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveStore(store: ProgressMap) {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    if (Object.keys(store).length === 0) {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } else {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function loadProgress(eventId: string): number | null {
+  const store = loadStore();
+  const now = Date.now();
+  let changed = false;
+  for (const [id, entry] of Object.entries(store)) {
+    if (now - entry.timestamp > EXPIRY_MS) {
+      delete store[id];
+      changed = true;
+    }
+  }
+  if (changed) saveStore(store);
+  const entry = store[eventId];
+  return entry ? entry.currentTime : null;
+}
+
+function saveProgress(eventId: string, currentTime: number) {
+  const store = loadStore();
+  store[eventId] = { currentTime, timestamp: Date.now() };
+  saveStore(store);
+}
+
+function clearProgress(eventId: string) {
+  const store = loadStore();
+  if (eventId in store) {
+    delete store[eventId];
+    saveStore(store);
+  }
+}
+
+export const VideoCardReactPlayer: React.FC<VideoCardReactPlayerProps> = ({
+  videoUrl,
+  manifestUrl,
+  posterUrl,
+  eventId,
+  onReady,
+}) => {
+  const playerRef = useRef<ReactPlayer>(null);
+  const { ref, inView } = useInView({ threshold: 0.25 });
+  const [muted, setMuted] = usePlaybackPrefs((s) => [s.isMuted, s.setMuted]);
+  const selectedVideoId = useFeedSelection((s) => s.selectedVideoId);
+  const setSelectedVideo = useFeedSelection((s) => s.setSelectedVideo);
+  const isActive = inView || selectedVideoId === eventId;
+  const [playing, setPlaying] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPlaying(isActive);
+  }, [isActive]);
+
+  useEffect(() => {
+    return () => {
+      const current = playerRef.current?.getCurrentTime?.();
+      if (current) saveProgress(eventId, current);
+    };
+  }, [eventId]);
+
+  const handleReady: ReactPlayerProps['onReady'] = () => {
+    const t = loadProgress(eventId);
+    if (t != null) {
+      playerRef.current?.seekTo(t, 'seconds');
+    }
+    setLoaded(true);
+    onReady?.();
+  };
+
+  return (
+    <div ref={ref} className="relative aspect-video w-full" onClick={() => setSelectedVideo(eventId)}>
+      {!loaded && !error && <PlaceholderVideo className="absolute inset-0" />}
+      {error && <VideoFallback posterUrl={posterUrl} message={error} />}
+      <ReactPlayer
+        ref={playerRef}
+        url={manifestUrl || videoUrl}
+        playing={playing}
+        muted={muted}
+        width="100%"
+        height="100%"
+        playsinline
+        config={{ file: { forceHLS: !!manifestUrl } }}
+        onReady={handleReady}
+        onError={(e) => {
+          const msg = typeof e === 'string' ? e : 'Playback error';
+          setError(msg);
+        }}
+        onProgress={({ playedSeconds }) => saveProgress(eventId, playedSeconds)}
+        onEnded={() => {
+          clearProgress(eventId);
+          setPlaying(false);
+        }}
+      />
+      {muted ? (
+        <button
+          type="button"
+          className="absolute bottom-4 right-4 z-10"
+          onClick={() => setMuted(false)}
+        >
+          Unmute
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="absolute bottom-4 right-4 z-10"
+          onClick={() => setMuted(true)}
+        >
+          Mute
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default VideoCardReactPlayer;
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,6 +55,7 @@
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^9.16.0",
+    "react-player": "2.16.1",
     "react-range": "^1.10.0",
     "react-use": "^17.6.0",
     "react-use-gesture": "^9.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       react-intersection-observer:
         specifier: ^9.16.0
         version: 9.16.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react-player:
+        specifier: 2.16.1
+        version: 2.16.1(react@19.1.1)
       react-range:
         specifier: ^1.10.0
         version: 1.10.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -4571,6 +4574,9 @@ packages:
     resolution: {integrity: sha512-DJ2P1Kv63y9CvSFFQcohaGUSwM4W6U6IPmiTNM03QBQer4zeJ11AneLJ8b780PKDFAZsRxX4Vs4NKQgiCj23OA==}
     engines: {node: '>=18'}
 
+  load-script@1.0.0:
+    resolution: {integrity: sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==}
+
   loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
@@ -4674,6 +4680,9 @@ packages:
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
+
+  memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -5347,6 +5356,11 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-player@2.16.1:
+    resolution: {integrity: sha512-mxP6CqjSWjidtyDoMOSHVPdhX0pY16aSvw5fVr44EMaT7X5Xz46uQ4b/YBm1v2x+3hHkB9PmjEEkmbHb9PXQ4w==}
+    peerDependencies:
+      react: '>=16.6.0'
 
   react-range@1.10.0:
     resolution: {integrity: sha512-kDo0LiBUHIQIP8menx0UoxTnHr7UXBYpIYl/DR9jCaO1o29VwvCLpkP/qOTNQz5hkJadPg1uEM07XJcJ1XGoKw==}
@@ -11420,6 +11434,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  load-script@1.0.0: {}
+
   loader-runner@4.3.0: {}
 
   loader-utils@2.0.4:
@@ -11516,6 +11532,8 @@ snapshots:
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
+
+  memoize-one@5.2.1: {}
 
   merge-stream@2.0.0: {}
 
@@ -12174,6 +12192,15 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-player@2.16.1(react@19.1.1):
+    dependencies:
+      deepmerge: 4.3.1
+      load-script: 1.0.0
+      memoize-one: 5.2.1
+      prop-types: 15.8.1
+      react: 19.1.1
+      react-fast-compare: 3.2.2
 
   react-range@1.10.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add ReactPlayer-based VideoCard prototype with autoplay, progress restore, and error handling
- add react-player dependency for evaluation

## Testing
- `pnpm test` *(fails: useFollowerCount resets count and closes previous subscription on pubkey change)*
- `pnpm test apps/web/hooks/useFollowerCount.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6899bef9a2ac8331815828b8b011475b